### PR TITLE
[sailfish-secrets] Add C API for Sailfish Secrets. Contributes to JB#36797

### DIFF
--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -78,7 +78,6 @@ class SecretsDBusObject : public QObject, protected QDBusContext
     "      <method name=\"deleteCollection\">\n"
     "          <arg name=\"collectionName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"userInteractionMode\" type=\"(i)\" direction=\"in\" />\n"
-    "          <arg name=\"interactionServiceAddress\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iis)\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In1\" value=\"Sailfish::Secrets::SecretManager::UserInteractionMode\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Secrets::Result\" />\n"

--- a/lib/Crypto/Crypto.pro
+++ b/lib/Crypto/Crypto.pro
@@ -7,6 +7,9 @@ DEFINES += SAILFISH_CRYPTO_LIBRARY_BUILD
 QT += dbus
 QT -= gui
 
+CONFIG += link_pkgconfig
+PKGCONFIG += dbus-1
+
 include($$PWD/../../common.pri)
 
 INCLUDEPATH += $$PWD/../
@@ -20,7 +23,8 @@ PUBLIC_HEADERS += \
     $$PWD/extensionplugins.h \
     $$PWD/key.h \
     $$PWD/result.h \
-    $$PWD/x509certificate.h
+    $$PWD/x509certificate.h \
+    $$PWD/crypto_c.h
 
 PRIVATE_HEADERS += \
     $$PWD/certificate_p.h \
@@ -40,7 +44,8 @@ SOURCES += \
     $$PWD/extensionplugins.cpp \
     $$PWD/key.cpp \
     $$PWD/serialisation.cpp \
-    $$PWD/x509certificate.cpp
+    $$PWD/x509certificate.cpp \
+    $$PWD/crypto_c.cpp
 
 develheaders.path = /usr/include/libsailfishcrypto/
 develheaders_crypto.path = /usr/include/libsailfishcrypto/Crypto/

--- a/lib/Crypto/crypto_c.cpp
+++ b/lib/Crypto/crypto_c.cpp
@@ -1,0 +1,1633 @@
+/*
+ * Copyright (C) 2017 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#include "Crypto/crypto_c.h"
+#include "Crypto/key.h"
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QString>
+#include <QVector>
+#include <QMap>
+
+#include <dbus/dbus.h>
+#include <sys/types.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+static int Sailfish_Crypto__getServerPeerToPeerAddress(
+        char ** p2pAddr,
+        DBusConnection **sessionBus)
+{
+    DBusMessage* msg;
+    DBusMessageIter args;
+    DBusError err;
+    DBusPendingCall* pending;
+    char *param = NULL;
+
+    if (p2pAddr == NULL || sessionBus == NULL) {
+        fprintf(stderr, "Invalid parameters, cannot get p2p address!\n");
+        return 0;
+    }
+
+    /* initialise the error */
+    dbus_error_init(&err);
+
+    /* connect to the session bus */
+    *sessionBus = dbus_bus_get(DBUS_BUS_SESSION, &err);
+    if (dbus_error_is_set(&err)) {
+        fprintf(stderr, "Connection Error (%s)\n", err.message);
+        dbus_error_free(&err);
+        *sessionBus = NULL;
+    }
+    if (*sessionBus == NULL) {
+        return 0;
+    }
+
+    /* create a new method call and check for errors */
+    msg = dbus_message_new_method_call(
+                "org.sailfishos.crypto.daemon.discovery",
+                "/Sailfish/Crypto/Discovery",
+                "org.sailfishos.crypto.daemon.discovery",
+                "peerToPeerAddress");
+    if (msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                *sessionBus,
+                msg,
+                &pending,
+                -1);
+
+    if (pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(msg);
+        return 0;
+    }
+
+    dbus_connection_flush(*sessionBus);
+    dbus_message_unref(msg);
+    dbus_pending_call_block(pending);
+    msg = dbus_pending_call_steal_reply(pending);
+    dbus_pending_call_unref(pending);
+    if (msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the address return argument */
+    if (!dbus_message_iter_init(msg, &args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(msg);
+        return 0;
+    } else if (DBUS_TYPE_STRING != dbus_message_iter_get_arg_type(&args)) {
+        fprintf(stderr, "Argument is not string!\n");
+        dbus_message_unref(msg);
+        return 0;
+    } else {
+        dbus_message_iter_get_basic(&args, &param);
+    }
+
+    if (param == NULL) {
+        fprintf(stderr, "Unable to read peer to peer address value!\n");
+        dbus_message_unref(msg);
+        return 0;
+    }
+
+    *p2pAddr = strdup(param);
+    dbus_message_unref(msg);
+
+    return 1;
+}
+
+static struct Sailfish_Crypto_DBus_Connection {
+    DBusConnection *sessionBus;
+    DBusConnection* p2pBus;
+    DBusMessage* msg;
+    DBusPendingCall* pending;
+    char* p2pAddr;
+} daemon_connection = {
+    .sessionBus = NULL,
+    .p2pBus = NULL,
+    .msg = NULL,
+    .pending = NULL,
+    .p2pAddr = NULL
+};
+
+static int Sailfish_Crypto__isConnectedToServer()
+{
+    return daemon_connection.p2pBus == NULL ? 0 : 1;
+}
+
+static int Sailfish_Crypto__connectToServer()
+{
+    DBusError daemon_connection_err;
+
+    if (daemon_connection.p2pBus != NULL) {
+        fprintf(stderr, "Already connected to crypto daemon!\n");
+        return 1; /* Return "ok" */
+    }
+
+    /* Get the peer to peer address of the daemon via the session bus */
+    if (!daemon_connection.p2pAddr &&
+            !Sailfish_Crypto__getServerPeerToPeerAddress(
+                &daemon_connection.p2pAddr,
+                &daemon_connection.sessionBus)) {
+        return 0;
+    }
+
+    /* initialise the error */
+    dbus_error_init(&daemon_connection_err);
+
+    /* Open a private peer to peer connection to the daemon */
+    daemon_connection.p2pBus = dbus_connection_open_private(
+                daemon_connection.p2pAddr,
+                &daemon_connection_err);
+    if (dbus_error_is_set(&daemon_connection_err)) {
+        fprintf(stderr,
+                "Connection Error (%s) to: %s\n",
+                daemon_connection_err.message,
+                daemon_connection.p2pAddr);
+        dbus_error_free(&daemon_connection_err);
+    }
+    if (daemon_connection.p2pBus == NULL) {
+        return 0;
+    }
+
+    return 1;
+}
+
+void Sailfish_Crypto_disconnectFromServer()
+{
+    if (daemon_connection.p2pBus) {
+        dbus_connection_close(daemon_connection.p2pBus);
+        dbus_connection_unref(daemon_connection.p2pBus);
+        daemon_connection.p2pBus = NULL;
+        free(daemon_connection.p2pAddr);
+        daemon_connection.p2pAddr = NULL;
+    }
+}
+
+static void Sailfish_Crypto__appendEnumArg(
+        DBusMessageIter *in_args,
+        int *arg)
+{
+    DBusMessageIter enum_struct;
+    dbus_message_iter_open_container(
+                in_args,
+                DBUS_TYPE_STRUCT,
+                NULL,
+                &enum_struct);
+    dbus_message_iter_append_basic(
+                &enum_struct,
+                DBUS_TYPE_INT32,
+                arg);
+    dbus_message_iter_close_container(
+                in_args,
+                &enum_struct);
+}
+
+static void Sailfish_Crypto__appendDataArg(
+        DBusMessageIter *in_args,
+        const unsigned char *data,
+        size_t dataSize)
+{
+    DBusMessageIter data_array;
+    dbus_message_iter_open_container(
+                in_args,
+                DBUS_TYPE_ARRAY,
+                "y",
+                &data_array);
+    dbus_message_iter_append_fixed_array(
+                &data_array,
+                DBUS_TYPE_BYTE,
+                &data,
+                dataSize);
+    dbus_message_iter_close_container(
+                in_args,
+                &data_array);
+}
+
+static void Sailfish_Crypto__appendKeyIdentifierArg(
+        DBusMessageIter *args,
+        struct Sailfish_Crypto_Key_Identifier *ident)
+{
+    DBusMessageIter ident_struct;
+
+    dbus_message_iter_open_container(
+                args,
+                DBUS_TYPE_STRUCT,
+                NULL,
+                &ident_struct);
+
+    dbus_message_iter_append_basic(
+                &ident_struct,
+                DBUS_TYPE_STRING,
+                &ident->name);
+
+    dbus_message_iter_append_basic(
+                &ident_struct,
+                DBUS_TYPE_STRING,
+                &ident->collectionName);
+
+    dbus_message_iter_close_container(
+                args,
+                &ident_struct);
+}
+
+static void Sailfish_Crypto__appendKeyArg(
+        DBusMessageIter *in_args,
+        struct Sailfish_Crypto_Key *key)
+{
+    DBusMessageIter key_struct;
+    DBusMessageIter data_array;
+
+    /* Convert the key to the C++ form so we can serialise it properly */
+    Sailfish::Crypto::Key cppKey;
+    cppKey.setIdentifier(Sailfish::Crypto::Key::Identifier(
+                QLatin1String(key->identifier->name),
+                QLatin1String(key->identifier->collectionName)));
+    cppKey.setOrigin(static_cast<Sailfish::Crypto::Key::Origin>(
+                key->origin));
+    cppKey.setAlgorithm(static_cast<Sailfish::Crypto::Key::Algorithm>(
+                key->algorithm));
+    cppKey.setBlockModes(static_cast<Sailfish::Crypto::Key::BlockModes>(
+                key->blockModes));
+    cppKey.setEncryptionPaddings(
+                static_cast<Sailfish::Crypto::Key::EncryptionPaddings>(
+                key->encryptionPaddings));
+    cppKey.setSignaturePaddings(
+                static_cast<Sailfish::Crypto::Key::SignaturePaddings>(
+                key->signaturePaddings));
+    cppKey.setDigests(static_cast<Sailfish::Crypto::Key::Digests>(
+                key->digests));
+    cppKey.setOperations(static_cast<Sailfish::Crypto::Key::Operations>(
+                key->operations));
+    cppKey.setSecretKey(QByteArray((const char *)key->secretKey,
+                                   (int)key->secretKeySize));
+    cppKey.setPrivateKey(QByteArray((const char *)key->privateKey,
+                                    (int)key->privateKeySize));
+    cppKey.setPublicKey(QByteArray((const char *)key->publicKey,
+                                   (int)key->publicKeySize));
+    cppKey.setValidityStart(QDateTime::fromTime_t(key->validityStart));
+    cppKey.setValidityEnd(QDateTime::fromTime_t(key->validityEnd));
+    QVector<QByteArray> cppKeyCp;
+    struct Sailfish_Crypto_Key_CustomParameter *currParameter =
+                key->customParameters;
+    while (currParameter) {
+        QByteArray cpdata((const char *)currParameter->parameter,
+                          (int)currParameter->parameterSize);
+        cppKeyCp.append(cpdata);
+        currParameter = currParameter->next;
+    }
+    cppKey.setCustomParameters(cppKeyCp);
+    QMap<QString,QString> cppKeyFd;
+    struct Sailfish_Crypto_Key_FilterDatum *currFilter = key->filterData;
+    while (currFilter) {
+        QByteArray fielddata(currFilter->field);
+        QByteArray valuedata(currFilter->value);
+        cppKeyFd.insert(QString(fielddata), QString(valuedata));
+        currFilter = currFilter->next;
+    }
+    cppKey.setFilterData(cppKeyFd);
+    QByteArray keyData = Sailfish::Crypto::Key::serialise(
+                cppKey, Sailfish::Crypto::Key::LosslessSerialisationMode);
+    const char *keyDataPtr = keyData.data();
+
+    /* Now marshal it for dbus */
+    dbus_message_iter_open_container(
+                in_args,
+                DBUS_TYPE_STRUCT,
+                NULL,
+                &key_struct);
+
+    dbus_message_iter_open_container(
+                &key_struct,
+                DBUS_TYPE_ARRAY,
+                "y",
+                &data_array);
+
+    dbus_message_iter_append_fixed_array(
+                &data_array,
+                DBUS_TYPE_BYTE,
+                &keyDataPtr,
+                keyData.size());
+
+    dbus_message_iter_close_container(
+                &key_struct,
+                &data_array);
+
+    dbus_message_iter_close_container(
+                in_args,
+                &key_struct);
+}
+
+static int Sailfish_Crypto__readResultStruct(
+        DBusMessageIter *args,
+        struct Sailfish_Crypto_Result **result)
+{
+    if (args == NULL || result == NULL || *result != NULL) {
+        fprintf(stderr, "Cannot read result: invalid parameters!\n");
+        return 0;
+    }
+
+    if (dbus_message_iter_get_arg_type(args) != DBUS_TYPE_STRUCT) {
+        fprintf(stderr, "Argument is not result struct!\n");
+        if (dbus_message_iter_get_arg_type(args) == DBUS_TYPE_STRING) {
+            char *resultStr;
+            dbus_message_iter_get_basic(args, &resultStr);
+            fprintf(stderr, "Got result str: %s\n", resultStr);
+        }
+        return 0;
+    } else {
+        DBusMessageIter res_struct;
+        int code;
+        int errorCode;
+        int storageErrorCode;
+        const char *errorMessage;
+
+        dbus_message_iter_recurse(args, &res_struct);
+
+        if (dbus_message_iter_get_arg_type(&res_struct) != DBUS_TYPE_INT32) {
+            fprintf(stderr, "First result struct arg not an integer!\n");
+            return 0;
+        }
+
+        dbus_message_iter_get_basic(&res_struct, &code);
+
+        dbus_message_iter_next(&res_struct);
+
+        if (dbus_message_iter_get_arg_type(&res_struct) != DBUS_TYPE_INT32) {
+            fprintf(stderr, "Second result struct arg not an integer!\n");
+            return 0;
+        }
+
+        dbus_message_iter_get_basic(&res_struct, &errorCode);
+
+        dbus_message_iter_next(&res_struct);
+
+        if (dbus_message_iter_get_arg_type(&res_struct) != DBUS_TYPE_INT32) {
+            fprintf(stderr, "Third result struct arg not an integer!\n");
+            return 0;
+        }
+
+        dbus_message_iter_get_basic(&res_struct, &storageErrorCode);
+
+        dbus_message_iter_next(&res_struct);
+
+        if (dbus_message_iter_get_arg_type(&res_struct) != DBUS_TYPE_STRING) {
+            fprintf(stderr, "Fourth result struct arg not a string!\n");
+            return 0;
+        }
+
+        dbus_message_iter_get_basic(&res_struct, &errorMessage);
+
+        *result = Sailfish_Crypto_Result_new(
+                    (Sailfish_Crypto_Result_Code)code,
+                    errorCode, storageErrorCode, errorMessage);
+    }
+
+    return 1;
+}
+
+static int Sailfish_Crypto__readKeyStruct(
+        DBusMessageIter *args,
+        struct Sailfish_Crypto_Key **key)
+{
+    if (args == NULL || key == NULL || *key != NULL) {
+        fprintf(stderr, "Cannot read key: invalid parameters!\n");
+        return 0;
+    }
+
+    if (dbus_message_iter_get_arg_type(args) != DBUS_TYPE_STRUCT) {
+        fprintf(stderr, "Argument is not result struct!\n");
+        if (dbus_message_iter_get_arg_type(args) == DBUS_TYPE_STRING) {
+            char *resultStr;
+            dbus_message_iter_get_basic(args, &resultStr);
+            fprintf(stderr, "Got result str: %s\n", resultStr);
+        }
+        return 0;
+    } else {
+        DBusMessageIter key_struct;
+        DBusMessageIter data_array;
+        unsigned char *data = NULL;
+        int n_bytes = 0;
+
+        /* Read the key blob data */
+        dbus_message_iter_recurse(args, &key_struct);
+        dbus_message_iter_recurse(&key_struct, &data_array);
+        dbus_message_iter_get_fixed_array(&data_array,
+                                          &data,
+                                          &n_bytes);
+        if (!data || !n_bytes) {
+            fprintf(stderr, "Unable to read data from key struct!\n");
+            return 0;
+        }
+
+        /* Convert the key blob data into a key */
+        QByteArray cppKeyData((const char *)data, n_bytes);
+        bool ok = true;
+        Sailfish::Crypto::Key cppKey(Sailfish::Crypto::Key::deserialise(
+                                         cppKeyData, &ok));
+        if (!ok) {
+            fprintf(stderr, "Unable to deserialise key data!\n");
+            return 0;
+        }
+
+        Sailfish_Crypto_Key *retn = Sailfish_Crypto_Key_new(
+                cppKey.identifier().name().toLatin1().constData(),
+                cppKey.identifier().collectionName().toLatin1().constData());
+        retn->origin = (Sailfish_Crypto_Key_Origin)cppKey.origin();
+        retn->algorithm = (Sailfish_Crypto_Key_Algorithm)cppKey.algorithm();
+        retn->blockModes = (int)cppKey.blockModes();
+        retn->encryptionPaddings = (int)cppKey.encryptionPaddings();
+        retn->signaturePaddings = (int)cppKey.signaturePaddings();
+        retn->digests = (int)cppKey.digests();
+        retn->operations = (int)cppKey.operations();
+        retn->validityStart = cppKey.validityStart().toTime_t();
+        retn->validityEnd = cppKey.validityEnd().toTime_t();
+        Sailfish_Crypto_Key_setSecretKey(retn,
+                                         (const unsigned char *)
+                                            cppKey.secretKey().constData(),
+                                         cppKey.secretKey().size());
+        Sailfish_Crypto_Key_setPublicKey(retn,
+                                         (const unsigned char *)
+                                            cppKey.publicKey().constData(),
+                                         cppKey.publicKey().size());
+        Sailfish_Crypto_Key_setPrivateKey(retn,
+                                          (const unsigned char *)
+                                            cppKey.privateKey().constData(),
+                                          cppKey.privateKey().size());
+        for (const QByteArray &customParameter : cppKey.customParameters()) {
+            Sailfish_Crypto_Key_addCustomParameter(
+                        retn,
+                        (const unsigned char *)customParameter.constData(),
+                        customParameter.size());
+        }
+        const QMap<QString, QString> filterData = cppKey.filterData();
+        for (QMap<QString, QString>::const_iterator
+             it = filterData.constBegin(); it != filterData.constEnd(); it++) {
+            Sailfish_Crypto_Key_addFilter(
+                        retn,
+                        it.key().toLatin1().constData(),
+                        it.value().toLatin1().constData());
+        }
+        *key = retn;
+    }
+
+    return 1;
+}
+
+/******************************* Methods ************************************/
+
+struct Sailfish_Crypto_Result*
+Sailfish_Crypto_Result_new(
+        enum Sailfish_Crypto_Result_Code code,
+        int errorCode,
+        int storageErrorCode,
+        const char *errorMessage)
+{
+    struct Sailfish_Crypto_Result *result =
+            (struct Sailfish_Crypto_Result *)malloc(
+                        sizeof(struct Sailfish_Crypto_Result));
+
+    result->code = code;
+    result->errorCode = errorCode;
+    result->storageErrorCode = storageErrorCode;
+    result->errorMessage = errorMessage ? strndup(errorMessage, 512) : NULL;
+    return result;
+}
+
+void Sailfish_Crypto_Result_delete(
+        struct Sailfish_Crypto_Result *result)
+{
+    if (result) {
+        free(result->errorMessage);
+        free(result);
+    }
+}
+
+struct Sailfish_Crypto_Key_Identifier*
+Sailfish_Crypto_Key_Identifier_new(
+        const char *name,
+        const char *collectionName)
+{
+    struct Sailfish_Crypto_Key_Identifier *ident =
+            (struct Sailfish_Crypto_Key_Identifier*)malloc(
+                        sizeof(struct Sailfish_Crypto_Key_Identifier));
+
+    ident->name = name
+            ? strndup(name, 512)
+            : NULL;
+    ident->collectionName = collectionName
+            ? strndup(collectionName, 512)
+            : NULL;
+
+    return ident;
+}
+
+void Sailfish_Crypto_Key_Identifier_delete(
+        struct Sailfish_Crypto_Key_Identifier *ident)
+{
+    if (ident) {
+        free(ident->name);
+        free(ident->collectionName);
+        free(ident);
+    }
+}
+
+struct Sailfish_Crypto_Key_FilterDatum*
+Sailfish_Crypto_Key_FilterDatum_new(
+        const char *field,
+        const char *value)
+{
+    struct Sailfish_Crypto_Key_FilterDatum *filter =
+            (struct Sailfish_Crypto_Key_FilterDatum *)malloc(
+                        sizeof(struct Sailfish_Crypto_Key_FilterDatum));
+
+    filter->field = field ? strndup(field, 512) : NULL;
+    filter->value = value ? strndup(value, 512) : NULL;
+    filter->next = NULL;
+
+    return filter;
+}
+
+void Sailfish_Crypto_Key_FilterDatum_delete(
+        struct Sailfish_Crypto_Key_FilterDatum *filter)
+{
+    if (filter) {
+        struct Sailfish_Crypto_Key_FilterDatum *curr = filter;
+        struct Sailfish_Crypto_Key_FilterDatum *next = filter->next
+                ? filter->next : NULL;
+
+        while (curr) {
+            free(curr->field);
+            free(curr->value);
+            free(curr);
+            curr = next;
+            next = curr ? curr->next : NULL;
+        }
+    }
+}
+
+struct Sailfish_Crypto_Key_CustomParameter*
+Sailfish_Crypto_Key_CustomParameter_new(
+        const unsigned char *parameter,
+        size_t parameterSize)
+{
+    if (parameter && parameterSize) {
+        struct Sailfish_Crypto_Key_CustomParameter *param =
+                (struct Sailfish_Crypto_Key_CustomParameter *)malloc(
+                            sizeof(struct Sailfish_Crypto_Key_CustomParameter));
+
+        param->parameter = (unsigned char *)malloc(parameterSize);
+        memcpy(param->parameter, parameter, parameterSize);
+        param->parameterSize = parameterSize;
+        param->next = NULL;
+
+        return param;
+    }
+
+    return NULL;
+}
+
+void Sailfish_Crypto_Key_CustomParameter_delete(
+        struct Sailfish_Crypto_Key_CustomParameter *param)
+{
+    if (param) {
+        struct Sailfish_Crypto_Key_CustomParameter *curr = param;
+        struct Sailfish_Crypto_Key_CustomParameter *next = param->next
+                ? param->next : NULL;
+
+        while (curr) {
+            free(curr->parameter);
+            free(curr);
+            curr = next;
+            next = curr ? curr->next : NULL;
+        }
+    }
+}
+
+struct Sailfish_Crypto_Key*
+Sailfish_Crypto_Key_new(
+        const char *name,
+        const char *collectionName)
+{
+    struct Sailfish_Crypto_Key* key =
+            (struct Sailfish_Crypto_Key*)malloc(
+                        sizeof(struct Sailfish_Crypto_Key));
+
+    key->identifier = Sailfish_Crypto_Key_Identifier_new(
+            name, collectionName);
+
+    key->secretKey = NULL;
+    key->publicKey = NULL;
+    key->privateKey = NULL;
+    key->customParameters = NULL;
+    key->filterData = NULL;
+
+    key->origin = Sailfish_Crypto_Key_OriginUnknown;
+    key->algorithm = Sailfish_Crypto_Key_AlgorithmUnknown;
+    key->blockModes = Sailfish_Crypto_Key_BlockModeUnknown;
+    key->encryptionPaddings = Sailfish_Crypto_Key_EncryptionPaddingUnknown;
+    key->signaturePaddings = Sailfish_Crypto_Key_SignaturePaddingUnknown;
+    key->digests = Sailfish_Crypto_Key_DigestUnknown;
+    key->operations = Sailfish_Crypto_Key_OperationUnknown;
+
+    return key;
+}
+
+void Sailfish_Crypto_Key_setPrivateKey(
+        struct Sailfish_Crypto_Key *key,
+        const unsigned char *privateKey,
+        size_t privateKeySize)
+{
+    if (key) {
+        free(key->privateKey);
+        if (privateKeySize && privateKey) {
+            key->privateKeySize = privateKeySize;
+            key->privateKey = (unsigned char *)malloc(privateKeySize);
+            memcpy(key->privateKey, privateKey, privateKeySize);
+        } else {
+            key->privateKeySize = 0;
+            key->privateKey = NULL;
+        }
+    }
+}
+
+void Sailfish_Crypto_Key_setPublicKey(
+        struct Sailfish_Crypto_Key *key,
+        const unsigned char *publicKey,
+        size_t publicKeySize)
+{
+    if (key) {
+        free(key->publicKey);
+        if (publicKeySize && publicKey) {
+            key->publicKeySize = publicKeySize;
+            key->publicKey = (unsigned char *)malloc(publicKeySize);
+            memcpy(key->publicKey, publicKey, publicKeySize);
+        } else {
+            key->publicKeySize = 0;
+            key->publicKey = NULL;
+        }
+    }
+}
+
+void Sailfish_Crypto_Key_setSecretKey(
+        struct Sailfish_Crypto_Key *key,
+        const unsigned char *secretKey,
+        size_t secretKeySize)
+{
+    if (key) {
+        free(key->secretKey);
+        if (secretKeySize && secretKey) {
+            key->secretKeySize = secretKeySize;
+            key->secretKey = (unsigned char *)malloc(secretKeySize);
+            memcpy(key->secretKey, secretKey, secretKeySize);
+        } else {
+            key->secretKeySize = 0;
+            key->secretKey = NULL;
+        }
+    }
+}
+
+void Sailfish_Crypto_Key_addFilter(
+        struct Sailfish_Crypto_Key *key,
+        const char *field,
+        const char *value)
+{
+    if (key && field && value) {
+        if (!key->filterData) {
+            key->filterData = Sailfish_Crypto_Key_FilterDatum_new(
+                        field, value);
+        } else {
+            struct Sailfish_Crypto_Key_FilterDatum *filter =
+                    key->filterData;
+            while (filter->next) {
+                filter = filter->next;
+            }
+            filter->next = Sailfish_Crypto_Key_FilterDatum_new(
+                        field, value);
+        }
+    }
+}
+
+void Sailfish_Crypto_Key_addCustomParameter(
+        struct Sailfish_Crypto_Key *key,
+        const unsigned char *parameter,
+        size_t parameterSize)
+{
+    if (key && parameter && parameterSize) {
+        if (!key->customParameters) {
+            key->customParameters = Sailfish_Crypto_Key_CustomParameter_new(
+                        parameter, parameterSize);
+        } else {
+            struct Sailfish_Crypto_Key_CustomParameter *param =
+                    key->customParameters;
+            while (param->next) {
+                param = param->next;
+            }
+            param->next = Sailfish_Crypto_Key_CustomParameter_new(
+                        parameter, parameterSize);
+        }
+    }
+}
+
+void Sailfish_Crypto_Key_delete(
+        struct Sailfish_Crypto_Key *key)
+{
+    if (key) {
+        Sailfish_Crypto_Key_Identifier_delete(key->identifier);
+        Sailfish_Crypto_Key_CustomParameter_delete(key->customParameters);
+        Sailfish_Crypto_Key_FilterDatum_delete(key->filterData);
+        free(key->publicKey);
+        free(key->privateKey);
+        free(key->secretKey);
+        free(key);
+    }
+}
+
+/****************************** Crypto Manager ******************************/
+
+int Sailfish_Crypto_CryptoManager_generateKey(
+        struct Sailfish_Crypto_Key *keyTemplate,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        struct Sailfish_Crypto_Key **out_key)
+{
+    DBusMessageIter in_args;
+    DBusMessageIter out_args;
+
+    if (keyTemplate == NULL
+            || cryptosystemProviderName == NULL
+            || out_result == NULL
+            || out_key == NULL
+            || *out_result != NULL
+            || *out_key != NULL) {
+        fprintf(stderr, "Invalid paramaters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__isConnectedToServer()) {
+        if (!Sailfish_Crypto__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                     /* service name */
+                "/Sailfish/Crypto",       /* object */
+                "org.sailfishos.crypto",  /* interface */
+                "generateKey");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Crypto__appendKeyArg(
+                &in_args,
+                keyTemplate);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &cryptosystemProviderName);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return arguments */
+    if (!dbus_message_iter_init(daemon_connection.msg, &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__readResultStruct(&out_args, out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_iter_next(&out_args);
+
+    if (!Sailfish_Crypto__readKeyStruct(&out_args, out_key)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Crypto_CryptoManager_generateStoredKey(
+        struct Sailfish_Crypto_Key *keyTemplate,
+        const char *cryptosystemProviderName,
+        const char *storageProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        struct Sailfish_Crypto_Key **out_keyReference)
+{
+    DBusMessageIter in_args;
+    DBusMessageIter out_args;
+
+    if (keyTemplate == NULL
+            || cryptosystemProviderName == NULL
+            || storageProviderName == NULL
+            || out_result == NULL
+            || out_keyReference == NULL
+            || *out_result != NULL
+            || *out_keyReference != NULL) {
+        fprintf(stderr, "Invalid paramaters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__isConnectedToServer()) {
+        if (!Sailfish_Crypto__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                     /* service name */
+                "/Sailfish/Crypto",       /* object */
+                "org.sailfishos.crypto",  /* interface */
+                "generateStoredKey");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Crypto__appendKeyArg(
+                &in_args,
+                keyTemplate);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &cryptosystemProviderName);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &storageProviderName);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return arguments */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__readResultStruct(&out_args,
+                                           out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_iter_next(&out_args);
+
+    if (!Sailfish_Crypto__readKeyStruct(&out_args,
+                                        out_keyReference)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Crypto_CryptoManager_storedKey(
+        struct Sailfish_Crypto_Key_Identifier *ident,
+        struct Sailfish_Crypto_Result **out_result,
+        struct Sailfish_Crypto_Key **out_key)
+{
+    DBusMessageIter in_args;
+    DBusMessageIter out_args;
+
+    if (ident == NULL
+            || out_result == NULL
+            || out_key == NULL
+            || *out_result != NULL
+            || *out_key != NULL) {
+        fprintf(stderr, "Invalid paramaters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__isConnectedToServer()) {
+        if (!Sailfish_Crypto__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                     /* service name */
+                "/Sailfish/Crypto",       /* object */
+                "org.sailfishos.crypto",  /* interface */
+                "storedKey");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Crypto__appendKeyIdentifierArg(
+                &in_args,
+                ident);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return arguments */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__readResultStruct(&out_args,
+                                           out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_iter_next(&out_args);
+
+    if (!Sailfish_Crypto__readKeyStruct(&out_args, out_key)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Crypto_CryptoManager_deleteStoredKey(
+        struct Sailfish_Crypto_Key_Identifier *ident,
+        struct Sailfish_Crypto_Result **out_result)
+{
+    DBusMessageIter in_args;
+    DBusMessageIter out_args;
+
+    if (ident == NULL
+            || out_result == NULL
+            || *out_result != NULL) {
+        fprintf(stderr, "Invalid paramaters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__isConnectedToServer()) {
+        if (!Sailfish_Crypto__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                     /* service name */
+                "/Sailfish/Crypto",       /* object */
+                "org.sailfishos.crypto",  /* interface */
+                "deleteStoredKey");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Crypto__appendKeyIdentifierArg(
+                &in_args,
+                ident);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return arguments */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__readResultStruct(&out_args,
+                                           out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Crypto_CryptoManager_sign(
+        const unsigned char *data,
+        size_t dataSize,
+        struct Sailfish_Crypto_Key *key,
+        Sailfish_Crypto_Key_SignaturePadding padding,
+        Sailfish_Crypto_Key_Digest digest,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        unsigned char **out_signature,
+        size_t *out_signature_size)
+{
+    DBusMessageIter in_args;
+    DBusMessageIter out_args;
+    DBusMessageIter sig_array;
+
+    int iPadding = (int)padding;
+    int iDigest = (int)digest;
+
+    unsigned char *out_sig = NULL;
+    int out_sig_size = 0;
+
+    if (data == NULL
+            || key == NULL
+            || cryptosystemProviderName == NULL
+            || out_result == NULL
+            || out_signature == NULL
+            || out_signature_size == NULL
+            || *out_result != NULL
+            || *out_signature != NULL) {
+        fprintf(stderr, "Invalid paramaters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__isConnectedToServer()) {
+        if (!Sailfish_Crypto__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                     /* service name */
+                "/Sailfish/Crypto",       /* object */
+                "org.sailfishos.crypto",  /* interface */
+                "sign");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Crypto__appendDataArg(&in_args, data, dataSize);
+    Sailfish_Crypto__appendKeyArg(&in_args, key);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iPadding);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iDigest);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &cryptosystemProviderName);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return arguments */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__readResultStruct(&out_args,
+                                           out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_iter_next(&out_args);
+
+    dbus_message_iter_recurse(&out_args, &sig_array);
+    dbus_message_iter_get_fixed_array(&sig_array,
+                                      &out_sig,
+                                      &out_sig_size);
+
+    *out_signature_size = (size_t)out_sig_size;
+    *out_signature = (unsigned char *)malloc(*out_signature_size);
+    memcpy(*out_signature, out_sig, *out_signature_size);
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Crypto_CryptoManager_verify(
+        const unsigned char *data,
+        size_t dataSize,
+        struct Sailfish_Crypto_Key *key,
+        Sailfish_Crypto_Key_SignaturePadding padding,
+        Sailfish_Crypto_Key_Digest digest,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        int *out_verified)
+{
+    DBusMessageIter in_args;
+    DBusMessageIter out_args;
+    dbus_bool_t verified = FALSE;
+
+    int iPadding = (int)padding;
+    int iDigest = (int)digest;
+
+    if (data == NULL
+            || key == NULL
+            || cryptosystemProviderName == NULL
+            || out_result == NULL
+            || out_verified == NULL
+            || *out_result != NULL) {
+        fprintf(stderr, "Invalid paramaters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__isConnectedToServer()) {
+        if (!Sailfish_Crypto__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                     /* service name */
+                "/Sailfish/Crypto",       /* object */
+                "org.sailfishos.crypto",  /* interface */
+                "verify");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Crypto__appendDataArg(&in_args, data, dataSize);
+    Sailfish_Crypto__appendKeyArg(&in_args, key);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iPadding);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iDigest);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &cryptosystemProviderName);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return arguments */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__readResultStruct(&out_args,
+                                           out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_iter_next(&out_args);
+    dbus_message_iter_get_basic(&out_args, &verified);
+    *out_verified = (verified == TRUE) ? 1 : 0;
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Crypto_CryptoManager_encrypt(
+        const unsigned char *data,
+        size_t dataSize,
+        struct Sailfish_Crypto_Key *key,
+        Sailfish_Crypto_Key_BlockMode blockMode,
+        Sailfish_Crypto_Key_EncryptionPadding padding,
+        Sailfish_Crypto_Key_Digest digest,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        unsigned char **out_ciphertext,
+        size_t *out_ciphertext_size)
+{
+    DBusMessageIter in_args;
+    DBusMessageIter out_args;
+    DBusMessageIter ciphertext_array;
+
+    int iBlockMode = (int)blockMode;
+    int iPadding = (int)padding;
+    int iDigest = (int)digest;
+
+    unsigned char *out_ciph = NULL;
+    int out_ciph_size = 0;
+
+    if (data == NULL
+            || key == NULL
+            || cryptosystemProviderName == NULL
+            || out_result == NULL
+            || out_ciphertext == NULL
+            || out_ciphertext_size == NULL
+            || *out_result != NULL
+            || *out_ciphertext != NULL) {
+        fprintf(stderr, "Invalid paramaters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__isConnectedToServer()) {
+        if (!Sailfish_Crypto__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                     /* service name */
+                "/Sailfish/Crypto",       /* object */
+                "org.sailfishos.crypto",  /* interface */
+                "encrypt");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Crypto__appendDataArg(&in_args, data, dataSize);
+    Sailfish_Crypto__appendKeyArg(&in_args, key);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iBlockMode);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iPadding);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iDigest);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &cryptosystemProviderName);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return arguments */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__readResultStruct(&out_args,
+                                           out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_iter_next(&out_args);
+
+    dbus_message_iter_recurse(&out_args, &ciphertext_array);
+    dbus_message_iter_get_fixed_array(&ciphertext_array,
+                                      &out_ciph,
+                                      &out_ciph_size);
+
+    *out_ciphertext_size = (size_t)out_ciph_size;
+    *out_ciphertext = (unsigned char *)malloc(*out_ciphertext_size);
+    memcpy(*out_ciphertext, out_ciph, *out_ciphertext_size);
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Crypto_CryptoManager_decrypt(
+        const unsigned char *data,
+        size_t dataSize,
+        struct Sailfish_Crypto_Key *key,
+        Sailfish_Crypto_Key_BlockMode blockMode,
+        Sailfish_Crypto_Key_EncryptionPadding padding,
+        Sailfish_Crypto_Key_Digest digest,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        unsigned char **out_plaintext,
+        size_t *out_plaintext_size)
+{
+    DBusMessageIter in_args;
+    DBusMessageIter out_args;
+    DBusMessageIter plaintext_array;
+
+    int iBlockMode = (int)blockMode;
+    int iPadding = (int)padding;
+    int iDigest = (int)digest;
+
+    unsigned char *out_pt = NULL;
+    int out_pt_size = 0;
+
+    if (data == NULL
+            || key == NULL
+            || cryptosystemProviderName == NULL
+            || out_result == NULL
+            || out_plaintext == NULL
+            || out_plaintext_size == NULL
+            || *out_result != NULL
+            || *out_plaintext != NULL) {
+        fprintf(stderr, "Invalid paramaters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__isConnectedToServer()) {
+        if (!Sailfish_Crypto__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                     /* service name */
+                "/Sailfish/Crypto",       /* object */
+                "org.sailfishos.crypto",  /* interface */
+                "decrypt");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Crypto__appendDataArg(&in_args, data, dataSize);
+    Sailfish_Crypto__appendKeyArg(&in_args, key);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iBlockMode);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iPadding);
+    Sailfish_Crypto__appendEnumArg(&in_args, &iDigest);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &cryptosystemProviderName);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return arguments */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Crypto__readResultStruct(&out_args,
+                                           out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_iter_next(&out_args);
+
+    dbus_message_iter_recurse(&out_args, &plaintext_array);
+    dbus_message_iter_get_fixed_array(&plaintext_array,
+                                      &out_pt,
+                                      &out_pt_size);
+
+
+    *out_plaintext_size = (size_t)out_pt_size;
+    *out_plaintext = (unsigned char *)malloc(*out_plaintext_size);
+    memcpy(*out_plaintext, out_pt, *out_plaintext_size);
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}

--- a/lib/Crypto/crypto_c.h
+++ b/lib/Crypto/crypto_c.h
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2017 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#ifndef LIBSAILFISHCRYPTO_CRYPTO_C_H
+#define LIBSAILFISHCRYPTO_CRYPTO_C_H
+
+/* This file provides a C-compatible wrapper for Crypto */
+
+#include <stddef.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/******************************** Result ************************************/
+
+enum Sailfish_Crypto_Result_Code {
+    Sailfish_Crypto_Result_Succeeded = 0,
+    Sailfish_Crypto_Result_Pending = 1,
+    Sailfish_Crypto_Result_Failed = 2
+};
+
+struct Sailfish_Crypto_Result {
+    enum Sailfish_Crypto_Result_Code code;
+    int errorCode;
+    int storageErrorCode;
+    char *errorMessage;
+};
+
+struct Sailfish_Crypto_Result*
+Sailfish_Crypto_Result_new(
+        enum Sailfish_Crypto_Result_Code code,
+        int errorCode,
+        int storageErrorCode,
+        const char *errorMessage);
+
+void Sailfish_Crypto_Result_delete(
+        struct Sailfish_Crypto_Result *result);
+
+/********************************* Key **************************************/
+
+struct Sailfish_Crypto_Key_Identifier {
+    char *name;
+    char *collectionName;
+};
+
+struct Sailfish_Crypto_Key_FilterDatum {
+    char *field;
+    char *value;
+    struct Sailfish_Crypto_Key_FilterDatum *next;
+};
+
+struct Sailfish_Crypto_Key_CustomParameter {
+    unsigned char *parameter;
+    size_t parameterSize;
+    struct Sailfish_Crypto_Key_CustomParameter *next;
+};
+
+enum Sailfish_Crypto_Key_Origin {
+    Sailfish_Crypto_Key_OriginUnknown       = 0,
+    Sailfish_Crypto_Key_OriginImported,
+    Sailfish_Crypto_Key_OriginDevice,
+    Sailfish_Crypto_Key_OriginSecureDevice
+};
+
+enum Sailfish_Crypto_Key_Algorithm {
+    Sailfish_Crypto_Key_AlgorithmUnknown    = 0,
+
+    Sailfish_Crypto_Key_Aes128              = 10,
+    Sailfish_Crypto_Key_Aes196,
+    Sailfish_Crypto_Key_Aes256,
+
+    Sailfish_Crypto_Key_Dsa512              = 20,
+    Sailfish_Crypto_Key_Dsa1024,
+    Sailfish_Crypto_Key_Dsa2048,
+    Sailfish_Crypto_Key_Dsa3072,
+    Sailfish_Crypto_Key_Dsa4096,
+
+    Sailfish_Crypto_Key_Rsa512              = 30,
+    Sailfish_Crypto_Key_Rsa1028,
+    Sailfish_Crypto_Key_Rsa2048,
+    Sailfish_Crypto_Key_Rsa3072,
+    Sailfish_Crypto_Key_Rsa4096,
+
+    Sailfish_Crypto_Key_NistEcc192          = 40,
+    Sailfish_Crypto_Key_NistEcc224,
+    Sailfish_Crypto_Key_NistEcc256,
+    Sailfish_Crypto_Key_NistEcc384,
+    Sailfish_Crypto_Key_NistEcc521,
+
+    Sailfish_Crypto_Key_BpEcc160            = 50,
+    Sailfish_Crypto_Key_BpEcc192,
+    Sailfish_Crypto_Key_BpEcc224,
+    Sailfish_Crypto_Key_BpEcc256,
+    Sailfish_Crypto_Key_BpEcc320,
+    Sailfish_Crypto_Key_BpEcc384,
+    Sailfish_Crypto_Key_BpEcc512
+};
+
+enum Sailfish_Crypto_Key_BlockMode {
+    Sailfish_Crypto_Key_BlockModeUnknown    = 0,
+    Sailfish_Crypto_Key_BlockModeCBC        = 1,
+    Sailfish_Crypto_Key_BlockModeCTR        = 2,
+    Sailfish_Crypto_Key_BlockModeECB        = 4,
+    Sailfish_Crypto_Key_BlockModeGCM        = 8
+};
+
+enum Sailfish_Crypto_Key_EncryptionPadding {
+    Sailfish_Crypto_Key_EncryptionPaddingUnknown    = 0,
+    Sailfish_Crypto_Key_EncryptionPaddingNone       = 1,
+    Sailfish_Crypto_Key_EncryptionPaddingPkcs7      = 2,
+    Sailfish_Crypto_Key_EncryptionPaddingRsaOaep    = 4,
+    Sailfish_Crypto_Key_EncryptionPaddingRsaOaepMgf1= 8,
+    Sailfish_Crypto_Key_EncryptionPaddingRsaPkcs1   = 16,
+    Sailfish_Crypto_Key_EncryptionPaddingAnsiX923   = 32
+};
+
+enum Sailfish_Crypto_Key_SignaturePadding {
+    Sailfish_Crypto_Key_SignaturePaddingUnknown     = 0,
+    Sailfish_Crypto_Key_SignaturePaddingNone        = 1,
+    Sailfish_Crypto_Key_SignaturePaddingRsaPss      = 2,
+    Sailfish_Crypto_Key_SignaturePaddingRsaPkcs1    = Sailfish_Crypto_Key_EncryptionPaddingRsaPkcs1,
+    Sailfish_Crypto_Key_SignaturePaddingAnsiX923    = Sailfish_Crypto_Key_EncryptionPaddingAnsiX923
+};
+
+enum Sailfish_Crypto_Key_Digest {
+    Sailfish_Crypto_Key_DigestUnknown       = 0,
+    Sailfish_Crypto_Key_DigestSha1          = 1,
+    Sailfish_Crypto_Key_DigestSha256        = 2,
+    Sailfish_Crypto_Key_DigestSha384        = 4,
+    Sailfish_Crypto_Key_DigestSha512        = 8
+};
+
+enum Sailfish_Crypto_Key_Operation {
+    Sailfish_Crypto_Key_OperationUnknown    = 0,
+    Sailfish_Crypto_Key_Sign                = 1,
+    Sailfish_Crypto_Key_Verify              = 2,
+    Sailfish_Crypto_Key_Encrypt             = 4,
+    Sailfish_Crypto_Key_Decrypt             = 8
+};
+
+struct Sailfish_Crypto_Key {
+    struct Sailfish_Crypto_Key_Identifier *identifier;
+
+    enum Sailfish_Crypto_Key_Origin origin;
+    enum Sailfish_Crypto_Key_Algorithm algorithm;
+    int blockModes;
+    int encryptionPaddings;
+    int signaturePaddings;
+    int digests;
+    int operations;
+
+    unsigned char *secretKey;
+    size_t secretKeySize;
+    unsigned char *publicKey;
+    size_t publicKeySize;
+    unsigned char *privateKey;
+    size_t privateKeySize;
+
+    time_t validityStart;
+    time_t validityEnd;
+
+    struct Sailfish_Crypto_Key_CustomParameter *customParameters;
+    struct Sailfish_Crypto_Key_FilterDatum *filterData;
+};
+
+struct Sailfish_Crypto_Key_Identifier*
+Sailfish_Crypto_Key_Identifier_new(
+        const char *name,
+        const char *collectionName);
+
+void Sailfish_Crypto_Key_Identifier_delete(
+        struct Sailfish_Crypto_Key_Identifier *ident);
+
+struct Sailfish_Crypto_Key_FilterDatum*
+Sailfish_Crypto_Key_FilterDatum_new(
+        const char *field,
+        const char *value);
+
+void Sailfish_Crypto_Key_FilterDatum_delete(
+        struct Sailfish_Crypto_Key_FilterDatum *filter);
+
+struct Sailfish_Crypto_Key_CustomParameter*
+Sailfish_Crypto_Key_CustomParameter_new(
+        const unsigned char *parameter,
+        size_t parameterSize);
+
+void Sailfish_Crypto_Key_CustomParameter_delete(
+        struct Sailfish_Crypto_Key_CustomParameter *param);
+
+struct Sailfish_Crypto_Key*
+Sailfish_Crypto_Key_new(
+        const char *name,
+        const char *collectionName);
+
+void Sailfish_Crypto_Key_setPrivateKey(
+        struct Sailfish_Crypto_Key *key,
+        const unsigned char *privateKey,
+        size_t privateKeySize);
+
+void Sailfish_Crypto_Key_setPublicKey(
+        struct Sailfish_Crypto_Key *key,
+        const unsigned char *publicKey,
+        size_t publicKeySize);
+
+void Sailfish_Crypto_Key_setSecretKey(
+        struct Sailfish_Crypto_Key *key,
+        const unsigned char *secretKey,
+        size_t secretKeySize);
+
+void Sailfish_Crypto_Key_addFilter(
+        struct Sailfish_Crypto_Key *key,
+        const char *field,
+        const char *value);
+
+void Sailfish_Crypto_Key_addCustomParameter(
+        struct Sailfish_Crypto_Key *key,
+        const unsigned char *parameter,
+        size_t parameterSize);
+
+void Sailfish_Crypto_Key_delete(
+        struct Sailfish_Crypto_Key *key);
+
+/****************************** Crypto Manager ******************************/
+
+int Sailfish_Crypto_CryptoManager_generateKey(
+        struct Sailfish_Crypto_Key *keyTemplate,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        struct Sailfish_Crypto_Key **out_key);
+
+int Sailfish_Crypto_CryptoManager_generateStoredKey(
+        struct Sailfish_Crypto_Key *keyTemplate,
+        const char *cryptosystemProviderName,
+        const char *storageProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        struct Sailfish_Crypto_Key **out_keyReference);
+
+int Sailfish_Crypto_CryptoManager_storedKey(
+        struct Sailfish_Crypto_Key_Identifier *ident,
+        struct Sailfish_Crypto_Result **out_result,
+        struct Sailfish_Crypto_Key **out_key);
+
+int Sailfish_Crypto_CryptoManager_deleteStoredKey(
+        struct Sailfish_Crypto_Key_Identifier *ident,
+        struct Sailfish_Crypto_Result **out_result);
+
+int Sailfish_Crypto_CryptoManager_sign(
+        const unsigned char *data,
+        size_t dataSize,
+        struct Sailfish_Crypto_Key *key,
+        enum Sailfish_Crypto_Key_SignaturePadding padding,
+        enum Sailfish_Crypto_Key_Digest digest,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        unsigned char **out_signature,
+        size_t *out_signature_size);
+
+int Sailfish_Crypto_CryptoManager_verify(
+        const unsigned char *data,
+        size_t dataSize,
+        struct Sailfish_Crypto_Key *key,
+        enum Sailfish_Crypto_Key_SignaturePadding padding,
+        enum Sailfish_Crypto_Key_Digest digest,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        int *out_verified);
+
+int Sailfish_Crypto_CryptoManager_encrypt(
+        const unsigned char *data,
+        size_t dataSize,
+        struct Sailfish_Crypto_Key *key,
+        enum Sailfish_Crypto_Key_BlockMode blockMode,
+        enum Sailfish_Crypto_Key_EncryptionPadding padding,
+        enum Sailfish_Crypto_Key_Digest digest,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        unsigned char **out_ciphertext,
+        size_t *out_ciphertext_size);
+
+int Sailfish_Crypto_CryptoManager_decrypt(
+        const unsigned char *data,
+        size_t dataSize,
+        struct Sailfish_Crypto_Key *key,
+        enum Sailfish_Crypto_Key_BlockMode blockMode,
+        enum Sailfish_Crypto_Key_EncryptionPadding padding,
+        enum Sailfish_Crypto_Key_Digest digest,
+        const char *cryptosystemProviderName,
+        struct Sailfish_Crypto_Result **out_result,
+        unsigned char **out_plaintext,
+        size_t *out_plaintext_size);
+
+void Sailfish_Crypto_disconnectFromServer();
+
+#ifdef __cplusplus
+} /* extern C */
+#endif /* __cplusplus */
+
+#endif /* LIBSAILFISHCRYPTO_CRYPTO_C_H */

--- a/lib/Secrets/Secrets.pro
+++ b/lib/Secrets/Secrets.pro
@@ -7,6 +7,9 @@ DEFINES += SAILFISH_SECRETS_LIBRARY_BUILD
 QT += dbus
 QT -= gui
 
+CONFIG += link_pkgconfig
+PKGCONFIG += dbus-1
+
 include($$PWD/../../common.pri)
 
 INCLUDEPATH += $$PWD/../
@@ -21,7 +24,8 @@ PUBLIC_HEADERS += \
     $$PWD/secretsglobal.h \
     $$PWD/interactionrequest.h \
     $$PWD/interactionrequestwatcher.h \
-    $$PWD/interactionview.h
+    $$PWD/interactionview.h \
+    $$PWD/secrets_c.h
 
 PRIVATE_HEADERS += \
     $$PWD/secretsdaemonconnection_p.h \
@@ -38,7 +42,8 @@ SOURCES += \
     $$PWD/secretmanager.cpp \
     $$PWD/serialisation.cpp \
     $$PWD/interactionrequestwatcher.cpp \
-    $$PWD/interactionservice.cpp
+    $$PWD/interactionservice.cpp \
+    $$PWD/secrets_c.c
 
 develheaders.path = /usr/include/libsailfishsecrets/
 develheaders_secrets.path = /usr/include/libsailfishsecrets/Secrets/

--- a/lib/Secrets/secrets_c.c
+++ b/lib/Secrets/secrets_c.c
@@ -1,0 +1,1147 @@
+/*
+ * Copyright (C) 2017 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#include "secrets_c.h"
+
+#include <dbus/dbus.h>
+#include <sys/types.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int Sailfish_Secrets__getServerPeerToPeerAddress(
+        char ** p2pAddr,
+        DBusConnection **sessionBus)
+{
+    DBusMessage* msg;
+    DBusMessageIter args;
+    DBusError err;
+    DBusPendingCall* pending;
+    char *param = NULL;
+
+    if (p2pAddr == NULL || sessionBus == NULL) {
+        fprintf(stderr, "Invalid parameters!\n");
+        return 0;
+    }
+
+    /* initialise the error */
+    dbus_error_init(&err);
+
+    /* connect to the session bus */
+    *sessionBus = dbus_bus_get(DBUS_BUS_SESSION, &err);
+    if (dbus_error_is_set(&err)) {
+        fprintf(stderr, "Connection Error (%s)\n", err.message);
+        dbus_error_free(&err);
+    }
+    if (*sessionBus == NULL) {
+        return 0;
+    }
+
+    /* create a new method call and check for errors */
+    msg = dbus_message_new_method_call(
+                "org.sailfishos.secrets.daemon.discovery",
+                "/Sailfish/Secrets/Discovery",
+                "org.sailfishos.secrets.daemon.discovery",
+                "peerToPeerAddress");
+    if (msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        dbus_error_free(&err);
+        return 0;
+    }
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                *sessionBus,
+                msg,
+                &pending,
+                -1);
+
+    if (pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_error_free(&err);
+        dbus_message_unref(msg);
+        return 0;
+    }
+
+    dbus_connection_flush(*sessionBus);
+    dbus_message_unref(msg);
+    dbus_pending_call_block(pending);
+    msg = dbus_pending_call_steal_reply(pending);
+    dbus_pending_call_unref(pending);
+    if (msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        dbus_error_free(&err);
+        return 0;
+    }
+
+    /* read the address return argument */
+    if (!dbus_message_iter_init(msg, &args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+    } else if (DBUS_TYPE_STRING != dbus_message_iter_get_arg_type(&args)) {
+        fprintf(stderr, "Argument is not string!\n");
+    } else {
+        dbus_message_iter_get_basic(&args, &param);
+    }
+
+    *p2pAddr = strdup(param);
+
+    dbus_error_free(&err);
+    dbus_message_unref(msg);
+
+    return 1;
+}
+
+static struct Sailfish_Secrets_DBus_Connection {
+    DBusConnection *sessionBus;
+    DBusConnection* p2pBus;
+    DBusMessage* msg;
+    DBusPendingCall* pending;
+    char *p2pAddr;
+} daemon_connection = {
+    .sessionBus = NULL,
+    .p2pBus = NULL,
+    .msg = NULL,
+    .pending = NULL,
+    .p2pAddr = NULL
+};
+
+static int Sailfish_Secrets__isConnectedToServer()
+{
+    return daemon_connection.p2pBus == NULL ? 0 : 1;
+}
+
+static int Sailfish_Secrets__connectToServer()
+{
+    DBusError daemon_connection_error;
+
+    if (daemon_connection.p2pBus != NULL) {
+        fprintf(stderr, "Already connected to secrets daemon!\n");
+        return 1; /* Return "ok" */
+    }
+
+    /* Get the peer to peer address of the daemon via the session bus */
+    if (!daemon_connection.p2pAddr &&
+            !Sailfish_Secrets__getServerPeerToPeerAddress(
+                &daemon_connection.p2pAddr,
+                &daemon_connection.sessionBus)) {
+        return 0;
+    }
+
+    /* Open a private peer to peer connection to the daemon */
+    dbus_error_init(&daemon_connection_error);
+    daemon_connection.p2pBus = dbus_connection_open_private(
+                daemon_connection.p2pAddr,
+                &daemon_connection_error);
+    if (dbus_error_is_set(&daemon_connection_error)) {
+        fprintf(stderr,
+                "Connection Error (%s) to: %s\n",
+                daemon_connection_error.message,
+                daemon_connection.p2pAddr);
+        dbus_error_free(&daemon_connection_error);
+    }
+    if (daemon_connection.p2pBus == NULL) {
+        return 0;
+    }
+
+    return 1;
+}
+
+void Sailfish_Secrets_disconnectFromServer()
+{
+    if (daemon_connection.p2pBus) {
+        dbus_connection_close(daemon_connection.p2pBus);
+        dbus_connection_unref(daemon_connection.p2pBus);
+        daemon_connection.p2pBus = NULL;
+        free(daemon_connection.p2pAddr);
+        daemon_connection.p2pAddr = NULL;
+    }
+}
+
+static void Sailfish_Secrets__appendEnumArg(
+        DBusMessageIter *in_args,
+        DBusMessageIter *enum_struct,
+        int *arg)
+{
+    dbus_message_iter_open_container(
+                in_args,
+                DBUS_TYPE_STRUCT,
+                NULL,
+                enum_struct);
+    dbus_message_iter_append_basic(
+                enum_struct,
+                DBUS_TYPE_INT32,
+                arg);
+    dbus_message_iter_close_container(
+                in_args,
+                enum_struct);
+}
+
+static void Sailfish_Secrets__appendSecretIdentifierArg(
+        DBusMessageIter *args,
+        struct Sailfish_Secrets_Secret_Identifier *ident)
+{
+    DBusMessageIter ident_struct;
+
+    dbus_message_iter_open_container(
+                args,
+                DBUS_TYPE_STRUCT,
+                NULL,
+                &ident_struct);
+
+    dbus_message_iter_append_basic(
+                &ident_struct,
+                DBUS_TYPE_STRING,
+                &ident->name);
+
+    dbus_message_iter_append_basic(
+                &ident_struct,
+                DBUS_TYPE_STRING,
+                &ident->collectionName);
+
+    dbus_message_iter_close_container(
+                args,
+                &ident_struct);
+}
+
+static void Sailfish_Secrets__appendSecretArg(
+        DBusMessageIter *in_args,
+        struct Sailfish_Secrets_Secret *secret)
+{
+    DBusMessageIter secret_struct;
+    DBusMessageIter data_array;
+    DBusMessageIter filter_dict;
+    struct Sailfish_Secrets_Secret_FilterDatum *next = secret->filterData;
+
+    dbus_message_iter_open_container(
+                in_args,
+                DBUS_TYPE_STRUCT,
+                NULL,
+                &secret_struct);
+
+    /* append the identifier */
+    Sailfish_Secrets__appendSecretIdentifierArg(&secret_struct,
+                                                secret->identifier);
+
+    /* append the data array */
+    dbus_message_iter_open_container(
+                &secret_struct,
+                DBUS_TYPE_ARRAY,
+                "y",
+                &data_array);
+
+    dbus_message_iter_append_fixed_array(
+                &data_array,
+                DBUS_TYPE_BYTE,
+                &secret->data,
+                secret->dataSize);
+
+    dbus_message_iter_close_container(
+                &secret_struct,
+                &data_array);
+
+    /* append the filter dict */
+    dbus_message_iter_open_container(
+                &secret_struct,
+                DBUS_TYPE_ARRAY,
+                "{sv}",
+                &filter_dict);
+
+    while (next) {
+        DBusMessageIter key_value;
+        DBusMessageIter value;
+        char signature[2];
+        signature[0] = DBUS_TYPE_STRING;
+        signature[1] = 0;
+
+        dbus_message_iter_open_container(
+                    &filter_dict,
+                    DBUS_TYPE_DICT_ENTRY,
+                    NULL,
+                    &key_value);
+        dbus_message_iter_append_basic(
+                    &key_value,
+                    DBUS_TYPE_STRING,
+                    &next->field);
+        dbus_message_iter_open_container(
+                    &key_value,
+                    DBUS_TYPE_VARIANT,
+                    signature,
+                    &value);
+        dbus_message_iter_append_basic(
+                    &value,
+                    DBUS_TYPE_STRING,
+                    &next->value);
+        dbus_message_iter_close_container(
+                    &key_value,
+                    &value);
+        dbus_message_iter_close_container(
+                    &filter_dict,
+                    &key_value);
+        next = next->next;
+    }
+
+    dbus_message_iter_close_container(
+                &secret_struct,
+                &filter_dict);
+
+    dbus_message_iter_close_container(
+                in_args,
+                &secret_struct);
+}
+
+static int Sailfish_Secrets__readResultStruct(
+        DBusMessageIter *args,
+        struct Sailfish_Secrets_Result **result)
+{
+    if (args == NULL
+            || result == NULL
+            || *result != NULL) {
+        fprintf(stderr, "Invalid parameters, cannot read result!\n");
+        return 0;
+    }
+
+    if (dbus_message_iter_get_arg_type(args) != DBUS_TYPE_STRUCT) {
+        fprintf(stderr, "Argument is not result struct!\n");
+        if (dbus_message_iter_get_arg_type(args) == DBUS_TYPE_STRING) {
+            char *resultStr;
+            dbus_message_iter_get_basic(args, &resultStr);
+            fprintf(stderr, "Got result str: %s\n", resultStr);
+        }
+        return 0;
+    } else {
+        DBusMessageIter res_struct;
+        int code;
+        int errorCode;
+        char *errorMessage;
+
+        dbus_message_iter_recurse(args, &res_struct);
+
+        if (dbus_message_iter_get_arg_type(&res_struct) != DBUS_TYPE_INT32) {
+            fprintf(stderr, "First result struct arg not an integer!\n");
+            return 0;
+        }
+
+        dbus_message_iter_get_basic(&res_struct, &code);
+
+        dbus_message_iter_next(&res_struct);
+
+        if (dbus_message_iter_get_arg_type(&res_struct) != DBUS_TYPE_INT32) {
+            fprintf(stderr, "Second result struct arg not an integer!\n");
+            return 0;
+        }
+
+        dbus_message_iter_get_basic(&res_struct, &errorCode);
+
+        dbus_message_iter_next(&res_struct);
+
+        if (dbus_message_iter_get_arg_type(&res_struct) != DBUS_TYPE_STRING) {
+            fprintf(stderr, "Third result struct arg not a string!\n");
+            return 0;
+        }
+
+        dbus_message_iter_get_basic(&res_struct, &errorMessage);
+
+        *result = Sailfish_Secrets_Result_new(
+                    code, errorCode, errorMessage);
+    }
+
+    return 1;
+}
+
+
+static int Sailfish_Secrets__readSecretStruct(
+        DBusMessageIter *args,
+        struct Sailfish_Secrets_Secret **secret)
+{
+    if (args == NULL
+            || secret == NULL
+            || *secret != NULL) {
+        fprintf(stderr, "Invalid parameters, cannot read secret!\n");
+        return 0;
+    }
+
+    if (dbus_message_iter_get_arg_type(args) != DBUS_TYPE_STRUCT) {
+        fprintf(stderr, "Argument is not result struct!\n");
+        if (dbus_message_iter_get_arg_type(args) == DBUS_TYPE_STRING) {
+            char *resultStr;
+            dbus_message_iter_get_basic(args, &resultStr);
+            fprintf(stderr, "Got result str: %s\n", resultStr);
+        }
+        return 0;
+    } else {
+        DBusMessageIter sec_struct;
+        DBusMessageIter id_struct;
+        DBusMessageIter data_array;
+        struct Sailfish_Secrets_Secret_FilterDatum *first = NULL;
+        const char *idName;
+        const char *idCName;
+        const unsigned char *data = NULL;
+        int n_bytes = 0;
+
+        dbus_message_iter_recurse(args, &sec_struct);
+
+        if (!dbus_message_iter_has_next(&sec_struct)) {
+            fprintf(stderr, "Sec struct doesn't contain any values!\n");
+            return 0;
+        }
+
+        /* Read the identifier data */
+        dbus_message_iter_recurse(&sec_struct, &id_struct);
+        if (dbus_message_iter_get_arg_type(&id_struct) != DBUS_TYPE_STRING) {
+            fprintf(stderr, "First ident struct arg not a string!\n");
+            return 0;
+        }
+        dbus_message_iter_get_basic(&id_struct, &idName);
+        dbus_message_iter_next(&id_struct);
+        if (dbus_message_iter_get_arg_type(&id_struct) != DBUS_TYPE_STRING) {
+            fprintf(stderr, "Second ident struct arg not a string!\n");
+            return 0;
+        }
+        dbus_message_iter_get_basic(&id_struct,
+                                    &idCName);
+
+        /* Read the secret blob data */
+        dbus_message_iter_next(&sec_struct);
+        dbus_message_iter_recurse(&sec_struct, &data_array);
+        dbus_message_iter_get_fixed_array(&data_array,
+                                          &data,
+                                          &n_bytes);
+        if (!data || !n_bytes) {
+            fprintf(stderr, "Unable to read data from secret struct!\n");
+            return 0;
+        }
+
+        /* Read the filter data */
+        if (dbus_message_iter_has_next(&sec_struct)) {
+            DBusMessageIter filter_dict;
+            DBusMessageIter dict_entry;
+            DBusMessageIter dict_val;
+            char *field;
+            char *value;
+            struct Sailfish_Secrets_Secret_FilterDatum *prev = NULL;
+            dbus_message_iter_next(&sec_struct);
+            dbus_message_iter_recurse(&sec_struct, &filter_dict);
+            while (dbus_message_iter_has_next(&filter_dict)) {
+                dbus_message_iter_next(&filter_dict);
+                dbus_message_iter_recurse(&filter_dict, &dict_entry);
+                if (dbus_message_iter_get_arg_type(&dict_entry)
+                        != DBUS_TYPE_STRING) {
+                    if (first) {
+                        Sailfish_Secrets_Secret_FilterDatum_delete(first);
+                    }
+                    fprintf(stderr, "Dict entry field not a string!\n");
+                    return 0;
+                }
+                dbus_message_iter_get_basic(&dict_entry, &field);
+                dbus_message_iter_next(&dict_entry);
+                dbus_message_iter_recurse(&dict_entry, &dict_val);
+                if (dbus_message_iter_get_arg_type(&dict_val)
+                        != DBUS_TYPE_STRING) {
+                    if (first) {
+                        Sailfish_Secrets_Secret_FilterDatum_delete(first);
+                    }
+                    fprintf(stderr, "Dict value not a string!\n");
+                    return 0;
+                }
+                dbus_message_iter_get_basic(&dict_val, &value);
+
+                struct Sailfish_Secrets_Secret_FilterDatum *f =
+                      Sailfish_Secrets_Secret_FilterDatum_new(field, value);
+                if (prev) {
+                    prev->next = f;
+                } else {
+                    first = f;
+                }
+                prev = f;
+            }
+        }
+
+        struct Sailfish_Secrets_Secret *retn = Sailfish_Secrets_Secret_new(
+                    data, n_bytes);
+        struct Sailfish_Secrets_Secret_Identifier *ident =
+                Sailfish_Secrets_Secret_Identifier_new(idName, idCName);
+        retn->identifier = ident;
+        retn->filterData = first;
+        *secret = retn;
+    }
+
+    return 1;
+}
+
+/******************************* new / delete *******************************/
+
+struct Sailfish_Secrets_Result*
+Sailfish_Secrets_Result_new(
+        enum Sailfish_Secrets_Result_Code code,
+        int errorCode,
+        const char *errorMessage)
+{
+    struct Sailfish_Secrets_Result *result =
+            (struct Sailfish_Secrets_Result *)malloc(
+                        sizeof(struct Sailfish_Secrets_Result));
+
+    result->code = code;
+    result->errorCode = errorCode;
+    result->errorMessage = errorMessage ? strndup(errorMessage, 512) : NULL;
+    return result;
+}
+
+void Sailfish_Secrets_Result_delete(
+        struct Sailfish_Secrets_Result *result)
+{
+    if (result) {
+        free(result->errorMessage);
+        free(result);
+    }
+}
+
+struct Sailfish_Secrets_Secret_Identifier*
+Sailfish_Secrets_Secret_Identifier_new(
+        const char *name,
+        const char *collectionName)
+{
+    struct Sailfish_Secrets_Secret_Identifier *ident =
+            (struct Sailfish_Secrets_Secret_Identifier*)malloc(
+                        sizeof(struct Sailfish_Secrets_Secret_Identifier));
+
+    ident->name = name
+            ? strndup(name, 512)
+            : NULL;
+    ident->collectionName = collectionName
+            ? strndup(collectionName, 512)
+            : NULL;
+
+    return ident;
+}
+
+void Sailfish_Secrets_Secret_Identifier_delete(
+        struct Sailfish_Secrets_Secret_Identifier *ident)
+{
+    if (ident) {
+        free(ident->name);
+        free(ident->collectionName);
+        free(ident);
+    }
+}
+
+struct Sailfish_Secrets_Secret_FilterDatum*
+Sailfish_Secrets_Secret_FilterDatum_new(
+        const char *field,
+        const char *value)
+{
+    struct Sailfish_Secrets_Secret_FilterDatum *filter =
+            (struct Sailfish_Secrets_Secret_FilterDatum *)malloc(
+                        sizeof(struct Sailfish_Secrets_Secret_FilterDatum));
+
+    filter->field = field ? strndup(field, 512) : NULL;
+    filter->value = value ? strndup(value, 512) : NULL;
+    filter->next = NULL;
+
+    return filter;
+}
+
+void Sailfish_Secrets_Secret_FilterDatum_delete(
+        struct Sailfish_Secrets_Secret_FilterDatum *filter)
+{
+    if (filter) {
+        struct Sailfish_Secrets_Secret_FilterDatum *curr = filter;
+        struct Sailfish_Secrets_Secret_FilterDatum *next = filter->next
+                ? filter->next : NULL;
+
+        while (curr) {
+            free(curr->field);
+            free(curr->value);
+            free(curr);
+            curr = next;
+            next = curr ? curr->next : NULL;
+        }
+    }
+}
+
+struct Sailfish_Secrets_Secret*
+Sailfish_Secrets_Secret_new(
+        const unsigned char *data,
+        size_t dataSize)
+{
+    struct Sailfish_Secrets_Secret *secret =
+            (struct Sailfish_Secrets_Secret *)malloc(
+                        sizeof(struct Sailfish_Secrets_Secret));
+
+    if (data) {
+        secret->dataSize = dataSize;
+        secret->data = (unsigned char *)malloc(dataSize);
+        memcpy(secret->data, data, dataSize);
+    } else {
+        secret->dataSize = 0;
+        secret->data = NULL;
+    }
+
+    secret->identifier = NULL;
+    secret->filterData = NULL;
+
+    return secret;
+}
+
+void Sailfish_Secrets_Secret_delete(
+        struct Sailfish_Secrets_Secret *secret)
+{
+    if (secret) {
+        Sailfish_Secrets_Secret_FilterDatum_delete(secret->filterData);
+        Sailfish_Secrets_Secret_Identifier_delete(secret->identifier);
+        free(secret->data);
+        free(secret);
+    }
+}
+
+void Sailfish_Secrets_Secret_setIdentifier(
+        struct Sailfish_Secrets_Secret *secret,
+        const char *name,
+        const char *collectionName)
+{
+    if (secret && name && collectionName) {
+        Sailfish_Secrets_Secret_Identifier_delete(secret->identifier);
+        secret->identifier = Sailfish_Secrets_Secret_Identifier_new(
+                    name, collectionName);
+    }
+}
+
+void Sailfish_Secrets_Secret_addFilter(
+        struct Sailfish_Secrets_Secret *secret,
+        const char *field,
+        const char *value)
+{
+    if (secret && field && value) {
+        if (!secret->filterData) {
+            secret->filterData = Sailfish_Secrets_Secret_FilterDatum_new(
+                        field, value);
+        } else {
+            struct Sailfish_Secrets_Secret_FilterDatum *filter =
+                    secret->filterData;
+            while (filter->next) {
+                filter = filter->next;
+            }
+            filter->next = Sailfish_Secrets_Secret_FilterDatum_new(
+                        field, value);
+        }
+    }
+}
+
+/******************************* SecretManager ******************************/
+
+int Sailfish_Secrets_SecretManager_createCollection(
+        const char *collectionName,
+        const char *storagePluginName,
+        const char *encryptionPluginName,
+        enum Sailfish_Secrets_SecretManager_DeviceLockUnlockSemantic unlockSemantic,
+        enum Sailfish_Secrets_SecretManager_AccessControlMode accessControlMode,
+        struct Sailfish_Secrets_Result **out_result)
+{
+    DBusMessageIter out_args;
+    DBusMessageIter in_args;
+    DBusMessageIter unlockSemantic_arg;
+    DBusMessageIter accessControlMode_arg;
+    int iUnlockSemantic = (int)(unlockSemantic);
+    int iAccessControlMode = (int)(accessControlMode);
+
+    if (collectionName == NULL
+            || storagePluginName == NULL
+            || encryptionPluginName == NULL
+            || out_result == NULL
+            || *out_result != NULL) {
+        fprintf(stderr, "Invalid parameters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__isConnectedToServer()) {
+        if (!Sailfish_Secrets__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                      /* service name */
+                "/Sailfish/Secrets",       /* object */
+                "org.sailfishos.secrets",  /* interface */
+                "createCollection");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &collectionName);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &storagePluginName);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &encryptionPluginName);
+    Sailfish_Secrets__appendEnumArg(
+                &in_args,
+                &unlockSemantic_arg,
+                &iUnlockSemantic);
+    Sailfish_Secrets__appendEnumArg(
+                &in_args,
+                &accessControlMode_arg,
+                &iAccessControlMode);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return argument */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__readResultStruct(&out_args, out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Secrets_SecretManager_deleteCollection(
+        const char *collectionName,
+        enum Sailfish_Secrets_SecretManager_UserInteractionMode uiMode,
+        struct Sailfish_Secrets_Result **out_result)
+{
+    DBusMessageIter out_args;
+    DBusMessageIter in_args;
+    DBusMessageIter uiMode_arg;
+    int iUiMode = (int)(uiMode);
+
+    if (collectionName == NULL
+            || out_result == NULL
+            || *out_result != NULL) {
+        fprintf(stderr, "Invalid parameters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__isConnectedToServer()) {
+        if (!Sailfish_Secrets__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                      /* service name */
+                "/Sailfish/Secrets",       /* object */
+                "org.sailfishos.secrets",  /* interface */
+                "deleteCollection");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &collectionName);
+    Sailfish_Secrets__appendEnumArg(
+                &in_args,
+                &uiMode_arg,
+                &iUiMode);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return argument */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__readResultStruct(&out_args, out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Secrets_SecretManager_setSecret(
+        struct Sailfish_Secrets_Secret *secret,
+        enum Sailfish_Secrets_SecretManager_UserInteractionMode uiMode,
+        const char *uiServiceAddress,
+        struct Sailfish_Secrets_Result **out_result)
+{
+    DBusMessageIter out_args;
+    DBusMessageIter in_args;
+    DBusMessageIter uiMode_arg;
+    int iUiMode = (int)(uiMode);
+
+    if (secret == NULL
+            || uiServiceAddress == NULL
+            || out_result == NULL
+            || *out_result != NULL) {
+        fprintf(stderr, "Invalid parameters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__isConnectedToServer()) {
+        if (!Sailfish_Secrets__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                      /* service name */
+                "/Sailfish/Secrets",       /* object */
+                "org.sailfishos.secrets",  /* interface */
+                "setSecret");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Secrets__appendSecretArg(
+                &in_args,
+                secret);
+    Sailfish_Secrets__appendEnumArg(
+                &in_args,
+                &uiMode_arg,
+                &iUiMode);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &uiServiceAddress);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return argument */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__readResultStruct(&out_args, out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Secrets_SecretManager_getSecret(
+        struct Sailfish_Secrets_Secret_Identifier *ident,
+        enum Sailfish_Secrets_SecretManager_UserInteractionMode uiMode,
+        const char *uiServiceAddress,
+        struct Sailfish_Secrets_Result **out_result,
+        struct Sailfish_Secrets_Secret **out_secret)
+{
+    DBusMessageIter out_args;
+    DBusMessageIter in_args;
+    DBusMessageIter uiMode_arg;
+    int iUiMode = (int)(uiMode);
+
+    if (ident == NULL
+            || uiServiceAddress == NULL
+            || out_result == NULL
+            || out_secret == NULL
+            || *out_result != NULL
+            || *out_secret != NULL) {
+        fprintf(stderr, "Invalid parameters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__isConnectedToServer()) {
+        if (!Sailfish_Secrets__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                      /* service name */
+                "/Sailfish/Secrets",       /* object */
+                "org.sailfishos.secrets",  /* interface */
+                "getSecret");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Secrets__appendSecretIdentifierArg(
+                &in_args,
+                ident);
+    Sailfish_Secrets__appendEnumArg(
+                &in_args,
+                &uiMode_arg,
+                &iUiMode);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &uiServiceAddress);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return arguments */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__readResultStruct(&out_args, out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_iter_next(&out_args);
+
+    if (!Sailfish_Secrets__readSecretStruct(&out_args, out_secret)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}
+
+int Sailfish_Secrets_SecretManager_deleteSecret(
+        struct Sailfish_Secrets_Secret_Identifier *ident,
+        enum Sailfish_Secrets_SecretManager_UserInteractionMode uiMode,
+        const char *uiServiceAddress,
+        struct Sailfish_Secrets_Result **out_result)
+{
+    DBusMessageIter out_args;
+    DBusMessageIter in_args;
+    DBusMessageIter uiMode_arg;
+    int iUiMode = (int)(uiMode);
+
+    if (ident == NULL
+            || uiServiceAddress == NULL
+            || out_result == NULL
+            || *out_result != NULL) {
+        fprintf(stderr, "Invalid parameters!\n");
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__isConnectedToServer()) {
+        if (!Sailfish_Secrets__connectToServer()) {
+            return 0;
+        }
+    }
+
+    /* create a new method call and check for errors */
+    daemon_connection.msg = dbus_message_new_method_call(
+                NULL,                      /* service name */
+                "/Sailfish/Secrets",       /* object */
+                "org.sailfishos.secrets",  /* interface */
+                "deleteSecret");
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Message Null\n");
+        return 0;
+    }
+
+    /* add parameters to the method call */
+    dbus_message_iter_init_append(daemon_connection.msg, &in_args);
+    Sailfish_Secrets__appendSecretIdentifierArg(
+                &in_args,
+                ident);
+    Sailfish_Secrets__appendEnumArg(
+                &in_args,
+                &uiMode_arg,
+                &iUiMode);
+    dbus_message_iter_append_basic(
+                &in_args,
+                DBUS_TYPE_STRING,
+                &uiServiceAddress);
+
+    /* send message and get a handle for a reply */
+    dbus_connection_send_with_reply(
+                daemon_connection.p2pBus,
+                daemon_connection.msg,
+                &daemon_connection.pending,
+                -1);
+
+    if (daemon_connection.pending == NULL) {
+        fprintf(stderr, "Pending Call Null\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_connection_flush(daemon_connection.p2pBus);
+    dbus_message_unref(daemon_connection.msg);
+    dbus_pending_call_block(daemon_connection.pending);
+    daemon_connection.msg = dbus_pending_call_steal_reply(
+                daemon_connection.pending);
+    dbus_pending_call_unref(daemon_connection.pending);
+    daemon_connection.pending = NULL;
+
+    if (daemon_connection.msg == NULL) {
+        fprintf(stderr, "Reply Null\n");
+        return 0;
+    }
+
+    /* read the return argument */
+    if (!dbus_message_iter_init(daemon_connection.msg,
+                                &out_args)) {
+        fprintf(stderr, "Message has no arguments!\n");
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    if (!Sailfish_Secrets__readResultStruct(&out_args, out_result)) {
+        dbus_message_unref(daemon_connection.msg);
+        daemon_connection.msg = NULL;
+        return 0;
+    }
+
+    dbus_message_unref(daemon_connection.msg);
+    daemon_connection.msg = NULL;
+
+    return 1;
+}

--- a/lib/Secrets/secrets_c.h
+++ b/lib/Secrets/secrets_c.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2017 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#ifndef LIBSAILFISHSECRETS_SECRETS_C_H
+#define LIBSAILFISHSECRETS_SECRETS_C_H
+
+/* This file provides a C-compatible wrapper for Secrets */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/****************************** result ******************************/
+
+enum Sailfish_Secrets_Result_Code {
+    Sailfish_Secrets_Result_Succeeded = 0,
+    Sailfish_Secrets_Result_Pending = 1,
+    Sailfish_Secrets_Result_Failed = 2
+};
+
+struct Sailfish_Secrets_Result {
+    enum Sailfish_Secrets_Result_Code code;
+    int errorCode;
+    char *errorMessage;
+};
+
+struct Sailfish_Secrets_Result*
+Sailfish_Secrets_Result_new(
+        enum Sailfish_Secrets_Result_Code code,
+        int errorCode,
+        const char *errorMessage);
+
+void Sailfish_Secrets_Result_delete(
+        struct Sailfish_Secrets_Result *result);
+
+/****************************** secret ******************************/
+
+struct Sailfish_Secrets_Secret_Identifier {
+    char *name;
+    char *collectionName;
+};
+
+struct Sailfish_Secrets_Secret_FilterDatum {
+    char *field;
+    char *value;
+    struct Sailfish_Secrets_Secret_FilterDatum *next;
+};
+
+struct Sailfish_Secrets_Secret {
+    struct Sailfish_Secrets_Secret_Identifier *identifier;
+    struct Sailfish_Secrets_Secret_FilterDatum *filterData;
+    unsigned char *data;
+    size_t dataSize;
+};
+
+struct Sailfish_Secrets_Secret_Identifier*
+Sailfish_Secrets_Secret_Identifier_new(
+        const char *name,
+        const char *collectionName);
+
+void Sailfish_Secrets_Secret_Identifier_delete(
+        struct Sailfish_Secrets_Secret_Identifier *ident);
+
+struct Sailfish_Secrets_Secret_FilterDatum*
+Sailfish_Secrets_Secret_FilterDatum_new(
+        const char *field,
+        const char *value);
+
+void Sailfish_Secrets_Secret_FilterDatum_delete(
+        struct Sailfish_Secrets_Secret_FilterDatum *filter);
+
+struct Sailfish_Secrets_Secret*
+Sailfish_Secrets_Secret_new(
+        const unsigned char *data,
+        size_t dataSize);
+
+void Sailfish_Secrets_Secret_delete(
+        struct Sailfish_Secrets_Secret *secret);
+
+void Sailfish_Secrets_Secret_setIdentifier(
+        struct Sailfish_Secrets_Secret *secret,
+        const char *name,
+        const char *collectionName);
+
+void Sailfish_Secrets_Secret_addFilter(
+        struct Sailfish_Secrets_Secret *secret,
+        const char *field,
+        const char *value);
+
+/****************************** secret manager **********************/
+
+enum Sailfish_Secrets_SecretManager_DeviceLockUnlockSemantic {
+    Sailfish_Secrets_SecretManager_DeviceLockKeepUnlocked = 0,
+    Sailfish_Secrets_SecretManager_DeviceLockRelock,
+};
+
+enum Sailfish_Secrets_SecretManager_AccessControlMode {
+    Sailfish_Secrets_SecretManager_OwnerOnlyMode = 0,
+    Sailfish_Secrets_SecretManager_SystemAccessControlMode
+};
+
+enum Sailfish_Secrets_SecretManager_UserInteractionMode {
+    Sailfish_Secrets_SecretManager_PreventInteraction = 0,
+    Sailfish_Secrets_SecretManager_SystemInteraction,
+    Sailflish_Secrets_SecretManager_ApplicationInteraction
+};
+
+int Sailfish_Secrets_SecretManager_createCollection(
+        const char *collectionName,
+        const char *storagePluginName,
+        const char *encryptionPluginName,
+        enum Sailfish_Secrets_SecretManager_DeviceLockUnlockSemantic unlockSemantic,
+        enum Sailfish_Secrets_SecretManager_AccessControlMode accessControlMode,
+        struct Sailfish_Secrets_Result **out_result);
+
+int Sailfish_Secrets_SecretManager_deleteCollection(
+        const char *collectionName,
+        enum Sailfish_Secrets_SecretManager_UserInteractionMode interactionMode,
+        struct Sailfish_Secrets_Result **out_result);
+
+int Sailfish_Secrets_SecretManager_setSecret(
+        struct Sailfish_Secrets_Secret *secret,
+        enum Sailfish_Secrets_SecretManager_UserInteractionMode uiMode,
+        const char *interactionServiceAddress,
+        struct Sailfish_Secrets_Result **out_result);
+
+int Sailfish_Secrets_SecretManager_getSecret(
+        struct Sailfish_Secrets_Secret_Identifier *ident,
+        enum Sailfish_Secrets_SecretManager_UserInteractionMode uiMode,
+        const char *interactionServiceAddress,
+        struct Sailfish_Secrets_Result **out_result,
+        struct Sailfish_Secrets_Secret **out_secret);
+
+int Sailfish_Secrets_SecretManager_deleteSecret(
+        struct Sailfish_Secrets_Secret_Identifier *ident,
+        enum Sailfish_Secrets_SecretManager_UserInteractionMode uiMode,
+        const char *interactionServiceAddress,
+        struct Sailfish_Secrets_Result **out_result);
+
+void Sailfish_Secrets_disconnectFromServer();
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* LIBSAILFISHSECRETS_SECRETS_C_H */

--- a/lib/Secrets/serialisation.cpp
+++ b/lib/Secrets/serialisation.cpp
@@ -117,9 +117,16 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, Secret::Identifie
 
 QDBusArgument &operator<<(QDBusArgument &argument, const Secret &secret)
 {
+    QVariantMap asv;
+    const QMap<QString,QString> fd = secret.filterData();
+    for (QMap<QString,QString>::const_iterator it = fd.constBegin(); it != fd.constEnd(); it++) {
+        asv.insert(it.key(), it.value());
+    }
+
     argument.beginStructure();
-    argument << secret.identifier() << secret.data() << secret.filterData();
+    argument << secret.identifier() << secret.data() << asv;
     argument.endStructure();
+
     return argument;
 }
 
@@ -127,15 +134,21 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, Secret &secret)
 {
     Secret::Identifier identifier;
     QByteArray data;
-    QMap<QString,QString> metadata;
+    QVariantMap asv;
 
     argument.beginStructure();
-    argument >> identifier >> data >> metadata;
+    argument >> identifier >> data >> asv;
     argument.endStructure();
+
+    QMap<QString, QString> filterData;
+    for (QVariantMap::const_iterator it = asv.constBegin(); it != asv.constEnd(); it++) {
+        filterData.insert(it.key(), it.value().toString());
+    }
 
     secret.setIdentifier(identifier);
     secret.setData(data);
-    secret.setFilterData(Secret::FilterData(metadata));
+    secret.setFilterData(filterData);
+
     return argument;
 }
 

--- a/lib/libsailfishcrypto.pri
+++ b/lib/libsailfishcrypto.pri
@@ -1,5 +1,9 @@
 CONFIG += qt
 QT += dbus
+
+CONFIG += link_pkgconfig
+PKGCONFIG += dbus-1
+
 LIBS += -L$$shadowed($$PWD/Crypto) -lsailfishcrypto
 
 INCLUDEPATH += $$PWD

--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -9,6 +9,7 @@ Source0:    %{name}-%{version}.tar.bz2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Sql)
 BuildRequires:  pkgconfig(Qt5DBus)
+BuildRequires:  pkgconfig(dbus-1)
 
 %description
 %{summary}.
@@ -174,6 +175,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 /opt/tests/Sailfish/Secrets/tst_secrets
 /opt/tests/Sailfish/Secrets/tst_secrets.qml
+/opt/tests/Sailfish/Secrets/tst_secrets_capi
 %{_libdir}/sailfish/secrets/libsailfishsecrets-testinappauth.so
 %{_libdir}/sailfish/secrets/libsailfishsecrets-testopenssl.so
 %{_libdir}/sailfish/secrets/libsailfishsecrets-testsqlcipher.so

--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -184,7 +184,9 @@ rm -rf %{buildroot}
 %files -n libsailfishcrypto-tests
 %defattr(-,root,root,-)
 /opt/tests/Sailfish/Crypto/tst_crypto
+/opt/tests/Sailfish/Crypto/tst_crypto_capi
 /opt/tests/Sailfish/Crypto/tst_cryptosecrets
+/opt/tests/Sailfish/Crypto/tst_cryptosecrets_capi
 %{_libdir}/sailfish/crypto/libsailfishcrypto-testopenssl.so
 
 %files -n qt5-plugin-sqldriver-sqlcipher

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -2,5 +2,6 @@ TEMPLATE = subdirs
 SUBDIRS = \
     $$PWD/plugins \
     $$PWD/tst_secrets \
+    $$PWD/tst_secrets_capi \
     $$PWD/tst_crypto \
     $$PWD/tst_cryptosecrets

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -4,4 +4,6 @@ SUBDIRS = \
     $$PWD/tst_secrets \
     $$PWD/tst_secrets_capi \
     $$PWD/tst_crypto \
-    $$PWD/tst_cryptosecrets
+    $$PWD/tst_crypto_capi \
+    $$PWD/tst_cryptosecrets \
+    $$PWD/tst_cryptosecrets_capi

--- a/tests/tst_crypto_capi/tst_crypto_capi.c
+++ b/tests/tst_crypto_capi/tst_crypto_capi.c
@@ -1,0 +1,132 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <Crypto/crypto_c.h>
+
+int main(int argc, char *argv[])
+{
+    struct Sailfish_Crypto_Result *result = NULL;
+    struct Sailfish_Crypto_Key *get_key = NULL;
+
+    unsigned char *ciphertext = NULL;
+    size_t ciphertext_size = 0;
+    unsigned char *decrypted = NULL;
+    size_t decrypted_size = 0;
+
+    unsigned char plaintext[32] = {
+        'a', 'b', 'c', 'd',
+        'e', 'f', 'g', 'h',
+        'i', 'j', 'k', 'l',
+        'm', 'n', 'o', 'p',
+        'q', 'r', 's', 't',
+        'u', 'v', 'w', 'x',
+        'y', 'z', '0', '1',
+        '2', '3', '4', '\0'
+    };
+
+    struct Sailfish_Crypto_Key *set_key = Sailfish_Crypto_Key_new(
+                "tst_capi_key",
+                "tst_capi_collection");
+    Sailfish_Crypto_Key_addFilter(set_key, "type", "blob");
+    Sailfish_Crypto_Key_addFilter(set_key, "test", "true");
+    set_key->origin = Sailfish_Crypto_Key_OriginDevice;
+    set_key->algorithm = Sailfish_Crypto_Key_Aes256;
+    set_key->blockModes = Sailfish_Crypto_Key_BlockModeCBC;
+    set_key->encryptionPaddings = Sailfish_Crypto_Key_EncryptionPaddingNone;
+    set_key->signaturePaddings = Sailfish_Crypto_Key_SignaturePaddingNone;
+    set_key->digests = Sailfish_Crypto_Key_DigestSha256;
+    set_key->operations = Sailfish_Crypto_Key_Encrypt | Sailfish_Crypto_Key_Decrypt;
+
+    (void)argc;
+    (void)argv;
+
+    if (!Sailfish_Crypto_CryptoManager_generateKey(
+                set_key,
+                "org.sailfishos.crypto.plugin.crypto.openssl.test",
+                &result,
+                &get_key)) {
+        fprintf(stderr, "Call to generateKey failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Crypto_Result_Succeeded) {
+        fprintf(stderr, "Call to generateKey failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+    Sailfish_Crypto_Result_delete(result);
+    result = NULL;
+
+    if (!Sailfish_Crypto_CryptoManager_encrypt(
+                plaintext,
+                32,
+                get_key,
+                Sailfish_Crypto_Key_BlockModeCBC,
+                Sailfish_Crypto_Key_EncryptionPaddingNone,
+                Sailfish_Crypto_Key_DigestSha256,
+                "org.sailfishos.crypto.plugin.crypto.openssl.test",
+                &result,
+                &ciphertext,
+                &ciphertext_size)) {
+        fprintf(stderr, "Call to encrypt failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Crypto_Result_Succeeded) {
+        fprintf(stderr, "Call to encrypt failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+    Sailfish_Crypto_Result_delete(result);
+    result = NULL;
+
+    if (!Sailfish_Crypto_CryptoManager_decrypt(
+                ciphertext, ciphertext_size,
+                get_key,
+                Sailfish_Crypto_Key_BlockModeCBC,
+                Sailfish_Crypto_Key_EncryptionPaddingNone,
+                Sailfish_Crypto_Key_DigestSha256,
+                "org.sailfishos.crypto.plugin.crypto.openssl.test",
+                &result,
+                &decrypted,
+                &decrypted_size)) {
+        fprintf(stderr, "Call to decrypt failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Crypto_Result_Succeeded) {
+        fprintf(stderr, "Call to decrypt failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+    Sailfish_Crypto_Result_delete(result);
+    result = NULL;
+
+    if (decrypted_size != 32 || memcmp(decrypted, plaintext, 32) != 0) {
+        fprintf(stderr, "Decrypted text not equal to original plaintext!"
+                        " %d\n", decrypted_size);
+        return -1;
+    }
+
+    Sailfish_Crypto_Key_delete(set_key);
+    Sailfish_Crypto_Key_delete(get_key);
+    free(ciphertext);
+    free(decrypted);
+
+    Sailfish_Crypto_disconnectFromServer();
+
+    fprintf(stdout, "PASS!\n");
+
+    return 0;
+}

--- a/tests/tst_crypto_capi/tst_crypto_capi.pro
+++ b/tests/tst_crypto_capi/tst_crypto_capi.pro
@@ -1,0 +1,7 @@
+TEMPLATE = app
+TARGET = tst_crypto_capi
+target.path = /opt/tests/Sailfish/Crypto/
+include($$PWD/../../lib/libsailfishcrypto.pri)
+CONFIG -= qt
+SOURCES += tst_crypto_capi.c
+INSTALLS += target

--- a/tests/tst_cryptosecrets_capi/tst_cryptosecrets_capi.c
+++ b/tests/tst_cryptosecrets_capi/tst_cryptosecrets_capi.c
@@ -1,0 +1,210 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <Crypto/crypto_c.h>
+#include <Secrets/secrets_c.h>
+
+int main(int argc, char *argv[])
+{
+    struct Sailfish_Secrets_Result *secrets_result = NULL;
+    struct Sailfish_Crypto_Result *result = NULL;
+    struct Sailfish_Crypto_Key *get_key = NULL;
+    struct Sailfish_Crypto_Key_Identifier *ident = NULL;
+
+    unsigned char *ciphertext = NULL;
+    size_t ciphertext_size = 0;
+    unsigned char *decrypted = NULL;
+    size_t decrypted_size = 0;
+
+    unsigned char plaintext[32] = {
+        'a', 'b', 'c', 'd',
+        'e', 'f', 'g', 'h',
+        'i', 'j', 'k', 'l',
+        'm', 'n', 'o', 'p',
+        'q', 'r', 's', 't',
+        'u', 'v', 'w', 'x',
+        'y', 'z', '0', '1',
+        '2', '3', '4', '\0'
+    };
+
+    struct Sailfish_Crypto_Key *set_key = Sailfish_Crypto_Key_new(
+                "tstcapikey",
+                "tstcapicollection");
+    Sailfish_Crypto_Key_addFilter(set_key, "type", "blob");
+    Sailfish_Crypto_Key_addFilter(set_key, "test", "true");
+    set_key->origin = Sailfish_Crypto_Key_OriginDevice;
+    set_key->algorithm = Sailfish_Crypto_Key_Aes256;
+    set_key->blockModes = Sailfish_Crypto_Key_BlockModeCBC;
+    set_key->encryptionPaddings = Sailfish_Crypto_Key_EncryptionPaddingNone;
+    set_key->signaturePaddings = Sailfish_Crypto_Key_SignaturePaddingNone;
+    set_key->digests = Sailfish_Crypto_Key_DigestSha256;
+    set_key->operations = Sailfish_Crypto_Key_Encrypt | Sailfish_Crypto_Key_Decrypt;
+
+    (void)argc;
+    (void)argv;
+
+    if (!Sailfish_Secrets_SecretManager_createCollection(
+                "tstcapicollection",
+                "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test",
+                "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test",
+                Sailfish_Secrets_SecretManager_DeviceLockKeepUnlocked,
+                Sailfish_Secrets_SecretManager_OwnerOnlyMode,
+                &secrets_result)) {
+        fprintf(stderr, "Call to createCollection failed: %d: %s\n",
+                secrets_result ? secrets_result->errorCode : 0,
+                secrets_result && secrets_result->errorMessage
+                    ? secrets_result->errorMessage
+                    : "");
+        return -1;
+    } else if (secrets_result && secrets_result->code !=
+               Sailfish_Secrets_Result_Succeeded) {
+        fprintf(stderr, "Call to createCollection failed: %d: %s\n",
+                secrets_result ? secrets_result->errorCode : 0,
+                secrets_result && secrets_result->errorMessage
+                    ? secrets_result->errorMessage
+                    : "");
+        return -1;
+    }
+    Sailfish_Secrets_Result_delete(secrets_result);
+    secrets_result = NULL;
+
+    if (!Sailfish_Crypto_CryptoManager_generateStoredKey(
+                set_key,
+                "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test",
+                "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test",
+                &result,
+                &get_key)) {
+        fprintf(stderr, "Call to generateKey failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Crypto_Result_Succeeded) {
+        fprintf(stderr, "Call to generateKey failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+    Sailfish_Crypto_Result_delete(result);
+    result = NULL;
+
+    if (!Sailfish_Crypto_CryptoManager_encrypt(
+                plaintext,
+                32,
+                get_key,
+                Sailfish_Crypto_Key_BlockModeCBC,
+                Sailfish_Crypto_Key_EncryptionPaddingNone,
+                Sailfish_Crypto_Key_DigestSha256,
+                "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test",
+                &result,
+                &ciphertext,
+                &ciphertext_size)) {
+        fprintf(stderr, "Call to encrypt failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Crypto_Result_Succeeded) {
+        fprintf(stderr, "Call to encrypt failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+    Sailfish_Crypto_Result_delete(result);
+    result = NULL;
+
+    if (!Sailfish_Crypto_CryptoManager_decrypt(
+                ciphertext, ciphertext_size,
+                get_key,
+                Sailfish_Crypto_Key_BlockModeCBC,
+                Sailfish_Crypto_Key_EncryptionPaddingNone,
+                Sailfish_Crypto_Key_DigestSha256,
+                "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test",
+                &result,
+                &decrypted,
+                &decrypted_size)) {
+        fprintf(stderr, "Call to decrypt failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Crypto_Result_Succeeded) {
+        fprintf(stderr, "Call to decrypt failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+    Sailfish_Crypto_Result_delete(result);
+    result = NULL;
+
+    if (decrypted_size != 32 || memcmp(decrypted, plaintext, 32) != 0) {
+        fprintf(stderr, "Decrypted text not equal to original plaintext!"
+                        " %d\n", decrypted_size);
+        return -1;
+    }
+
+    Sailfish_Crypto_Key_delete(set_key);
+    set_key = NULL;
+    Sailfish_Crypto_Key_delete(get_key);
+    get_key = NULL;
+    free(ciphertext);
+    ciphertext = NULL;
+    free(decrypted);
+    decrypted = NULL;
+
+    ident = Sailfish_Crypto_Key_Identifier_new(
+                "tstcapikey",
+                "tstcapicollection");
+    if (Sailfish_Crypto_CryptoManager_deleteStoredKey(
+                ident,
+                &result) < 0) {
+        fprintf(stderr, "Call to deleteStoredKey failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Crypto_Result_Succeeded) {
+        fprintf(stderr, "Call to deleteStoredKey failed: %d: %d: %s\n",
+                result ? result->errorCode : 0,
+                result ? result->storageErrorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+    Sailfish_Crypto_Result_delete(result);
+    result = NULL;
+    Sailfish_Crypto_Key_Identifier_delete(ident);
+    ident = NULL;
+
+    if (!Sailfish_Secrets_SecretManager_deleteCollection(
+                "tstcapicollection",
+                Sailfish_Secrets_SecretManager_PreventInteraction,
+                &secrets_result)) {
+        fprintf(stderr, "Call to deleteCollection failed: %d: %s\n",
+                secrets_result ? secrets_result->errorCode : 0,
+                secrets_result && secrets_result->errorMessage
+                    ? secrets_result->errorMessage
+                    : "");
+        return -1;
+    } else if (secrets_result && secrets_result->code !=
+               Sailfish_Secrets_Result_Succeeded) {
+        fprintf(stderr, "Call to deleteCollection failed: %d: %s\n",
+                secrets_result ? secrets_result->errorCode : 0,
+                secrets_result && secrets_result->errorMessage
+                    ? secrets_result->errorMessage
+                    : "");
+        return -1;
+    }
+    Sailfish_Secrets_Result_delete(secrets_result);
+    secrets_result = NULL;
+
+    Sailfish_Crypto_disconnectFromServer();
+
+    fprintf(stdout, "PASS!\n");
+
+    return 0;
+}

--- a/tests/tst_cryptosecrets_capi/tst_cryptosecrets_capi.pro
+++ b/tests/tst_cryptosecrets_capi/tst_cryptosecrets_capi.pro
@@ -1,0 +1,8 @@
+TEMPLATE = app
+TARGET = tst_cryptosecrets_capi
+target.path = /opt/tests/Sailfish/Crypto/
+include($$PWD/../../lib/libsailfishcrypto.pri)
+include($$PWD/../../lib/libsailfishsecrets.pri)
+CONFIG -= qt
+SOURCES += tst_cryptosecrets_capi.c
+INSTALLS += target

--- a/tests/tst_secrets_capi/tst_secrets_capi.c
+++ b/tests/tst_secrets_capi/tst_secrets_capi.c
@@ -1,0 +1,116 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <Secrets/secrets_c.h>
+
+int main(int argc, char *argv[])
+{
+    struct Sailfish_Secrets_Result *result = NULL;
+    struct Sailfish_Secrets_Secret *get_secret = NULL;
+
+    unsigned char set_secret_data[16] = {
+        's', 'e', 'c', 'r', 'e', 't',
+        ' ', 'd', 'a', 't', 'a', '\0',
+        '\0', '\0', '\0', '\0'
+    };
+    struct Sailfish_Secrets_Secret *set_secret = Sailfish_Secrets_Secret_new(
+                set_secret_data, 16);
+    Sailfish_Secrets_Secret_setIdentifier(set_secret,
+                                          "tst_capi_secret",
+                                          "tst_capi_collection");
+    Sailfish_Secrets_Secret_addFilter(set_secret, "type", "blob");
+    Sailfish_Secrets_Secret_addFilter(set_secret, "test", "true");
+
+    (void)argc;
+    (void)argv;
+
+    if (!Sailfish_Secrets_SecretManager_createCollection(
+                "tst_capi_collection",
+                "org.sailfishos.secrets.plugin.storage.sqlite.test",
+                "org.sailfishos.secrets.plugin.encryption.openssl.test",
+                Sailfish_Secrets_SecretManager_DeviceLockKeepUnlocked,
+                Sailfish_Secrets_SecretManager_OwnerOnlyMode,
+                &result)) {
+        fprintf(stderr, "Call to createCollection failed: %d: %s\n",
+                result ? result->errorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Secrets_Result_Succeeded) {
+        fprintf(stderr, "Call to createCollection failed: %d: %s\n",
+                result ? result->errorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+    Sailfish_Secrets_Result_delete(result);
+    result = NULL;
+
+    if (!Sailfish_Secrets_SecretManager_setSecret(
+                set_secret,
+                Sailfish_Secrets_SecretManager_PreventInteraction,
+                "",
+                &result)) {
+        fprintf(stderr, "Call to setSecret failed: %d: %s\n",
+                result ? result->errorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Secrets_Result_Succeeded) {
+        fprintf(stderr, "Call to setSecret failed: %d: %s\n",
+                result ? result->errorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+    Sailfish_Secrets_Result_delete(result);
+    result = NULL;
+
+    if (!Sailfish_Secrets_SecretManager_getSecret(
+                set_secret->identifier,
+                Sailfish_Secrets_SecretManager_PreventInteraction,
+                "",
+                &result,
+                &get_secret)) {
+        fprintf(stderr, "Call to getSecret failed: %d: %s\n",
+                result ? result->errorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Secrets_Result_Succeeded) {
+        fprintf(stderr, "Call to getSecret failed: %d: %s\n",
+                result ? result->errorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (get_secret->dataSize != set_secret->dataSize) {
+        fprintf(stderr, "Retrieved secret data size different! %d != %d\n",
+                get_secret->dataSize, set_secret->dataSize);
+        return -1;
+    } else if (memcmp(get_secret->data,
+                      set_secret->data,
+                      set_secret->dataSize) != 0) {
+        fprintf(stderr, "Retrieved secret data different!\n");
+        return -1;
+    }
+    Sailfish_Secrets_Result_delete(result);
+    result = NULL;
+
+    if (!Sailfish_Secrets_SecretManager_deleteCollection(
+                "tst_capi_collection",
+                Sailfish_Secrets_SecretManager_PreventInteraction,
+                &result)) {
+        fprintf(stderr, "Call to deleteCollection failed: %d: %s\n",
+                result ? result->errorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    } else if (result && result->code != Sailfish_Secrets_Result_Succeeded) {
+        fprintf(stderr, "Call to deleteCollection failed: %d: %s\n",
+                result ? result->errorCode : 0,
+                result && result->errorMessage ? result->errorMessage : "");
+        return -1;
+    }
+
+    Sailfish_Secrets_Result_delete(result);
+    Sailfish_Secrets_Secret_delete(set_secret);
+    Sailfish_Secrets_Secret_delete(get_secret);
+
+    fprintf(stdout, "PASS!\n");
+
+    return 0;
+}

--- a/tests/tst_secrets_capi/tst_secrets_capi.pro
+++ b/tests/tst_secrets_capi/tst_secrets_capi.pro
@@ -1,0 +1,7 @@
+TEMPLATE = app
+TARGET = tst_secrets_capi
+target.path = /opt/tests/Sailfish/Secrets/
+include($$PWD/../../lib/libsailfishsecrets.pri)
+CONFIG -= qt
+SOURCES += tst_secrets_capi.c
+INSTALLS += target


### PR DESCRIPTION
This commit adds a C API which can be used by non-C++ applications to
perform some simple operations with the Sailfish Secrets API.