### PR TITLE
Fix typo in sqlcipher plugin

### DIFF
--- a/plugins/sqlcipherplugin/sqlcipherplugin.cpp
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.cpp
@@ -35,7 +35,7 @@ QString Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::databaseDirPath(
     const QString systemDataDirPath(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QLatin1String("/system/"));
     const QString privilegedDataDirPath(systemDataDirPath + QLatin1String("privileged/"));
     const QString subdir = isTestPlugin
-                         ? QString(QLatin1String("Secrets/%1/")).arg(databaseSubdir)
-                         : QString(QLatin1String("Secrets/%1-test/")).arg(databaseSubdir);
+                         ? QString(QLatin1String("Secrets/%1-test/")).arg(databaseSubdir)
+                         : QString(QLatin1String("Secrets/%1/")).arg(databaseSubdir);
     return privilegedDataDirPath + subdir;
 }

--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -52,6 +52,7 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(dbus-1)
 BuildRequires:  pkgconfig(libcrypto)
 BuildRequires:  qt5-plugin-sqldriver-sqlite
+Requires:   qt5-plugin-sqldriver-sqlcipher
 Requires:   sailfishsecretsdaemon = %{version}-%{release}
 
 %description -n sailfishsecretsdaemonplugins


### PR DESCRIPTION
Previously, the sqlcipher plugin used the incorrect path to store
its database files in depending on whether it was constructed in
test mode or not.  This commit fixes that.

It also fixes packaging to ensure the Qt5Sql SQLCipher driver plugin
is installed.