### PR TITLE
[sailfish-secrets] Add framework overview documentation. Contributes to JB#36797

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -20,8 +20,8 @@ Q_LOGGING_CATEGORY(lcSailfishCryptoDaemonDBus, "org.sailfishos.crypto.daemon.dbu
 
 Q_DECL_EXPORT int main(int argc, char *argv[])
 {
-    const QString secretsPluginDir = QLatin1String("/usr/lib/sailfish/secrets/");
-    const QString cryptoPluginDir = QLatin1String("/usr/lib/sailfish/crypto/");
+    const QString secretsPluginDir = QLatin1String("/usr/lib/Sailfish/Secrets/");
+    const QString cryptoPluginDir = QLatin1String("/usr/lib/Sailfish/Crypto/");
     QCoreApplication::addLibraryPath(secretsPluginDir);
     QCoreApplication::addLibraryPath(cryptoPluginDir);
     QCoreApplication app(argc, argv);

--- a/doc/index.qdoc
+++ b/doc/index.qdoc
@@ -1,0 +1,173 @@
+/****************************************************************************************
+**
+** Copyright (C) 2018 Jolla Ltd.
+** Contact: Chris Adams <chris.adams@jollamobile.com>
+** All rights reserved.
+**
+****************************************************************************************/
+
+/*!
+\contentspage {Sailfish OS Secrets and Crypto Framework Contents}
+\page index.html
+
+\title Secret Data and Cryptographic Operations in Sailfish OS
+
+Applications running on highly-connected devices require the capability to
+perform advanced cryptographic operations, in order to protect the user's data,
+authenticate with remote services, verify the authenticity of other connected
+devices, and communicate securely.  The keys and certificates which are used
+to perform such operations also need to be stored securely on the device, in
+order to prevent malicious third-party applications from accessing those keys.
+
+The Sailfish OS Secrets and Crypto Framework provides applications with
+full-featured secret data storage and cryptography services.  Applications
+using the framework delegate cryptographic operations to a system service,
+and the framework has been designed to ensure that when used appropriately,
+secret key data need never enter the process address space of the application.
+Furthermore, if the cryptographic service provider plugin to the framework is
+backed by secure hardware, Trusted Execution Environment application, or
+Trusted Platform Module, then secret key data need never enter the normal
+"rich" execution environment.
+
+The framework also provides secure storage of secret data (including but not
+limited to keys, certificates, passwords, and other credentials) either in
+value-encrypted databases, block-encrypted databases, or hardware-backed
+secure storage.  Access to secret data requires user authentication which
+is provided either by the system device lock, a system-mediated authentication
+flow, an application-mediated authentication flow, or a custom authentication
+flow implemented by a framework extension plugin.
+
+\section1 Architecture of the Sailfish OS Secrets and Crypto Framework
+
+The framework consists of three major parts:
+
+\list
+\li The system daemon providing the services to clients
+\li Extension plugins allowing vendors or partners to extend the daemon's functionality
+\li Client libraries which allow applications to easily make use of the daemon's services
+\endlist
+
+In addition to those components, the system daemon makes use of other system
+services in order to properly implement the functionality and ensure that the
+security of the system is maintained, including the device lock service (in
+order to properly authenticate the user and unlock encrypted collections of
+secrets) and the access control service.
+
+\b{Note: the access control service is not yet integrated in the current
+version of the Sailfish OS Secrets and Crypto Framework, and as such the
+only access control mode which is supported is the Owner-Only mode!}
+
+If the application doesn't wish to make use of the system authentication flows,
+it may instead use the Sailfish OS Secrets Authentication UI Plugin to
+register an in-application authentication view with the system service.
+
+\b{Note: in-application authentication should be avoided unless your
+application is a trusted (vendor- or partner-supplied application)!}
+
+A diagram which shows the architecture follows:
+
+\badcode
+                                      +-------------+
+                                      |    Secure   |
+                                      |  Peripheral |
+                                      +-------------+
+                                          ^    ^
+                                          |    |
+                                    r-----'    '------,
+                                    |                 |
+                                 +--^---+-------+ +---^---+-------+
+                                 |crypto|plugins| |secrets|plugins|
+  +---------------------+        +------+-------+-+-------+-------+
+  |    Access Control   |<------<|                                |
+  |       Daemon        |>------>|                                |
+  +---------------------+  DBus  |                                |
+                                 |        sailfishsecretsd        |
+  +---------------------+        |                                |
+  |     Lock Screen     |<------<|                                |
+  |       Daemon        |>------>|                                |
+  | (SystemInteraction) |  DBus  |                                |
+  +---------------------+        +--------------------------------+
+                                     V ^            ^   ^
+                                     | |            |   |
+         r---------------------------' |            |   |
+         | .---------------------------'            |   |
+         | |               DBus                     |   |
+         V ^                                        |   |
+  +--------------------------+                      |   |
+  |     Sailfish Secrets     |                      |   |
+  |        UI Plugin         |                      |   |
+  | (ApplicationInteraction) |                      |   |
+  +--------------------------+  (Crypto API Call)   |   |
+  |                          |        DBus          |   |
+  |                          |>---------------------'   |
+  |         Client           |                          |
+  |        Application       |  (Secrets API Call)      |
+  |                          |        DBus              |
+  |                          |>-------------------------'
+  +--------------------------+
+\endcode
+
+\section1 Extending the Sailfish OS Secrets and Crypto Framework
+
+Device vendors and trusted partners may extend the Sailfish OS Secrets and
+Crypto Framework by installing extension plugins into the appropriate plugin
+location on the device.
+
+Please see the \l{Sailfish OS Crypto Library Overview} documentation and the
+\l{Sailfish OS Secrets Library Overview} documentation for more information
+on that topic.
+
+\section1 Using the Sailfish OS Secrets and Crypto Framework
+
+The functionality provided by the framework is exposed by three separate
+libraries: two Qt-based C++ libraries and one glib-based C library.
+Each of the libraries is simply a thin wrapper around IPC calls to the system
+daemon which provides the cryptography and secret storage services.  The
+C++ libraries provide significantly more syntactic sugar than the C library.
+A QML plugin also exists which provides applications with a simple-to-extend
+view which allows the application to implement an in-process authentication
+flow which inter-operates correctly with the system service daemon.
+
+\section2 The Sailfish OS Secrets Library
+
+This library provides client applications written in C++ (with Qt) with API to
+make use of the secrets storage services provided by the Sailfish OS Secrets
+and Crypto Framework.
+
+In-depth information can be found on the page about the
+\l{Sailfish OS Secrets Library Overview}.
+
+\section3 The Sailfish OS Secrets Authentication QML Plugin
+
+This plugin provides client applications written in C++ (with Qt and QML) with
+a QML component which allows in-process authentication flows to be implemented
+easily.  This type of authentication flow is useful when the the application
+uses Owner-Only access control semantics, and the user trusts the application
+with the authentication data.
+
+More information about how this component may be used in an application can be
+found at the page about the \l{Sailfish OS Secrets Authentication QML Plugin}.
+
+\b{Note: in general, system authentication flows should be used instead of
+in-process authentication flows, to ensure that the user need not trust the
+application with authentication data!}
+
+\section2 The Sailfish OS Crypto Library
+
+This library provides client applications written in C++ (with Qt) with API to
+make use of the cryptographic services provided by the Sailfish OS Secrets and
+Crypto Framework.
+
+In-depth information can be found on the page about the
+\l{Sailfish OS Crypto Library Overview}.
+
+\section2 The Sailfish OS Secrets/Crypto C Library
+
+This library provides client applications written in C (with glib) with API to
+make use of the secrets storage and cryptography services provided by the
+Sailfish OS Secrets and Crypto Framework.
+
+In-depth information can be found on the page about the
+\l{Sailfish OS Secrets/Crypto C Library Overview}.
+
+*/

--- a/doc/sailfish.cpp
+++ b/doc/sailfish.cpp
@@ -1,0 +1,9 @@
+namespace Sailfish {
+}
+
+/*!
+  \namespace Sailfish
+  \brief This namespace provides various APIs to interact with the Sailfish OS system.
+ */
+
+using namespace Sailfish;

--- a/lib/Crypto/Crypto.pro
+++ b/lib/Crypto/Crypto.pro
@@ -42,8 +42,8 @@ SOURCES += \
     $$PWD/serialisation.cpp \
     $$PWD/x509certificate.cpp
 
-develheaders.path = /usr/include/libsailfishcrypto/
-develheaders_crypto.path = /usr/include/libsailfishcrypto/Crypto/
+develheaders.path = /usr/include/Sailfish/
+develheaders_crypto.path = /usr/include/Sailfish/Crypto/
 develheaders_crypto.files = $$PUBLIC_HEADERS
 
 pkgconfig.files = $$TARGET.pc

--- a/lib/Crypto/doc/doc.pro
+++ b/lib/Crypto/doc/doc.pro
@@ -1,0 +1,15 @@
+TEMPLATE = aux
+
+CONFIG += mer-qdoc-template
+MER_QDOC.project = sailfish-crypto
+MER_QDOC.config = sailfish-crypto.qdocconf
+MER_QDOC.style = offline
+MER_QDOC.path = /usr/share/doc/Sailfish/Crypto/
+
+OTHER_FILES += \
+    $$PWD/sailfish-crypto.qdocconf \
+    $$PWD/sailfish-crypto-overview.qdoc \
+    $$PWD/sailfish-crypto-plugins.qdoc \
+    $$PWD/sailfish-crypto.cpp \
+    $$PWD/../../../doc/index.qdoc \
+    $$PWD/../../../doc/sailfish.cpp

--- a/lib/Crypto/doc/sailfish-crypto-overview.qdoc
+++ b/lib/Crypto/doc/sailfish-crypto-overview.qdoc
@@ -1,0 +1,218 @@
+/****************************************************************************************
+**
+** Copyright (C) 2018 Jolla Ltd.
+** Contact: Chris Adams <chris.adams@jollamobile.com>
+** All rights reserved.
+**
+****************************************************************************************/
+
+/*!
+\contentspage {Sailfish OS Crypto Library Contents}
+\page sailfish-crypto-overview.html
+
+\title Sailfish OS Crypto Library Overview
+
+The Sailfish OS Crypto Library provides applications with API to access the
+cryptography functionality offered by the system service daemon as part of the
+Sailfish OS Secrets and Crypto Framework.  Please see the Sailfish OS Secrets
+documentation for more in-depth documentation about the framework architecture,
+and broad overview of the features the framework provides.
+
+\section1 Using the Sailfish OS Crypto Library
+
+As described in the Sailfish OS Secrets and Crypto Framework overview
+documentation, client applications can use the Sailfish OS Crypto Library
+in order to make use of the cryptographic services provided by the
+Sailfish OS Secrets and Crypto Framework.
+
+This library provides client applications written in C++ (with Qt) with API to
+make use of the cryptographic services provided by the Sailfish OS Secrets and
+Crypto Framework.
+
+To make use of this library, applications should depend on the
+"sailfishcrypto.pc" pkgconfig file.
+
+e.g. in a qmake-based project:
+
+\code
+CONFIG += link_pkgconfig
+PKGCONFIG += sailfishcrypto
+\endcode
+
+\section2 Client API
+
+The client API consists of a variety of C++ classes which represent the
+inputs to cryptographic operations (including secret keys and certificates),
+the result of a cryptographic operation (that is, whether it succeeded or
+failed, along with some information about the reason for the failure),
+and one class which provides an interface to the remote service.
+
+\list
+\li \l{Sailfish::Crypto::Key} represents a (possibly partial or reference) cryptographic key
+\li \l{Sailfish::Crypto::Key::Identifier} consists of a key name and optionally a collection name
+\li \l{Sailfish::Crypto::Certificate} represents a cryptographic certificate
+\li \l{Sailfish::Crypto::X509Certificate} represents an X.509 certificate
+\li \l{Sailfish::Crypto::Result} represents the result (but not the output) of a cryptographic operation
+\li \l{Sailfish::Crypto::CryptoManager} provides an interface to the system cryptography service
+\endlist
+
+\section3 Supported Operations
+
+The cryptography operations which are supported and offered by the Sailfish OS
+Secrets and Crypto Framework are documented thoroughly in the
+\l{Sailfish::Crypto::CryptoManager} class documentation.  They are included
+briefly here for reference:
+
+\list
+\li Generate a cryptographically secure random number
+\li Validate certificate (or certificate chain)
+\li Generate a cryptographic key based upon some template
+\li Securely generate and store a cryptographic key based upon some template
+\li Access a securely stored cryptographic key
+\li Delete a securely stored cryptographic key
+\li Sign arbitrary data using a cryptographic key
+\li Verify a signature using a cryptographic key or certificate
+\li Encrypt arbitrary data using a cryptographic key
+\li Decrypt encrypted data using a cryptographic key
+\endlist
+
+\section3 Usage Examples
+
+The examples directory in the source repository contains a variety of examples
+of usage of the Sailfish OS Crypto Library as well as the Sailfish OS Secrets
+Library.  Please see those for complete, working examples.
+
+Some snippets showing commonly-required functionality are included below.
+
+\section4 Generating a securely-stored symmetric cipher key
+
+This snippet shows how to generate a symmetric cipher key which will be stored
+securely by the Sailfish OS Secrets and Crypto Framework. It assumes that a
+secure storage collection has previously been created, in which to store the
+key. Please see the Sailfish OS Secrets Library documentation for information
+about how to create such a collection.
+
+First, the client defines the algorithm, supported block modes, supported
+padding schemes, and supported operations in a template key.  That template key
+is given an identifier which includes the name of the key and the name of the
+secure storage collection in which it should be stored, and is then passed as a
+parameter when invoking the \tt{generateStoredKey()} method, which results in an
+IPC call to the secure Sailfish OS Secrets and Crypto Framework system service.
+
+The Sailfish OS Secrets and Crypto Framework system service will then delegate
+the operation to the specified crypto plugin, which in turn will generate a
+full symmetric key based upon the given template, and store it securely.  A
+reference key (that is, a key containing a valid identifier and metadata, but
+no secret key data) will be returned to the client application.
+
+Note that these operations are all asynchronous, however in the snippet we
+force the operation to be synchronous by calling the \tt{waitForFinished()}
+method on the reply object.  In practice, the client application should instead
+use a watcher object which will notify when the operation is complete.
+
+\code
+// Set the key template metadata.
+Sailfish::Crypto::Key keyTemplate, symmetricKeyReference;
+keyTemplate.setAlgorithm(Sailfish::Crypto::Key::Aes256);
+keyTemplate.setOrigin(Sailfish::Crypto::Key::OriginDevice);
+keyTemplate.setBlockModes(Sailfish::Crypto::Key::BlockModeCBC);
+keyTemplate.setEncryptionPaddings(Sailfish::Crypto::Key::EncryptionPaddingNone);
+keyTemplate.setSignaturePaddings(Sailfish::Crypto::Key::SignaturePaddingNone);
+keyTemplate.setDigests(Sailfish::Crypto::Key::DigestSha256);
+keyTemplate.setOperations(Sailfish::Crypto::Key::Encrypt
+                         |Sailfish::Crypto::Key::Decrypt);
+
+// Set the identifier for the key.
+// This assumes the existence of an "ExampleCollection" secure storage
+// collection, in which the key will be stored.
+// See Sailfish::Secrets::SecretManager::createCollection().
+keyTemplate.setIdentifier(QStringLiteral("ExampleKey"),
+                          QStringLiteral("ExampleCollection"));
+
+// Ask the system service to generate and store the key securely.
+Sailfish::Crypto::CryptoManager cm;
+QDBusPendingReply<Sailfish::Crypto::Result, Sailfish::Crypto::Key>
+        generateReply = cm.generateStoredKey(
+                keyTemplate,
+                Sailfish::Crypto::CryptoManager::DefaultCryptoStoragePluginName);
+generateReply.waitForFinished();
+if (generateReply.argumentAt<0>().code() == Sailfish::Crypto::Result::Failed) {
+    qWarning() << "Unable to generate and store symmetric key:"
+               << generateReply.argumentAt<0>().errorMessage();
+} else {
+    symmetricKeyReference = generateReply.argumentAt<1>();
+}
+\endcode
+
+\section4 Encrypting data with a symmetric key
+
+After generating a symmetric key, that key may be used to encrypt data.
+Note that the key may be either a key reference (that is, a key which contains
+only metadata and a valid identifier, which references a full key stored in
+secure storage) or a full key (that is, a key which contains secret key data).
+
+In this example, we use the reference key which was returned to the application
+in the previous snippet.
+
+\code
+QByteArray ciphertext, plaintext = "Example plaintext data";
+QDBusPendingReply<Sailfish::Crypto::Result, QByteArray>
+        encryptReply = cm.encrypt(
+                plaintext,
+                symmetricKeyReference,
+                Sailfish::Crypto::Key::BlockModeCBC,
+                Sailfish::Crypto::Key::EncryptionPaddingNone,
+                Sailfish::Crypto::Key::DigestSha256,
+                Sailfish::Crypto::CryptoManager::DefaultCryptoStoragePluginName);
+encryptReply.waitForFinished();
+if (encryptReply.argumentAt<0>().code() == Sailfish::Crypto::Result::Failed) {
+    qWarning() << "Failed to encrypt:"
+               << encryptReply.argumentAt<0>().errorMessage();
+} else {
+    ciphertext = encryptReply.argumentAt<1>();
+}
+\endcode
+
+\section4 Decrypting data with a symmetric key
+
+A symmetric key may also be used to decrypt data.  In the following snippet,
+the client asks the system service to decrypt the ciphertext with the same
+key reference, to produce decrypted data.
+
+\code
+QDBusPendingReply<Sailfish::Crypto::Result, QByteArray>
+        decryptReply = cm.decrypt(
+                ciphertext,
+                symmetricKeyReference,
+                Sailfish::Crypto::Key::BlockModeCBC,
+                Sailfish::Crypto::Key::EncryptionPaddingNone,
+                Sailfish::Crypto::Key::DigestSha256,
+                Sailfish::Crypto::CryptoManager::DefaultCryptoStoragePluginName);
+decryptReply.waitForFinished();
+if (decryptReply.argumentAt<0>().code() == Sailfish::Crypto::Result::Failed) {
+    qWarning() << "Failed to decrypt ciphertext:"
+               << decryptReply.argumentAt<0>().errorMessage();
+} else {
+    QByteArray decrypted = decryptReply.argumentAt<1>();
+    qDebug() << "Decrypted:" << decrypted;
+}
+\endcode
+
+\section1 Extending the Sailfish OS Secrets and Crypto Framework with Crypto Plugins
+
+The Sailfish OS Crypto Library also provides a plugin base-class which may be
+extended by device vendors or trusted partners to allow them to build plugins
+to extend the Sailfish OS Secrets and Crypto Framework with additional
+cryptography functionality (for example, supporting different algorithms or
+block modes, or performing the operations via a Trusted Execution Environment
+application rather than in-process in the rich application process).
+
+The \l{Sailfish::Crypto::CryptoPlugin} class should be extended in order to
+achieve this, and the resulting plugin should be installed into the
+\tt{/usr/lib/Sailfish/Crypto/} directory.
+
+A variety of plugins are shipped by default with the framework, and these are
+documented at the page about
+\l{Default Crypto Plugins for the Sailfish OS Secrets and Crypto Framework}.
+
+*/

--- a/lib/Crypto/doc/sailfish-crypto-plugins.qdoc
+++ b/lib/Crypto/doc/sailfish-crypto-plugins.qdoc
@@ -1,0 +1,92 @@
+/****************************************************************************************
+**
+** Copyright (C) 2018 Jolla Ltd.
+** Contact: Chris Adams <chris.adams@jollamobile.com>
+** All rights reserved.
+**
+****************************************************************************************/
+
+/*!
+\contentspage {Sailfish OS Crypto Plugins Contents}
+\page sailfish-crypto-plugins.html
+
+\title Default Crypto Plugins for the Sailfish OS Secrets and Crypto Framework
+
+A number of plugins have been written for the framework which provide
+a variety of functionality for clients to use.  Most clients should use
+the platform default plugins when writing their applications, as these
+will provide the most consistent and secure experience.
+
+Device vendors and trusted partners may wish to provide their own plugins,
+and some applications may wish to specifically use those plugins.
+
+\section1 Default Crypto Plugins
+
+Currently, there are two Sailfish OS Crypto plugins shipped by default:
+
+\list
+\li org.sailfishos.crypto.plugin.crypto.openssl
+\li org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher
+\endlist
+
+The first plugin provides implementations of common cryptography functionality
+by calling the OpenSSL library functions internally.
+
+The second plugin shares its cryptography implementation with the first plugin,
+but also provides block-level encrypted secure storage of collections of
+secrets, using the SQLCipher library for its database operations.  Thus it is
+both a \tt{Sailfish::Crypto::CryptoPlugin} and a
+\tt{Sailfish::Secrets::EncryptedStoragePlugin}.
+
+Note that neither of these plugins use TEE/TPM or other secure-hardware
+to implement the cryptographic functionality.
+
+\section1 Which Plugin Should My Application Use?
+
+We recommend that the system default CryptoStorage plugin be used where
+possible.  In most cases, this will be the
+"org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher" plugin.
+
+The following snippet shows an example of using the default crypto
+storage plugin to create a symmetric key, and store it in an encrypted
+database managed by that same plugin:
+
+\code
+// Set the key template metadata.
+Sailfish::Crypto::Key keyTemplate, symmetricKeyReference;
+keyTemplate.setAlgorithm(Sailfish::Crypto::Key::Aes256);
+keyTemplate.setOrigin(Sailfish::Crypto::Key::OriginDevice);
+keyTemplate.setBlockModes(Sailfish::Crypto::Key::BlockModeCBC);
+keyTemplate.setEncryptionPaddings(Sailfish::Crypto::Key::EncryptionPaddingNone);
+keyTemplate.setSignaturePaddings(Sailfish::Crypto::Key::SignaturePaddingNone);
+keyTemplate.setDigests(Sailfish::Crypto::Key::DigestSha256);
+keyTemplate.setOperations(Sailfish::Crypto::Key::Encrypt
+                         |Sailfish::Crypto::Key::Decrypt);
+
+// Set the identifier for the key.
+// This assumes the existence of an "ExampleCollection" secure storage
+// collection, in which the key will be stored.
+// See Sailfish::Secrets::SecretManager::createCollection().
+keyTemplate.setIdentifier(QStringLiteral("ExampleKey"),
+                          QStringLiteral("ExampleCollection"));
+
+// Ask the system service to generate and store the key securely.
+Sailfish::Crypto::CryptoManager cm;
+QDBusPendingReply<Sailfish::Crypto::Result, Sailfish::Crypto::Key>
+        generateReply = cm.generateStoredKey(
+                keyTemplate,
+                Sailfish::Crypto::CryptoManager::DefaultCryptoStoragePluginName);
+generateReply.waitForFinished();
+if (generateReply.argumentAt<0>().code() == Sailfish::Crypto::Result::Failed) {
+    qWarning() << "Unable to generate and store symmetric key:"
+               << generateReply.argumentAt<0>().errorMessage();
+} else {
+    symmetricKeyReference = generateReply.argumentAt<1>();
+}
+\endcode
+
+Note that this example assumes that the "ExampleCollection" had already
+been created, via the appropriate call to
+\tt{Sailfish::Secrets::SecretManager::createCollection()}.
+
+*/

--- a/lib/Crypto/doc/sailfish-crypto.cpp
+++ b/lib/Crypto/doc/sailfish-crypto.cpp
@@ -1,0 +1,14 @@
+#include "../../../doc/sailfish.cpp"
+
+namespace Sailfish {
+namespace Crypto {}
+}
+
+using namespace Sailfish;
+
+/*!
+  \namespace Crypto
+  \brief This namespace provides various types related to performing cryptographic operations in the Sailfish OS system.
+ */
+
+using namespace Sailfish::Crypto;

--- a/lib/Crypto/doc/sailfish-crypto.qdocconf
+++ b/lib/Crypto/doc/sailfish-crypto.qdocconf
@@ -1,0 +1,41 @@
+project         = Sailfish OS Secrets and Crypto Framework - Crypto Library
+description     = Sailfish OS Secrets and Crypto Framework - Crypto Library Reference Documentation
+versionsym      =
+version         = 0.0.1
+url             = https://github.com/sailfishos/sailfish-secrets/
+
+sourcedirs += $$PWD/../ $$PWD/../doc $$PWD/../../../doc
+headerdirs += $$PWD/../
+
+outputformats = HTML
+outputdir = $$PWD/../doc/html
+base = file:$$PWD/../doc/html
+tagfile = $$PWD/../doc/html/sailfish-crypto.tags
+
+outputprefixes = QML
+outputprefixes.QML = qml-sailfishcrypto-
+
+qhp.projects = SailfishCrypto
+
+qhp.SailfishCrypto.file = sailfish-crypto.qhp
+qhp.SailfishCrypto.namespace = org.sailfishos.crypto.0.0.1
+qhp.SailfishCrypto.virtualFolder = sailfish-crypto
+qhp.SailfishCrypto.indexTitle = Sailfish OS Secrets and Crypto Framework Overview
+qhp.SailfishCrypto.indexRoot =
+
+qhp.SailfishCrypto.filterAttributes = sailfish-crypto 1.0.0
+qhp.SailfishCrypto.customFilters.SailfishCrypto.name = Sailfish OS Crypto Library 0.0.1
+qhp.SailfishCrypto.customFilters.SailfishCrypto.filterAttributes = sailfish-crypto 0.0.1
+
+HTML.footer += \
+    "<div class=\"footer\">\n" \
+    "  <p><acronym title=\"Copyright\">&copy;</acronym> 2018 Jolla Ltd.</p>\n" \
+    "  <p>All other trademarks are property of their respective owners.</p>\n" \
+    "  <p>\n" \
+    "    This document may be used under the terms of the " \
+    "    <a href=\"http://www.gnu.org/licenses/fdl.html\">GNU Free Documentation License version 1.3</a>" \
+    "    as published by the Free Software Foundation." \
+    "  </p>\n" \
+    "</div>\n"
+
+navigation.homepage = "Sailfish OS Secrets and Crypto Framework Overview"

--- a/lib/Secrets/Secrets.pro
+++ b/lib/Secrets/Secrets.pro
@@ -40,8 +40,8 @@ SOURCES += \
     $$PWD/interactionrequestwatcher.cpp \
     $$PWD/interactionservice.cpp
 
-develheaders.path = /usr/include/libsailfishsecrets/
-develheaders_secrets.path = /usr/include/libsailfishsecrets/Secrets/
+develheaders.path = /usr/include/Sailfish/
+develheaders_secrets.path = /usr/include/Sailfish/Secrets/
 develheaders_secrets.files = $$PUBLIC_HEADERS
 
 pkgconfig.files = $$TARGET.pc

--- a/lib/Secrets/doc/doc.pro
+++ b/lib/Secrets/doc/doc.pro
@@ -1,0 +1,15 @@
+TEMPLATE = aux
+
+CONFIG += mer-qdoc-template
+MER_QDOC.project = sailfish-secrets
+MER_QDOC.config = sailfish-secrets.qdocconf
+MER_QDOC.style = offline
+MER_QDOC.path = /usr/share/doc/Sailfish/Secrets/
+
+OTHER_FILES += \
+    $$PWD/sailfish-secrets.qdocconf \
+    $$PWD/sailfish-secrets-overview.qdoc \
+    $$PWD/sailfish-secrets-plugins.qdoc \
+    $$PWD/sailfish-secrets.cpp \
+    $$PWD/../../../doc/index.qdoc \
+    $$PWD/../../../doc/sailfish.cpp

--- a/lib/Secrets/doc/sailfish-secrets-overview.qdoc
+++ b/lib/Secrets/doc/sailfish-secrets-overview.qdoc
@@ -1,0 +1,242 @@
+/****************************************************************************************
+**
+** Copyright (C) 2018 Jolla Ltd.
+** Contact: Chris Adams <chris.adams@jollamobile.com>
+** All rights reserved.
+**
+****************************************************************************************/
+
+/*!
+\contentspage {Sailfish OS Secrets Library Contents}
+\page sailfish-secrets-overview.html
+
+\title Sailfish OS Secrets Library Overview
+
+The Sailfish OS Secrets Library provides applications with API to access the
+secure storage functionality offered by the system service daemon as part of
+the Sailfish OS Secrets and Crypto Framework. Please see the Sailfish OS
+Secrets and Crypto Framework documentation for more in-depth documentation
+about the framework architecture, and broad overview of the features the
+framework provides.
+
+\section1 Using the Sailfish OS Secrets Library
+
+As described in the Sailfish OS Secrets and Crypto Framework overview
+documentation, client applications can use the Sailfish OS Secrets Library
+in order to make use of the secure storage services provided by the
+Sailfish OS Secrets and Crypto Framework.
+
+This library provides client applications written in C++ (with Qt) with API to
+make use of the secure storage services provided by the Sailfish OS Secrets and
+Crypto Framework.
+
+To make use of this library, applications should depend on the
+"sailfishsecrets.pc" pkgconfig file.
+
+e.g. in a qmake-based project:
+
+\code
+CONFIG += link_pkgconfig
+PKGCONFIG += sailfishsecrets
+\endcode
+
+\section2 Client API
+
+The client API consists of a variety of C++ classes which represent the
+inputs to secure storage operations (including secrets of various types),
+the result of a secure storage operation (that is, whether it succeeded or
+failed, along with some information about the reason for the failure),
+and one class which provides an interface to the remote service.
+
+\list
+\li \l{Sailfish::Secrets::Secret} represents a (possibly partial or reference) secret
+\li \l{Sailfish::Secrets::Secret::Identifier} consists of a secret name and optionally a collection name
+\li \l{Sailfish::Secrets::Result} represents the result (but not the output) of a secure storage operation
+\li \l{Sailfish::Secrets::SecretManager} provides an interface to the system secure storage service
+\endlist
+
+There also exist some API for dealing with authentication flows which require
+user interaction, where that user interaction is not mediated by the system
+(e.g., device lock). These APIs are listed here only for the sake of
+completeness as most applications should never use them:
+
+\list
+\li \l{Sailfish::Secrets::InteractionRequest} represents a request for authorization or other user interaction
+\li \l{Sailfish::Secrets::InteractionResponse} represents a response to an interaction request
+\li \l{Sailfish::Secrets::InteractionRequestWatcher} represents a watcher on an interaction request
+\li \l{Sailfish::Secrets::InteractionView} provides a view for user interaction
+\endlist
+
+As described previously, these APIs are only useful for applications which
+implement in-process authentication flows rather than using the system-mediated
+authentication flows, and thus only apply to device vendor- or partner-supplied
+applications, and even then they need not be directly used if the appropriate
+QML plugin is used to provide this functionality within the application.
+
+\section3 Supported Operations
+
+The secure storage operations which are supported and offered by the
+Sailfish OS Secrets and Crypto Framework are documented thoroughly in the
+\l{Sailfish::Secrets::SecretManager} class documentation.  They are included
+briefly here for reference:
+
+\list
+\li Create a device-lock-protected collection of secrets
+\li Create a custom-lock-protected collection of secrets
+\li Delete a collection of secrets
+\li Store a secret into a collection
+\li Retrieve a secret from a collection
+\li Delete a secret from a collection
+\li Store a standalone secret
+\li Retrieve a standalone secret
+\li Delete a standalone secret
+\li Find secrets based on filter data
+\endlist
+
+\section3 Usage Examples
+
+The examples directory in the source repository contains a variety of examples
+of usage of the Sailfish OS Crypto Library as well as the Sailfish OS Secrets
+Library.  Please see those for complete, working examples.
+
+Some snippets showing commonly-required functionality are included below.
+
+\section4 Creating a block-encrypted collection of secrets
+
+This snippet shows how to create a block-encrypted collection of secrets
+which will be automatically locked when the device is locked, and unlocked
+when the device is unlocked.  The client specifies the type of storage
+to create the collection in, along with the required locking and access
+control semantics, as parameters to the call to the \tt{createCollection()}
+method, which results in an IPC call to the Sailfish OS Secrets and Crypto
+Framework system service.
+
+The Sailfish OS Secrets and Crypto Framework system service will then delegate
+the operation to the specified storage plugin, which in turn will generate a
+block-level encrypted database file for the collection.
+
+Note that these operations are all asynchronous, however in the snippet we
+force the operation to be synchronous by calling the \tt{waitForFinished()}
+method on the reply object.  In practice, the client application should instead
+use a watcher object which will notify when the operation is complete.
+
+\code
+Sailfish::Secrets::SecretManager sm;
+QDBusPendingReply<Sailfish::Secrets::Result>
+        collectionReply = sm.createCollection(
+                QLatin1String("ExampleCollection"),
+                Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName,
+                Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName,
+                Sailfish::Secrets::SecretManager::DeviceLockKeepUnlocked,
+                Sailfish::Secrets::SecretManager::OwnerOnlyMode);
+collectionReply.waitForFinished();
+if (collectionReply.argumentAt<0>().code() == Sailfish::Secrets::Result::Failed) {
+    qWarning() << "Failed to create collection:"
+               << collectionReply.argumentAt<0>().errorMessage();
+}
+\endcode
+
+\section4 Storing a secret into a collection
+
+After creating a collection, an application may wish to store a secret into
+that collection.  To do so, the client specifies the name of the collection
+in the identifier of the secret, along with the secret's own name.
+
+Once the identifier is set, the client can set the secret data into the
+secret, and specify some metadata and filter tags, before performing the
+call to request that the secret be stored in the collection by the
+system service.
+
+\code
+// Define the secret.
+Sailfish::Secrets::Secret exampleSecret(
+        Sailfish::Secrets::Secret::Identifier(
+                QLatin1String("ExampleSecret"),
+                QLatin1String("ExampleCollection")));
+testSecret.setData("Some secret data");
+testSecret.setType(Sailfish::Secrets::Secret::TypeBlob);
+testSecret.setFilterData(QLatin1String("domain"),
+                         QLatin1String("sailfishos.org"));
+testSecret.setFilterData(QLatin1String("example"),
+                         QLatin1String("true"));
+
+// Request that the secret be securely stored.
+QDBusPendingReply<Sailfish::Secrets::Result>
+        storeReply = sm.setSecret(
+                testSecret,
+                Sailfish::Secrets::SecretManager::SystemInteraction);
+storeReply.waitForFinished();
+if (storeReply.argumentAt<0>().code() == Sailfish::Secrets::Result::Failed) {
+    qWarning() << "Failed to store secret:"
+               << storeReply.argumentAt<0>().errorMessage();
+}
+\endcode
+
+\section4 Retrieving a secret from a collection
+
+A secret may be retrieved from a collection either by specifying the secret's
+identifier, or by specifying filter tags which are used to find matching
+secrets.  The APIs are very similar, here we will show the case where the
+identifier is known (e.g. this would be the case if this application
+originally stored the secret).
+
+\code
+QDBusPendingReply<Sailfish::Secrets::Result, Sailfish::Secrets::Secret>
+        secretReply = sm.getSecret(
+                testSecret.identifier(),
+                Sailfish::Secrets::SecretManager::SystemInteraction);
+secretReply.waitForFinished();
+if (secretReply.argumentAt<0>().code() == Sailfish::Secrets::Result::Failed) {
+    qWarning() << "Failed to retrieve secret:"
+               << secretReply.argumentAt<0>().errorMessage();
+} else {
+    qDebug() << "The secret data is:"
+             << secretReply.argumentAt<1>().data();
+}
+\endcode
+
+\section4 Deleting a secret or a collection
+
+An application may want to delete a secret (or a collection of secrets) at
+some point, after the secret data is no longer valid.  The API to delete
+a collection is very similar to that for deleting a secret, so only the
+latter will be shown below.
+
+\code
+QDBusPendingReply<Sailfish::Secrets::Result>
+        deleteReply = sm.deleteSecret(
+                Sailfish::Secrets::Secret::Identifier("ExampleSecret",
+                                                      "ExampleCollection"),
+                SecretManager::ApplicationInteraction);
+deleteReply.waitForFinished();
+if (deleteReply.argumentAt<0>().code() == Sailfish::Secrets::Result::Failed) {
+    qWarning() << "Failed to delete secret:"
+               << deleteReply.argumentAt<0>().errorMessage();
+}
+\endcode
+
+\section1 Extending the Sailfish OS Secrets and Crypto Framework with Secrets Plugins
+
+The Sailfish OS Secrets Library also provides a plugin base-class which may be
+extended by device vendors or trusted partners to allow them to build plugins
+to extend the Sailfish OS Secrets and Crypto Framework with additional
+secure storage functionality (for example, supporting different algorithms or
+databases, or performing the operations via a Trusted Execution Environment
+application rather than in-process in the rich application process).
+
+The following classes may be extended in order to achieve this, and the
+resulting plugins should be installed into the
+\tt{/usr/lib/Sailfish/Secrets/} directory.
+
+\list
+\li \l{Sailfish::Secrets::EncryptionPlugin} to value-encrypt secrets
+\li \l{Sailfish::Secrets::StoragePlugin} to store value-encrypted secrets
+\li \l{Sailfish::Secrets::EncryptedStoragePlugin} to store block-encrypted collections of secrets
+\li \l{Sailfish::Secrets::AuthenticationPlugin} to implement alternative user authentication flows
+\endlist
+
+A variety of plugins are shipped by default with the framework, and these are
+documented at the page about
+\l{Default Secrets Plugins for the Sailfish OS Secrets and Crypto Framework}.
+
+*/

--- a/lib/Secrets/doc/sailfish-secrets-plugins.qdoc
+++ b/lib/Secrets/doc/sailfish-secrets-plugins.qdoc
@@ -1,0 +1,118 @@
+/****************************************************************************************
+**
+** Copyright (C) 2018 Jolla Ltd.
+** Contact: Chris Adams <chris.adams@jollamobile.com>
+** All rights reserved.
+**
+****************************************************************************************/
+
+/*!
+\contentspage {Sailfish OS Secrets Plugins Contents}
+\page sailfish-secrets-plugins.html
+
+\title Default Secrets Plugins for the Sailfish OS Secrets and Crypto Framework
+
+A number of plugins have been written for the framework which provide
+a variety of functionality for clients to use.  Most clients should use
+the platform default plugins when writing their applications, as these
+will provide the most consistent and secure experience.
+
+Device vendors and trusted partners may wish to provide their own plugins,
+and some applications may wish to specifically use those plugins.
+
+\section1 Default Secrets Plugins
+
+Currently, there are several Sailfish OS Secrets plugins shipped by default:
+
+\list
+\li org.sailfishos.secrets.plugin.encryption.openssl
+\li org.sailfishos.secrets.plugin.storage.sqlite
+\li org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher
+\li org.sailfishos.secrets.plugin.authentication.inapp
+\endlist
+
+The first plugin is used internally to encrypt the data in a secret when that
+secret is either standalone or stored in a collection in unencrypted storage.
+This plugin uses the OpenSSL library to perform the encryption.
+
+The second plugin provides unencrypted storage for collections of secrets.
+
+The third plugin provides (block-level) encrypted storage for collections of
+secrets (using the popular SQLCipher as its database storage backend).  When
+using this plugin, every collection is stored in its own database.  Note: this
+plugin is also a Sailfish OS Crypto plugin.
+
+The fourth plugin provides in-application authentication flows, for cases
+where the user trusts the application with the authentication data, rather
+than using the system-mediated authentication flows (e.g. device lock).
+
+Note that neither of these plugins use TEE/TPM or other secure-hardware
+to implement the cryptographic functionality.
+
+\section1 Which Plugin Should My Application Use?
+
+We recommend that the system default EncryptedStorage plugin be used where
+possible.  In most cases, this will be the
+"org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher" plugin.
+
+In order to use the system default EncryptedStorage plugin, it should be
+specified for both the encryption plugin and storage plugin parameters when
+invoking a method via the SecretManager.
+
+The following snippet shows an example of creating a collection of secrets
+in an encrypted database managed by the default encrypted storage plugin:
+
+\code
+Sailfish::Secrets::SecretManager sm;
+QDBusPendingReply<Sailfish::Secrets::Result>
+        collectionReply = sm.createCollection(
+                QLatin1String("ExampleCollection"),
+                Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName,
+                Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName,
+                Sailfish::Secrets::SecretManager::DeviceLockKeepUnlocked,
+                Sailfish::Secrets::SecretManager::OwnerOnlyMode);
+collectionReply.waitForFinished();
+if (collectionReply.argumentAt<0>().code() == Sailfish::Secrets::Result::Failed) {
+    qWarning() << "Failed to create collection:"
+               << collectionReply.argumentAt<0>().errorMessage();
+}
+\endcode
+
+If standalone secrets are required for any reason, we recommend that the
+application uses the default EncryptionPlugin and default StoragePlugin.
+In most cases, these will be the
+"org.sailfishos.secrets.plugin.encryption.openssl" and
+"org.sailfishos.secrets.plugin.storage.sqlite" plugins respectively.
+
+The following snippet shows an example of storing a standalone, device-lock
+protected secret in the default storage plugin:
+
+\code
+// Define a standalone secret (no collection name specified in the identifier)
+Sailfish::Secrets::Secret standaloneSecret(
+        Sailfish::Secrets::Secret::Identifier("StandaloneSecret"));
+standaloneSecret.setData("Example secret data");
+standaloneSecret.setType(Secret::TypeBlob);
+standaloneSecret.setFilterData(QLatin1String("domain"),
+                               QLatin1String("sailfishos.org"));
+standaloneSecret.setFilterData(QLatin1String("example"),
+                               QLatin1String("true"));
+
+// Request that the secret be stored by the default storage plugin
+Sailfish::Secrets::SecretManager sm;
+QDBusPendingReply<Sailfish::Secrets::Result>
+        secretReply = sm.setSecret(
+            Sailfish::Secrets::SecretManager::DefaultStoragePluginName,
+            Sailfish::Secrets::SecretManager::DefaultEncryptionPluginName,
+            standaloneSecret,
+            Sailfish::Secrets::SecretManager::DeviceLockKeepUnlocked,
+            Sailfish::Secrets::SecretManager::OwnerOnlyMode,
+            Sailfish::Secrets::SecretManager::ApplicationInteraction);
+secretReply.waitForFinished();
+if (secretReply.argumentAt<0>().code() == Sailfish::Secrets::Result::Failed) {
+    qWarning() << "Failed to store secret:"
+               << secretReply.argumentAt<0>().errorMessage();
+}
+\endcode
+
+*/

--- a/lib/Secrets/doc/sailfish-secrets.cpp
+++ b/lib/Secrets/doc/sailfish-secrets.cpp
@@ -1,0 +1,14 @@
+#include "../../../doc/sailfish.cpp"
+
+namespace Sailfish {
+namespace Secrets {}
+}
+
+using namespace Sailfish;
+
+/*!
+  \namespace Secrets
+  \brief This namespace provides various types related to storing secret data in the Sailfish OS system.
+ */
+
+using namespace Sailfish::Secrets;

--- a/lib/Secrets/doc/sailfish-secrets.qdocconf
+++ b/lib/Secrets/doc/sailfish-secrets.qdocconf
@@ -1,0 +1,41 @@
+project         = Sailfish OS Secrets and Crypto Framework - Secrets Library
+description     = Sailfish OS Secrets and Crypto Framework - Secrets Library Reference Documentation
+versionsym      =
+version         = 0.0.1
+url             = https://github.com/sailfishos/sailfish-secrets/
+
+sourcedirs += $$PWD/../ $$PWD/../doc $$PWD/../../../doc/
+headerdirs += $$PWD/../
+
+outputformats = HTML
+outputdir = $$PWD/../doc/html
+base = file:$$PWD/../doc/html
+tagfile = $$PWD/../doc/html/sailfish-secrets.tags
+
+outputprefixes = QML
+outputprefixes.QML = qml-sailfishsecrets-
+
+qhp.projects = SailfishSecrets
+
+qhp.SailfishSecrets.file = sailfish-secrets.qhp
+qhp.SailfishSecrets.namespace = org.sailfishos.secrets.0.0.1
+qhp.SailfishSecrets.virtualFolder = sailfish-secrets
+qhp.SailfishSecrets.indexTitle = Sailfish OS Secrets and Crypto Framework Overview
+qhp.SailfishSecrets.indexRoot =
+
+qhp.SailfishSecrets.filterAttributes = sailfish-secrets 0.0.1
+qhp.SailfishSecrets.customFilters.SailfishSecrets.name = Sailfish OS Secrets Library 0.0.1
+qhp.SailfishSecrets.customFilters.SailfishSecrets.filterAttributes = sailfish-secrets 0.0.1
+
+HTML.footer += \
+    "<div class=\"footer\">\n" \
+    "  <p><acronym title=\"Copyright\">&copy;</acronym> 2018 Jolla Ltd.</p>\n" \
+    "  <p>All other trademarks are property of their respective owners.</p>\n" \
+    "  <p>\n" \
+    "    This document may be used under the terms of the " \
+    "    <a href=\"http://www.gnu.org/licenses/fdl.html\">GNU Free Documentation License version 1.3</a>" \
+    "    as published by the Free Software Foundation." \
+    "  </p>\n" \
+    "</div>\n"
+
+navigation.homepage = "Sailfish OS Secrets and Crypto Framework Overview"

--- a/lib/SecretsCrypto/README
+++ b/lib/SecretsCrypto/README
@@ -1,0 +1,1 @@
+C API - TODO

--- a/lib/lib.pro
+++ b/lib/lib.pro
@@ -1,4 +1,4 @@
 TEMPLATE = subdirs
 SUBDIRS += \
-    Secrets \
-    Crypto
+    $$PWD/Secrets $$PWD/Secrets/doc \
+    $$PWD/Crypto $$PWD/Crypto/doc

--- a/plugins/inappauthplugin/inappauthplugin.pro
+++ b/plugins/inappauthplugin/inappauthplugin.pro
@@ -9,5 +9,5 @@ include($$PWD/../../lib/libsailfishsecrets.pri)
 HEADERS += $$PWD/plugin.h
 SOURCES += $$PWD/plugin.cpp
 
-target.path=/usr/lib/sailfish/secrets/
+target.path=/usr/lib/Sailfish/Secrets/
 INSTALLS += target

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.pro
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.pro
@@ -10,5 +10,5 @@ HEADERS += $$PWD/evp_p.h $$PWD/opensslcryptoplugin.h
 SOURCES += $$PWD/opensslcryptoplugin.cpp
 OTHER_FILES += $$PWD/cryptoplugin_common.cpp
 
-target.path=/usr/lib/sailfish/crypto/
+target.path=/usr/lib/Sailfish/Crypto/
 INSTALLS += target

--- a/plugins/opensslplugin/opensslplugin.pro
+++ b/plugins/opensslplugin/opensslplugin.pro
@@ -9,5 +9,5 @@ include($$PWD/../../lib/libsailfishsecrets.pri)
 HEADERS += $$PWD/evp_p.h $$PWD/plugin.h
 SOURCES += $$PWD/plugin.cpp
 
-target.path=/usr/lib/sailfish/secrets/
+target.path=/usr/lib/Sailfish/Secrets/
 INSTALLS += target

--- a/plugins/sqlcipherplugin/sqlcipherplugin.pro
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.pro
@@ -20,5 +20,5 @@ SOURCES += \
 OTHER_FILES += \
     $$PWD/../opensslcryptoplugin/cryptoplugin_common.cpp
 
-target.path=/usr/lib/sailfish/secrets/
+target.path=/usr/lib/Sailfish/Secrets/
 INSTALLS += target

--- a/plugins/sqliteplugin/sqliteplugin.pro
+++ b/plugins/sqliteplugin/sqliteplugin.pro
@@ -10,5 +10,5 @@ include($$PWD/../../database/database.pri)
 HEADERS += $$PWD/sqlitedatabase_p.h $$PWD/plugin.h
 SOURCES += $$PWD/plugin.cpp
 
-target.path=/usr/lib/sailfish/secrets/
+target.path=/usr/lib/Sailfish/Secrets/
 INSTALLS += target

--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -1,5 +1,5 @@
 Name:       libsailfishsecrets
-Summary:    Sailfish OS secrets storage system functionality library
+Summary:    Sailfish OS secrets storage system functionality client library
 Version:    0.0.1
 Release:    1
 Group:      System/Libraries
@@ -14,15 +14,33 @@ BuildRequires:  pkgconfig(Qt5DBus)
 %{summary}.
 
 %package devel
-Summary:    Development package for Sailfish OS secrets storage library.
+Summary:    Development package for Sailfish OS Secrets Library.
 Group:      System/Libraries
 Requires:   %{name} = %{version}-%{release}
 
 %description devel
 %{summary}.
 
+%package doc
+Summary: Documentation for Sailfish OS Secrets Library
+BuildRequires:  mer-qdoc-template
+BuildRequires:  qt5-qttools-qthelp-devel
+BuildRequires:  qt5-tools
+
+%description doc
+%{summary}.
+
+%package tests
+Summary:    Unit tests for the Sailfish OS Secrets Library.
+Group:      System/Libraries
+BuildRequires:  pkgconfig(Qt5Test)
+Requires:   %{name} = %{version}-%{release}
+
+%description tests
+%{summary}.
+
 %package -n libsailfishsecretsplugin
-Summary:    QML plugin providing types for clients of libsailfishsecrets.
+Summary:    QML plugin providing types for applications using libsailfishsecrets.
 Group:      System/Libraries
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(Qt5Gui)
@@ -31,18 +49,55 @@ Requires:   %{name} = %{version}-%{release}
 %description -n libsailfishsecretsplugin
 %{summary}.
 
+%package -n libsailfishcrypto
+Summary:    Sailfish OS cryptographic operations system functionality client library
+Group:      System/Libraries
+BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5Sql)
+BuildRequires:  pkgconfig(Qt5DBus)
+
+%description -n libsailfishcrypto
+%{summary}.
+
+%package -n libsailfishcrypto-devel
+Summary:    Development package for Sailfish OS Crypto Library
+Group:      System/Libraries
+Requires:   libsailfishcrypto = %{version}-%{release}
+
+%description -n libsailfishcrypto-devel
+%{summary}.
+
+%package -n libsailfishcrypto-doc
+Summary: Documentation for Sailfish OS Crypto Library
+BuildRequires:  mer-qdoc-template
+BuildRequires:  qt5-qttools-qthelp-devel
+BuildRequires:  qt5-tools
+
+%description -n libsailfishcrypto-doc
+%{summary}.
+
+%package -n libsailfishcrypto-tests
+Summary:    Unit tests for the libsailfishcrypto library.
+Group:      System/Libraries
+BuildRequires:  pkgconfig(Qt5Test)
+Requires:   libsailfishcrypto = %{version}-%{release}
+
+%description -n libsailfishcrypto-tests
+%{summary}.
+
 %package -n sailfishsecretsdaemon
 Summary:    Sailfish OS secrets daemon (example).
 Group:      Applications/System
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(dbus-1)
-BuildRequires:  pkgconfig(libcrypto)
 BuildRequires:  qt5-plugin-sqldriver-sqlite
 Requires:   %{name} = %{version}-%{release}
+Requires:   libsailfishcrypto = %{version}-%{release}
 
 %description -n sailfishsecretsdaemon
-Provides an example secrets storage daemon service, which exposes functionality provided by libsailfishsecrets to clients via DBus.
+Provides an example secrets storage and cryptographic operations system daemon service,
+which exposes functionality provided by libsailfishsecrets and libsailfishcrypto to clients via DBus.
 
 %package -n sailfishsecretsdaemonplugins
 Summary:    Sailfish OS secrets daemon (example) plugins.
@@ -57,42 +112,6 @@ Requires:   sailfishsecretsdaemon = %{version}-%{release}
 
 %description -n sailfishsecretsdaemonplugins
 Provides a set of example secrets daemon plugins.
-
-%package tests
-Summary:    Unit tests for the libsailfishsecrets library.
-Group:      System/Libraries
-BuildRequires:  pkgconfig(Qt5Test)
-Requires:   %{name} = %{version}-%{release}
-
-%description tests
-%{summary}.
-
-%package -n libsailfishcrypto
-Summary:    Sailfish OS cryptographic operations library
-Group:      System/Libraries
-BuildRequires:  pkgconfig(Qt5Core)
-BuildRequires:  pkgconfig(Qt5Sql)
-BuildRequires:  pkgconfig(Qt5DBus)
-
-%description -n libsailfishcrypto
-%{summary}.
-
-%package -n libsailfishcrypto-devel
-Summary:    Development package for Sailfish OS cryptographic operations library
-Group:      System/Libraries
-Requires:   libsailfishcrypto = %{version}-%{release}
-
-%description -n libsailfishcrypto-devel
-%{summary}.
-
-%package -n libsailfishcrypto-tests
-Summary:    Unit tests for the libsailfishcrypto library.
-Group:      System/Libraries
-BuildRequires:  pkgconfig(Qt5Test)
-Requires:   libsailfishcrypto = %{version}-%{release}
-
-%description -n libsailfishcrypto-tests
-%{summary}.
 
 %package -n sailfishcryptodaemonplugins
 Summary:    Sailfish OS crypto daemon (example) plugins.
@@ -130,25 +149,33 @@ make %{?_smp_mflags}
 rm -rf %{buildroot}
 %qmake5_install
 
+mkdir -p %{buildroot}/%{_docdir}/Sailfish/Secrets/
+mkdir -p %{buildroot}/%{_docdir}/Sailfish/Crypto/
+cp -R lib/Secrets/doc/html/* %{buildroot}/%{_docdir}/Sailfish/Secrets/
+cp -R lib/Crypto/doc/html/* %{buildroot}/%{_docdir}/Sailfish/Crypto/
+
 %files
 %defattr(-,root,root,-)
 %{_libdir}/libsailfishsecrets.so.*
-
-%files -n libsailfishcrypto
-%defattr(-,root,root,-)
-%{_libdir}/libsailfishcrypto.so.*
 
 %files devel
 %defattr(-,root,root,-)
 %{_libdir}/libsailfishsecrets.so
 %{_libdir}/pkgconfig/sailfishsecrets.pc
-%{_includedir}/libsailfishsecrets/*
+%{_includedir}/Sailfish/Secrets/*
 
-%files -n libsailfishcrypto-devel
+%files doc
 %defattr(-,root,root,-)
-%{_libdir}/libsailfishcrypto.so
-%{_libdir}/pkgconfig/sailfishcrypto.pc
-%{_includedir}/libsailfishcrypto/*
+%{_docdir}/Sailfish/Secrets/*
+
+%files tests
+%defattr(-,root,root,-)
+/opt/tests/Sailfish/Secrets/tst_secrets
+/opt/tests/Sailfish/Secrets/tst_secrets.qml
+%{_libdir}/Sailfish/Secrets/libsailfishsecrets-testinappauth.so
+%{_libdir}/Sailfish/Secrets/libsailfishsecrets-testopenssl.so
+%{_libdir}/Sailfish/Secrets/libsailfishsecrets-testsqlcipher.so
+%{_libdir}/Sailfish/Secrets/libsailfishsecrets-testsqlite.so
 
 %files -n libsailfishsecretsplugin
 %defattr(-,root,root,-)
@@ -156,35 +183,40 @@ rm -rf %{buildroot}
 %{_libdir}/qt5/qml/Sailfish/Secrets/qmldir
 %{_libdir}/qt5/qml/Sailfish/Secrets/InteractionView.qml
 
+%files -n libsailfishcrypto
+%defattr(-,root,root,-)
+%{_libdir}/libsailfishcrypto.so.*
+
+%files -n libsailfishcrypto-devel
+%defattr(-,root,root,-)
+%{_libdir}/libsailfishcrypto.so
+%{_libdir}/pkgconfig/sailfishcrypto.pc
+%{_includedir}/Sailfish/Crypto/*
+
+%files -n libsailfishcrypto-doc
+%defattr(-,root,root,-)
+%{_docdir}/Sailfish/Crypto/*
+
+%files -n libsailfishcrypto-tests
+%defattr(-,root,root,-)
+/opt/tests/Sailfish/Crypto/tst_crypto
+/opt/tests/Sailfish/Crypto/tst_cryptosecrets
+%{_libdir}/Sailfish/Crypto/libsailfishcrypto-testopenssl.so
+
 %files -n sailfishsecretsdaemon
 %defattr(-,root,root,-)
 %{_bindir}/sailfishsecretsd
 
 %files -n sailfishsecretsdaemonplugins
 %defattr(-,root,root,-)
-%{_libdir}/sailfish/secrets/libsailfishsecrets-inappauth.so
-%{_libdir}/sailfish/secrets/libsailfishsecrets-openssl.so
-%{_libdir}/sailfish/secrets/libsailfishsecrets-sqlcipher.so
-%{_libdir}/sailfish/secrets/libsailfishsecrets-sqlite.so
+%{_libdir}/Sailfish/Secrets/libsailfishsecrets-inappauth.so
+%{_libdir}/Sailfish/Secrets/libsailfishsecrets-openssl.so
+%{_libdir}/Sailfish/Secrets/libsailfishsecrets-sqlcipher.so
+%{_libdir}/Sailfish/Secrets/libsailfishsecrets-sqlite.so
 
 %files -n sailfishcryptodaemonplugins
 %defattr(-,root,root,-)
-%{_libdir}/sailfish/crypto/libsailfishcrypto-openssl.so
-
-%files tests
-%defattr(-,root,root,-)
-/opt/tests/Sailfish/Secrets/tst_secrets
-/opt/tests/Sailfish/Secrets/tst_secrets.qml
-%{_libdir}/sailfish/secrets/libsailfishsecrets-testinappauth.so
-%{_libdir}/sailfish/secrets/libsailfishsecrets-testopenssl.so
-%{_libdir}/sailfish/secrets/libsailfishsecrets-testsqlcipher.so
-%{_libdir}/sailfish/secrets/libsailfishsecrets-testsqlite.so
-
-%files -n libsailfishcrypto-tests
-%defattr(-,root,root,-)
-/opt/tests/Sailfish/Crypto/tst_crypto
-/opt/tests/Sailfish/Crypto/tst_cryptosecrets
-%{_libdir}/sailfish/crypto/libsailfishcrypto-testopenssl.so
+%{_libdir}/Sailfish/Crypto/libsailfishcrypto-openssl.so
 
 %files -n qt5-plugin-sqldriver-sqlcipher
 %defattr(-,root,root,-)

--- a/tests/plugins/testinappauthplugin/testinappauthplugin.pro
+++ b/tests/plugins/testinappauthplugin/testinappauthplugin.pro
@@ -10,5 +10,5 @@ DEFINES += SAILFISHSECRETS_TESTPLUGIN
 HEADERS += $$PWD/../../../plugins/inappauthplugin/plugin.h
 SOURCES += $$PWD/../../../plugins/inappauthplugin/plugin.cpp
 
-target.path=/usr/lib/sailfish/secrets/
+target.path=/usr/lib/Sailfish/Secrets/
 INSTALLS += target

--- a/tests/plugins/testopensslcryptoplugin/testopensslcryptoplugin.pro
+++ b/tests/plugins/testopensslcryptoplugin/testopensslcryptoplugin.pro
@@ -18,5 +18,5 @@ SOURCES += \
 OTHER_FILES += \
     $$PWD/../../../plugins/opensslcryptoplugin/cryptoplugin_common.cpp
 
-target.path=/usr/lib/sailfish/crypto/
+target.path=/usr/lib/Sailfish/Crypto/
 INSTALLS += target

--- a/tests/plugins/testopensslplugin/testopensslplugin.pro
+++ b/tests/plugins/testopensslplugin/testopensslplugin.pro
@@ -15,5 +15,5 @@ HEADERS += \
 SOURCES += \
     $$PWD/../../../plugins/opensslplugin/plugin.cpp
 
-target.path=/usr/lib/sailfish/secrets/
+target.path=/usr/lib/Sailfish/Secrets/
 INSTALLS += target

--- a/tests/plugins/testsqlcipherplugin/testsqlcipherplugin.pro
+++ b/tests/plugins/testsqlcipherplugin/testsqlcipherplugin.pro
@@ -22,5 +22,5 @@ SOURCES += \
 OTHER_FILES += \
     $$PWD/../../plugins/opensslcryptoplugin/cryptoplugin_common.cpp
 
-target.path=/usr/lib/sailfish/secrets/
+target.path=/usr/lib/Sailfish/Secrets/
 INSTALLS += target

--- a/tests/plugins/testsqliteplugin/testsqliteplugin.pro
+++ b/tests/plugins/testsqliteplugin/testsqliteplugin.pro
@@ -16,5 +16,5 @@ HEADERS += \
 SOURCES += \
     $$PWD/../../../plugins/sqliteplugin/plugin.cpp
 
-target.path=/usr/lib/sailfish/secrets/
+target.path=/usr/lib/Sailfish/Secrets/
 INSTALLS += target


### PR DESCRIPTION
This commit adds documentation for the Sailfish OS Secrets and Crypto
Framework, including overview documentation for the Sailfish OS Secrets
Library and the Sailfish OS Crypto Library.

It also changes the install path of C++ plugins and devel headers
for symmetry with the install path for QML plugins and documentation.

Contributes to JB#36797