### PR TITLE
[sailfish-crypto] Allow the client to limit retrieve key data. Contributes to JB#40058

### DIFF
--- a/daemon/CryptoImpl/crypto_p.h
+++ b/daemon/CryptoImpl/crypto_p.h
@@ -13,6 +13,7 @@
 #include "applicationpermissions_p.h"
 
 #include "Crypto/extensionplugins.h"
+#include "Crypto/storedkeyrequest.h"
 
 #include <QtDBus/QDBusContext>
 
@@ -75,9 +76,11 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "      </method>\n"
     "      <method name=\"storedKey\">\n"
     "          <arg name=\"identifier\" type=\"(ss)\" direction=\"in\" />\n"
+    "          <arg name=\"keyComponents\" type=\"(i)\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"key\" type=\"(ay)\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Crypto::Key::Identifier\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In1\" value=\"Sailfish::Crypto::StoredKeyRequest::KeyComponents\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out1\" value=\"Sailfish::Crypto::Key\" />\n"
     "      </method>\n"
@@ -186,6 +189,7 @@ public Q_SLOTS:
 
     void storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
+            Sailfish::Crypto::StoredKeyRequest::KeyComponents keyComponents,
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result,
             Sailfish::Crypto::Key &key);

--- a/daemon/CryptoImpl/cryptorequestprocessor_p.h
+++ b/daemon/CryptoImpl/cryptorequestprocessor_p.h
@@ -24,6 +24,7 @@
 #include "Crypto/key.h"
 #include "Crypto/certificate.h"
 #include "Crypto/extensionplugins.h"
+#include "Crypto/storedkeyrequest.h"
 
 #include "CryptoImpl/crypto_p.h"
 
@@ -93,6 +94,7 @@ public:
             pid_t callerPid,
             quint64 requestId,
             const Sailfish::Crypto::Key::Identifier &identifier,
+            StoredKeyRequest::KeyComponents keyComponents,
             Sailfish::Crypto::Key *key);
 
     Sailfish::Crypto::Result deleteStoredKey(
@@ -186,6 +188,7 @@ private:
 
     void storedKey2(
             quint64 requestId,
+            StoredKeyRequest::KeyComponents keyComponents,
             const Sailfish::Crypto::Result &result,
             const QByteArray &serialisedKey,
             const QMap<QString, QString> &filterData);

--- a/lib/Crypto/cryptodaemonconnection.cpp
+++ b/lib/Crypto/cryptodaemonconnection.cpp
@@ -14,6 +14,7 @@
 #include "Crypto/key.h"
 #include "Crypto/certificate.h"
 #include "Crypto/extensionplugins.h"
+#include "Crypto/storedkeyrequest.h"
 
 #include <QtDBus/QDBusReply>
 #include <QtDBus/QDBusInterface>
@@ -172,6 +173,8 @@ void Sailfish::Crypto::CryptoDaemonConnection::registerDBusTypes()
     qRegisterMetaType<Sailfish::Crypto::Result>("Sailfish::Crypto::Result");
     qRegisterMetaType<Sailfish::Crypto::CryptoPluginInfo>("Sailfish::Crypto::CryptoPluginInfo");
     qRegisterMetaType<QVector<Sailfish::Crypto::CryptoPluginInfo> >("QVector<Sailfish::Crypto::CryptoPluginInfo>");
+    qRegisterMetaType<Sailfish::Crypto::StoredKeyRequest::KeyComponent>("Sailfish::Crypto::StoredKeyRequest::KeyComponent");
+    qRegisterMetaType<Sailfish::Crypto::StoredKeyRequest::KeyComponents>("Sailfish::Crypto::StoredKeyRequest::KeyComponents");
 
     qDBusRegisterMetaType<Sailfish::Crypto::Key::Origin>();
     qDBusRegisterMetaType<Sailfish::Crypto::Key::Algorithm>();
@@ -193,4 +196,6 @@ void Sailfish::Crypto::CryptoDaemonConnection::registerDBusTypes()
     qDBusRegisterMetaType<Sailfish::Crypto::Result>();
     qDBusRegisterMetaType<Sailfish::Crypto::CryptoPluginInfo>();
     qDBusRegisterMetaType<QVector<Sailfish::Crypto::CryptoPluginInfo> >();
+    qDBusRegisterMetaType<Sailfish::Crypto::StoredKeyRequest::KeyComponent>();
+    qDBusRegisterMetaType<Sailfish::Crypto::StoredKeyRequest::KeyComponents>();
 }

--- a/lib/Crypto/cryptomanager.cpp
+++ b/lib/Crypto/cryptomanager.cpp
@@ -137,7 +137,8 @@ CryptoManagerPrivate::generateStoredKey(
 
 QDBusPendingReply<Result, Key>
 CryptoManagerPrivate::storedKey(
-        const Key::Identifier &identifier) // TODO: do we need parameter: just get metadata/public vs get private data, etc?
+        const Key::Identifier &identifier,
+        StoredKeyRequest::KeyComponents keyComponents)
 {
     if (!m_interface) {
         return QDBusPendingReply<Result, Key>(
@@ -148,7 +149,8 @@ CryptoManagerPrivate::storedKey(
     QDBusPendingReply<Result, Key> reply
             = m_interface->asyncCallWithArgumentList(
                 "storedKey",
-                QVariantList() << QVariant::fromValue<Key::Identifier>(identifier));
+                QVariantList() << QVariant::fromValue<Key::Identifier>(identifier)
+                               << QVariant::fromValue<StoredKeyRequest::KeyComponents>(keyComponents));
     return reply;
 }
 

--- a/lib/Crypto/cryptomanager_p.h
+++ b/lib/Crypto/cryptomanager_p.h
@@ -15,6 +15,7 @@
 #include "Crypto/key.h"
 #include "Crypto/certificate.h"
 #include "Crypto/extensionplugins.h"
+#include "Crypto/storedkeyrequest.h"
 
 #include <QtDBus/QDBusContext>
 #include <QtDBus/QDBusPendingReply>
@@ -55,7 +56,8 @@ public:
             const QString &storageProviderName);
 
     QDBusPendingReply<Sailfish::Crypto::Result, Sailfish::Crypto::Key> storedKey(
-            const Sailfish::Crypto::Key::Identifier &identifier);
+            const Sailfish::Crypto::Key::Identifier &identifier,
+            StoredKeyRequest::KeyComponents keyComponents);
 
     QDBusPendingReply<Sailfish::Crypto::Result> deleteStoredKey(
             const Sailfish::Crypto::Key::Identifier &identifier);

--- a/lib/Crypto/extensionplugins.h
+++ b/lib/Crypto/extensionplugins.h
@@ -12,6 +12,7 @@
 #include "Crypto/certificate.h"
 #include "Crypto/key.h"
 #include "Crypto/result.h"
+#include "Crypto/storedkeyrequest.h"
 
 #include <QtCore/QObject>
 #include <QtCore/QString>
@@ -66,6 +67,7 @@ public:
 
     virtual Sailfish::Crypto::Result storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
+            Sailfish::Crypto::StoredKeyRequest::KeyComponents keyComponents,
             Sailfish::Crypto::Key *key) = 0;
 
     // This doesn't exist - if you can store keys, then you must also

--- a/lib/Crypto/key.h
+++ b/lib/Crypto/key.h
@@ -122,7 +122,7 @@ public:
 
     class Identifier {
     public:
-        Identifier(const QString &name = QString(), const QString &collectionName = QString())
+        explicit Identifier(const QString &name = QString(), const QString &collectionName = QString())
             : m_name(name), m_collectionName(collectionName) {}
         Identifier(const Sailfish::Crypto::Key::Identifier &other)
             : m_name(other.m_name), m_collectionName(other.m_collectionName) {}

--- a/lib/Crypto/serialisation.cpp
+++ b/lib/Crypto/serialisation.cpp
@@ -745,6 +745,42 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, Key::Operations &
     return argument;
 }
 
+QDBusArgument &operator<<(QDBusArgument &argument, const StoredKeyRequest::KeyComponent component)
+{
+    argument.beginStructure();
+    argument << static_cast<int>(component);
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, StoredKeyRequest::KeyComponent &component)
+{
+    int iv = 0;
+    argument.beginStructure();
+    argument >> iv;
+    argument.endStructure();
+    component = static_cast<StoredKeyRequest::KeyComponent>(iv);
+    return argument;
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument, const StoredKeyRequest::KeyComponents components)
+{
+    argument.beginStructure();
+    argument << static_cast<int>(components);
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, StoredKeyRequest::KeyComponents &components)
+{
+    int iv = 0;
+    argument.beginStructure();
+    argument >> iv;
+    argument.endStructure();
+    components = static_cast<StoredKeyRequest::KeyComponents>(iv);
+    return argument;
+}
+
 QDBusArgument &operator<<(QDBusArgument &argument, const Result &result)
 {
     argument.beginStructure();

--- a/lib/Crypto/serialisation_p.h
+++ b/lib/Crypto/serialisation_p.h
@@ -19,6 +19,7 @@
 #include "Crypto/extensionplugins.h"
 #include "Crypto/key.h"
 #include "Crypto/result.h"
+#include "Crypto/storedkeyrequest.h"
 
 #include <QtDBus/QDBusArgument>
 #include <QtDBus/QDBusMetaType>
@@ -64,6 +65,11 @@ QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::Key::
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::Key::Digests &digests) SAILFISH_CRYPTO_API;
 QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::Key::Operations operations) SAILFISH_CRYPTO_API;
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::Key::Operations &operations) SAILFISH_CRYPTO_API;
+
+QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::StoredKeyRequest::KeyComponent component) SAILFISH_CRYPTO_API;
+const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::StoredKeyRequest::KeyComponent &component) SAILFISH_CRYPTO_API;
+QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::StoredKeyRequest::KeyComponents components) SAILFISH_CRYPTO_API;
+const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::StoredKeyRequest::KeyComponents &components) SAILFISH_CRYPTO_API;
 
 QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::Result &result) SAILFISH_CRYPTO_API;
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::Result &result) SAILFISH_CRYPTO_API;

--- a/lib/Crypto/storedkeyrequest.h
+++ b/lib/Crypto/storedkeyrequest.h
@@ -26,14 +26,27 @@ class SAILFISH_CRYPTO_API StoredKeyRequest : public Sailfish::Crypto::Request
 {
     Q_OBJECT
     Q_PROPERTY(Sailfish::Crypto::Key::Identifier identifier READ identifier NOTIFY identifierChanged)
+    Q_PROPERTY(KeyComponents keyComponents READ keyComponents WRITE setKeyComponents NOTIFY keyComponentsChanged)
     Q_PROPERTY(Sailfish::Crypto::Key storedKey READ storedKey NOTIFY storedKeyChanged)
 
 public:
+    enum KeyComponent {
+        NoData          = 0,
+        MetaData        = 1,
+        PublicKeyData   = 2,
+        SecretKeyData   = 4
+    };
+    Q_DECLARE_FLAGS(KeyComponents, KeyComponent)
+    Q_FLAG(KeyComponents)
+
     StoredKeyRequest(QObject *parent = Q_NULLPTR);
     ~StoredKeyRequest();
 
     Sailfish::Crypto::Key::Identifier identifier() const;
     void setIdentifier(const Sailfish::Crypto::Key::Identifier &ident);
+
+    KeyComponents keyComponents() const;
+    void setKeyComponents(KeyComponents components);
 
     Sailfish::Crypto::Key storedKey() const;
 
@@ -48,6 +61,7 @@ public:
 
 Q_SIGNALS:
     void identifierChanged();
+    void keyComponentsChanged();
     void storedKeyChanged();
 
 private:
@@ -58,5 +72,9 @@ private:
 } // namespace Crypto
 
 } // namespace Sailfish
+
+Q_DECLARE_METATYPE(Sailfish::Crypto::StoredKeyRequest::KeyComponent);
+Q_DECLARE_METATYPE(Sailfish::Crypto::StoredKeyRequest::KeyComponents);
+Q_DECLARE_OPERATORS_FOR_FLAGS(Sailfish::Crypto::StoredKeyRequest::KeyComponents);
 
 #endif // LIBSAILFISHCRYPTO_STOREDKEYREQUEST_H

--- a/lib/Crypto/storedkeyrequest_p.h
+++ b/lib/Crypto/storedkeyrequest_p.h
@@ -31,6 +31,7 @@ public:
 
     QPointer<Sailfish::Crypto::CryptoManager> m_manager;
     Sailfish::Crypto::Key::Identifier m_identifier;
+    StoredKeyRequest::KeyComponents m_keyComponents;
     Sailfish::Crypto::Key m_storedKey;
 
     QScopedPointer<QDBusPendingCallWatcher> m_watcher;

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
@@ -46,9 +46,11 @@ Daemon::Plugins::OpenSslCryptoPlugin::generateAndStoreKey(
 Result
 Daemon::Plugins::OpenSslCryptoPlugin::storedKey(
         const Key::Identifier &identifier,
+        StoredKeyRequest::KeyComponents keyComponents,
         Key *key)
 {
     Q_UNUSED(identifier);
+    Q_UNUSED(keyComponents);
     Q_UNUSED(key);
     return Result(Result::UnsupportedOperation,
                   QLatin1String("The OpenSSL crypto plugin doesn't support storing keys"));

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.h
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.h
@@ -65,6 +65,7 @@ public:
 
     Sailfish::Crypto::Result storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
+            Sailfish::Crypto::StoredKeyRequest::KeyComponents keyComponents,
             Sailfish::Crypto::Key *key) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result storedKeyIdentifiers(

--- a/plugins/sqlcipherplugin/sqlcipherplugin.h
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.h
@@ -115,6 +115,7 @@ public:
 
     Sailfish::Crypto::Result storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
+            Sailfish::Crypto::StoredKeyRequest::KeyComponents keyComponents,
             Sailfish::Crypto::Key *key) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result storedKeyIdentifiers(


### PR DESCRIPTION
Previously, the StoredKeyRequest would retrieve all of the data
associated with a key entry, including metadata, public key data, and
private key data.  This commit allows the client to specify which
of these portions of data they wish to retrieve.

This allows, for example, the client to retrieve just the public
key data portion, allowing the client to limit potential secret
key data leakage in the case where they suspect that the secrecy
of their process's memory address space may be compromised.

Contributes to JB#40058