### PR TITLE
[sailfish-crypto] Improve the encrypt/decrypt client API. Contributes to JB#40058

### DIFF
--- a/daemon/CryptoImpl/crypto.cpp
+++ b/daemon/CryptoImpl/crypto.cpp
@@ -239,10 +239,10 @@ void Daemon::ApiImpl::CryptoDBusObject::verify(
 
 void Daemon::ApiImpl::CryptoDBusObject::encrypt(
         const QByteArray &data,
+        const QByteArray &iv,
         const Key &key,
         Key::BlockMode blockMode,
         Key::EncryptionPadding padding,
-        Key::Digest digest,
         const QString &cryptosystemProviderName,
         const QDBusMessage &message,
         Result &result,
@@ -251,10 +251,10 @@ void Daemon::ApiImpl::CryptoDBusObject::encrypt(
     Q_UNUSED(encrypted);  // outparam, set in handlePendingRequest / handleFinishedRequest
     QList<QVariant> inParams;
     inParams << QVariant::fromValue<QByteArray>(data);
+    inParams << QVariant::fromValue<QByteArray>(iv);
     inParams << QVariant::fromValue<Key>(key);
     inParams << QVariant::fromValue<Key::BlockMode>(blockMode);
     inParams << QVariant::fromValue<Key::EncryptionPadding>(padding);
-    inParams << QVariant::fromValue<Key::Digest>(digest);
     inParams << QVariant::fromValue<QString>(cryptosystemProviderName);
     m_requestQueue->handleRequest(Daemon::ApiImpl::EncryptRequest,
                                   inParams,
@@ -265,10 +265,10 @@ void Daemon::ApiImpl::CryptoDBusObject::encrypt(
 
 void Daemon::ApiImpl::CryptoDBusObject::decrypt(
         const QByteArray &data,
+        const QByteArray &iv,
         const Key &key,
         Key::BlockMode blockMode,
         Key::EncryptionPadding padding,
-        Key::Digest digest,
         const QString &cryptosystemProviderName,
         const QDBusMessage &message,
         Result &result,
@@ -277,10 +277,10 @@ void Daemon::ApiImpl::CryptoDBusObject::decrypt(
     Q_UNUSED(decrypted);  // outparam, set in handlePendingRequest / handleFinishedRequest
     QList<QVariant> inParams;
     inParams << QVariant::fromValue<QByteArray>(data);
+    inParams << QVariant::fromValue<QByteArray>(iv);
     inParams << QVariant::fromValue<Key>(key);
     inParams << QVariant::fromValue<Key::BlockMode>(blockMode);
     inParams << QVariant::fromValue<Key::EncryptionPadding>(padding);
-    inParams << QVariant::fromValue<Key::Digest>(digest);
     inParams << QVariant::fromValue<QString>(cryptosystemProviderName);
     m_requestQueue->handleRequest(Daemon::ApiImpl::DecryptRequest,
                                   inParams,
@@ -605,19 +605,19 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
             qCDebug(lcSailfishCryptoDaemon) << "Handling EncryptRequest from client:" << request->remotePid << ", request number:" << request->requestId;
             QByteArray encrypted;
             QByteArray data = request->inParams.size() ? request->inParams.takeFirst().value<QByteArray>() : QByteArray();
+            QByteArray iv = request->inParams.size() ? request->inParams.takeFirst().value<QByteArray>() : QByteArray();
             Key key = request->inParams.size() ? request->inParams.takeFirst().value<Key>() : Key();
             Key::BlockMode blockMode = request->inParams.size() ? request->inParams.takeFirst().value<Key::BlockMode>() : Key::BlockModeUnknown;
             Key::EncryptionPadding padding = request->inParams.size() ? request->inParams.takeFirst().value<Key::EncryptionPadding>() : Key::EncryptionPaddingUnknown;
-            Key::Digest digest = request->inParams.size() ? request->inParams.takeFirst().value<Key::Digest>() : Key::DigestUnknown;
             QString cryptosystemProviderName = request->inParams.size() ? request->inParams.takeFirst().value<QString>() : QString();
             Result result = m_requestProcessor->encrypt(
                         request->remotePid,
                         request->requestId,
                         data,
+                        iv,
                         key,
                         blockMode,
                         padding,
-                        digest,
                         cryptosystemProviderName,
                         &encrypted);
             // send the reply to the calling peer.
@@ -635,19 +635,19 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
             qCDebug(lcSailfishCryptoDaemon) << "Handling DecryptRequest from client:" << request->remotePid << ", request number:" << request->requestId;
             QByteArray decrypted;
             QByteArray data = request->inParams.size() ? request->inParams.takeFirst().value<QByteArray>() : QByteArray();
+            QByteArray iv = request->inParams.size() ? request->inParams.takeFirst().value<QByteArray>() : QByteArray();
             Key key = request->inParams.size() ? request->inParams.takeFirst().value<Key>() : Key();
             Key::BlockMode blockMode = request->inParams.size() ? request->inParams.takeFirst().value<Key::BlockMode>() : Key::BlockModeUnknown;
             Key::EncryptionPadding padding = request->inParams.size() ? request->inParams.takeFirst().value<Key::EncryptionPadding>() : Key::EncryptionPaddingUnknown;
-            Key::Digest digest = request->inParams.size() ? request->inParams.takeFirst().value<Key::Digest>() : Key::DigestUnknown;
             QString cryptosystemProviderName = request->inParams.size() ? request->inParams.takeFirst().value<QString>() : QString();
             Result result = m_requestProcessor->decrypt(
                         request->remotePid,
                         request->requestId,
                         data,
+                        iv,
                         key,
                         blockMode,
                         padding,
-                        digest,
                         cryptosystemProviderName,
                         &decrypted);
             // send the reply to the calling peer.

--- a/daemon/CryptoImpl/crypto_p.h
+++ b/daemon/CryptoImpl/crypto_p.h
@@ -140,32 +140,30 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "      </method>\n"
     "      <method name=\"encrypt\">\n"
     "          <arg name=\"data\" type=\"ay\" direction=\"in\" />\n"
+    "          <arg name=\"iv\" type=\"ay\" direction=\"in\" />\n"
     "          <arg name=\"key\" type=\"(ay)\" direction=\"in\" />\n"
     "          <arg name=\"blockMode\" type=\"(i)\" direction=\"in\" />\n"
     "          <arg name=\"padding\" type=\"(i)\" direction=\"in\" />\n"
-    "          <arg name=\"digest\" type=\"(i)\" direction=\"in\" />\n"
     "          <arg name=\"cryptosystemProviderName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"encrypted\" type=\"ay\" direction=\"out\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In1\" value=\"Sailfish::Crypto::Key\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::Key::BlockMode\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Crypto::Key::EncryptionPadding\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In4\" value=\"Sailfish::Crypto::Key::Digest\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::Key\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Crypto::Key::BlockMode\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In4\" value=\"Sailfish::Crypto::Key::EncryptionPadding\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
     "      </method>\n"
     "      <method name=\"decrypt\">\n"
     "          <arg name=\"data\" type=\"ay\" direction=\"in\" />\n"
+    "          <arg name=\"iv\" type=\"ay\" direction=\"in\" />\n"
     "          <arg name=\"key\" type=\"(ay)\" direction=\"in\" />\n"
     "          <arg name=\"blockMode\" type=\"(i)\" direction=\"in\" />\n"
     "          <arg name=\"padding\" type=\"(i)\" direction=\"in\" />\n"
-    "          <arg name=\"digest\" type=\"(i)\" direction=\"in\" />\n"
     "          <arg name=\"cryptosystemProviderName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"decrypted\" type=\"ay\" direction=\"out\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In1\" value=\"Sailfish::Crypto::Key\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::Key::BlockMode\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Crypto::Key::EncryptionPadding\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In4\" value=\"Sailfish::Crypto::Key::Digest\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::Key\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Crypto::Key::BlockMode\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In4\" value=\"Sailfish::Crypto::Key::EncryptionPadding\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
     "      </method>\n"
     "  </interface>\n"
@@ -258,10 +256,10 @@ public Q_SLOTS:
 
     void encrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key,
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             const QString &cryptosystemProviderName,
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result,
@@ -269,10 +267,10 @@ public Q_SLOTS:
 
     void decrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key,
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             const QString &cryptosystemProviderName,
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result,

--- a/daemon/CryptoImpl/cryptorequestprocessor_p.h
+++ b/daemon/CryptoImpl/cryptorequestprocessor_p.h
@@ -147,10 +147,10 @@ public:
             pid_t callerPid,
             quint64 requestId,
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key,
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             const QString &cryptosystemProviderName,
             QByteArray *encrypted);
 
@@ -158,10 +158,10 @@ public:
             pid_t callerPid,
             quint64 requestId,
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key,
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             const QString &cryptosystemProviderName,
             QByteArray *decrypted);
 
@@ -261,9 +261,9 @@ private:
             const Sailfish::Crypto::Result &result,
             const QByteArray &serialisedKey,
             const QByteArray &data,
+            const QByteArray &iv,
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             const QString &cryptoPluginName);
 
     void decrypt2(
@@ -271,9 +271,9 @@ private:
             const Sailfish::Crypto::Result &result,
             const QByteArray &serialisedKey,
             const QByteArray &data,
+            const QByteArray &iv,
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             const QString &cryptoPluginName);
 
 private:

--- a/lib/Crypto/cryptomanager.cpp
+++ b/lib/Crypto/cryptomanager.cpp
@@ -282,10 +282,10 @@ CryptoManagerPrivate::verify(
 QDBusPendingReply<Result, QByteArray>
 CryptoManagerPrivate::encrypt(
         const QByteArray &data,
+        const QByteArray &iv,
         const Key &key, // or keyreference, i.e. Key(keyName)
         Key::BlockMode blockMode,
         Key::EncryptionPadding padding,
-        Key::Digest digest,
         const QString &cryptosystemProviderName)
 {
     if (!m_interface) {
@@ -298,10 +298,10 @@ CryptoManagerPrivate::encrypt(
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("encrypt"),
                 QVariantList() << QVariant::fromValue<QByteArray>(data)
+                               << QVariant::fromValue<QByteArray>(iv)
                                << QVariant::fromValue<Key>(key)
                                << QVariant::fromValue<Key::BlockMode>(blockMode)
                                << QVariant::fromValue<Key::EncryptionPadding>(padding)
-                               << QVariant::fromValue<Key::Digest>(digest)
                                << QVariant::fromValue<QString>(cryptosystemProviderName));
     return reply;
 }
@@ -309,10 +309,10 @@ CryptoManagerPrivate::encrypt(
 QDBusPendingReply<Result, QByteArray>
 CryptoManagerPrivate::decrypt(
         const QByteArray &data,
+        const QByteArray &iv,
         const Key &key, // or keyreference, i.e. Key(keyName)
         Key::BlockMode blockMode,
         Key::EncryptionPadding padding,
-        Key::Digest digest,
         const QString &cryptosystemProviderName)
 {
     if (!m_interface) {
@@ -325,10 +325,10 @@ CryptoManagerPrivate::decrypt(
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("decrypt"),
                 QVariantList() << QVariant::fromValue<QByteArray>(data)
+                               << QVariant::fromValue<QByteArray>(iv)
                                << QVariant::fromValue<Key>(key)
                                << QVariant::fromValue<Key::BlockMode>(blockMode)
                                << QVariant::fromValue<Key::EncryptionPadding>(padding)
-                               << QVariant::fromValue<Key::Digest>(digest)
                                << QVariant::fromValue<QString>(cryptosystemProviderName));
     return reply;
 }

--- a/lib/Crypto/cryptomanager_p.h
+++ b/lib/Crypto/cryptomanager_p.h
@@ -94,18 +94,18 @@ public:
 
     QDBusPendingReply<Sailfish::Crypto::Result, QByteArray> encrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key, // or keyreference, i.e. Key(keyName)
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             const QString &cryptosystemProviderName);
 
     QDBusPendingReply<Sailfish::Crypto::Result, QByteArray> decrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key, // or keyreference, i.e. Key(keyName)
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             const QString &cryptosystemProviderName);
 
     // do we also need "continueEncrypt(data, ...)" etc?  Do we need "cipher sessions"?  what about denial of service / resource exhaustion etc?

--- a/lib/Crypto/decryptrequest.h
+++ b/lib/Crypto/decryptrequest.h
@@ -28,10 +28,10 @@ class SAILFISH_CRYPTO_API DecryptRequest : public Sailfish::Crypto::Request
 {
     Q_OBJECT
     Q_PROPERTY(QByteArray data READ data WRITE setData NOTIFY dataChanged)
+    Q_PROPERTY(QByteArray initialisationVector READ initialisationVector WRITE setInitialisationVector NOTIFY initialisationVectorChanged)
     Q_PROPERTY(Sailfish::Crypto::Key key READ key WRITE setKey NOTIFY keyChanged)
     Q_PROPERTY(Sailfish::Crypto::Key::BlockMode blockMode READ blockMode WRITE setBlockMode NOTIFY blockModeChanged)
     Q_PROPERTY(Sailfish::Crypto::Key::EncryptionPadding padding READ padding WRITE setPadding NOTIFY paddingChanged)
-    Q_PROPERTY(Sailfish::Crypto::Key::Digest digest READ digest WRITE setDigest NOTIFY digestChanged)
     Q_PROPERTY(QString cryptoPluginName READ cryptoPluginName WRITE setCryptoPluginName NOTIFY cryptoPluginNameChanged)
     Q_PROPERTY(QByteArray plaintext READ plaintext NOTIFY plaintextChanged)
 
@@ -42,6 +42,9 @@ public:
     QByteArray data() const;
     void setData(const QByteArray &data);
 
+    QByteArray initialisationVector() const;
+    void setInitialisationVector(const QByteArray &iv);
+
     Sailfish::Crypto::Key key() const;
     void setKey(const Sailfish::Crypto::Key &key);
 
@@ -50,9 +53,6 @@ public:
 
     Sailfish::Crypto::Key::EncryptionPadding padding() const;
     void setPadding(Sailfish::Crypto::Key::EncryptionPadding padding);
-
-    Sailfish::Crypto::Key::Digest digest() const;
-    void setDigest(Sailfish::Crypto::Key::Digest digest);
 
     QString cryptoPluginName() const;
     void setCryptoPluginName(const QString &pluginName);
@@ -70,10 +70,10 @@ public:
 
 Q_SIGNALS:
     void dataChanged();
+    void initialisationVectorChanged();
     void keyChanged();
     void blockModeChanged();
     void paddingChanged();
-    void digestChanged();
     void cryptoPluginNameChanged();
     void plaintextChanged();
 

--- a/lib/Crypto/decryptrequest_p.h
+++ b/lib/Crypto/decryptrequest_p.h
@@ -31,10 +31,10 @@ public:
 
     QPointer<Sailfish::Crypto::CryptoManager> m_manager;
     QByteArray m_data;
+    QByteArray m_initialisationVector;
     Sailfish::Crypto::Key m_key;
     Sailfish::Crypto::Key::BlockMode m_blockMode;
     Sailfish::Crypto::Key::EncryptionPadding m_padding;
-    Sailfish::Crypto::Key::Digest m_digest;
     QString m_cryptoPluginName;
     QByteArray m_plaintext;
 

--- a/lib/Crypto/encryptrequest.h
+++ b/lib/Crypto/encryptrequest.h
@@ -28,10 +28,10 @@ class SAILFISH_CRYPTO_API EncryptRequest : public Sailfish::Crypto::Request
 {
     Q_OBJECT
     Q_PROPERTY(QByteArray data READ data WRITE setData NOTIFY dataChanged)
+    Q_PROPERTY(QByteArray initialisationVector READ initialisationVector WRITE setInitialisationVector NOTIFY initialisationVectorChanged)
     Q_PROPERTY(Sailfish::Crypto::Key key READ key WRITE setKey NOTIFY keyChanged)
     Q_PROPERTY(Sailfish::Crypto::Key::BlockMode blockMode READ blockMode WRITE setBlockMode NOTIFY blockModeChanged)
     Q_PROPERTY(Sailfish::Crypto::Key::EncryptionPadding padding READ padding WRITE setPadding NOTIFY paddingChanged)
-    Q_PROPERTY(Sailfish::Crypto::Key::Digest digest READ digest WRITE setDigest NOTIFY digestChanged)
     Q_PROPERTY(QString cryptoPluginName READ cryptoPluginName WRITE setCryptoPluginName NOTIFY cryptoPluginNameChanged)
     Q_PROPERTY(QByteArray ciphertext READ ciphertext NOTIFY ciphertextChanged)
 
@@ -42,6 +42,9 @@ public:
     QByteArray data() const;
     void setData(const QByteArray &data);
 
+    QByteArray initialisationVector() const;
+    void setInitialisationVector(const QByteArray &iv);
+
     Sailfish::Crypto::Key key() const;
     void setKey(const Sailfish::Crypto::Key &key);
 
@@ -50,9 +53,6 @@ public:
 
     Sailfish::Crypto::Key::EncryptionPadding padding() const;
     void setPadding(Sailfish::Crypto::Key::EncryptionPadding padding);
-
-    Sailfish::Crypto::Key::Digest digest() const;
-    void setDigest(Sailfish::Crypto::Key::Digest digest);
 
     QString cryptoPluginName() const;
     void setCryptoPluginName(const QString &pluginName);
@@ -70,10 +70,10 @@ public:
 
 Q_SIGNALS:
     void dataChanged();
+    void initialisationVectorChanged();
     void keyChanged();
     void blockModeChanged();
     void paddingChanged();
-    void digestChanged();
     void cryptoPluginNameChanged();
     void ciphertextChanged();
 

--- a/lib/Crypto/encryptrequest_p.h
+++ b/lib/Crypto/encryptrequest_p.h
@@ -31,10 +31,10 @@ public:
 
     QPointer<Sailfish::Crypto::CryptoManager> m_manager;
     QByteArray m_data;
+    QByteArray m_initialisationVector;
     Sailfish::Crypto::Key m_key;
     Sailfish::Crypto::Key::BlockMode m_blockMode;
     Sailfish::Crypto::Key::EncryptionPadding m_padding;
-    Sailfish::Crypto::Key::Digest m_digest;
     QString m_cryptoPluginName;
     QByteArray m_ciphertext;
 

--- a/lib/Crypto/extensionplugins.h
+++ b/lib/Crypto/extensionplugins.h
@@ -107,18 +107,18 @@ public:
 
     virtual Sailfish::Crypto::Result encrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key,
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             QByteArray *encrypted) = 0;
 
     virtual Sailfish::Crypto::Result decrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key, // or keyreference, i.e. Key(keyName)
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             QByteArray *decrypted) = 0;
 };
 

--- a/plugins/opensslcryptoplugin/cryptoplugin_common.cpp
+++ b/plugins/opensslcryptoplugin/cryptoplugin_common.cpp
@@ -174,10 +174,10 @@ CRYPTOPLUGINCOMMON_NAMESPACE::CRYPTOPLUGINCOMMON_CLASS::verify(
 Sailfish::Crypto::Result
 CRYPTOPLUGINCOMMON_NAMESPACE::CRYPTOPLUGINCOMMON_CLASS::encrypt(
         const QByteArray &data,
+        const QByteArray &iv,
         const Sailfish::Crypto::Key &key,
         Sailfish::Crypto::Key::BlockMode blockMode,
         Sailfish::Crypto::Key::EncryptionPadding padding,
-        Sailfish::Crypto::Key::Digest digest,
         QByteArray *encrypted)
 {
     if (key.algorithm() != Sailfish::Crypto::Key::Aes256) {
@@ -195,22 +195,15 @@ CRYPTOPLUGINCOMMON_NAMESPACE::CRYPTOPLUGINCOMMON_CLASS::encrypt(
                                         QLatin1String("TODO: encryption padding other than None"));
     }
 
-    if (digest != Sailfish::Crypto::Key::DigestSha256) {
-        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedOperation,
-                                        QLatin1String("TODO: digests other than Sha256"));
-    }
-
     if (key.secretKey().isEmpty()) {
         return Sailfish::Crypto::Result(Sailfish::Crypto::Result::EmptySecretKey,
                                         QLatin1String("Cannot encrypt with empty secret key"));
     }
 
-    // generate initialisation vector and key hash
+    // generate key hash and normalise init vector
     QCryptographicHash keyHash(QCryptographicHash::Sha512);
     keyHash.addData(key.secretKey());
-    QCryptographicHash ivHash(QCryptographicHash::Sha256);
-    ivHash.addData(key.secretKey());
-    QByteArray initVector = ivHash.result();
+    QByteArray initVector = iv;
     if (initVector.size() > 16) {
         initVector.chop(initVector.size() - 16);
     } else while (initVector.size() < 16) {
@@ -233,10 +226,10 @@ CRYPTOPLUGINCOMMON_NAMESPACE::CRYPTOPLUGINCOMMON_CLASS::encrypt(
 Sailfish::Crypto::Result
 CRYPTOPLUGINCOMMON_NAMESPACE::CRYPTOPLUGINCOMMON_CLASS::decrypt(
         const QByteArray &data,
+        const QByteArray &iv,
         const Sailfish::Crypto::Key &key,
         Sailfish::Crypto::Key::BlockMode blockMode,
         Sailfish::Crypto::Key::EncryptionPadding padding,
-        Sailfish::Crypto::Key::Digest digest,
         QByteArray *decrypted)
 {
 
@@ -255,22 +248,15 @@ CRYPTOPLUGINCOMMON_NAMESPACE::CRYPTOPLUGINCOMMON_CLASS::decrypt(
                                         QLatin1String("TODO: encryption padding other than None"));
     }
 
-    if (digest != Sailfish::Crypto::Key::DigestSha256) {
-        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedOperation,
-                                        QLatin1String("TODO: digests other than Sha256"));
-    }
-
     if (key.secretKey().isEmpty()) {
         return Sailfish::Crypto::Result(Sailfish::Crypto::Result::EmptySecretKey,
                                         QLatin1String("Cannot encrypt with empty secret key"));
     }
 
-    // generate initialisation vector and key hash
+    // generate key hash and normalise init vector
     QCryptographicHash keyHash(QCryptographicHash::Sha512);
     keyHash.addData(key.secretKey());
-    QCryptographicHash ivHash(QCryptographicHash::Sha256);
-    ivHash.addData(key.secretKey());
-    QByteArray initVector = ivHash.result();
+    QByteArray initVector = iv;
     if (initVector.size() > 16) {
         initVector.chop(initVector.size() - 16);
     } else while (initVector.size() < 16) {

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.h
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.h
@@ -99,18 +99,18 @@ public:
 
     Sailfish::Crypto::Result encrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key,
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             QByteArray *encrypted) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result decrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key, // or keyreference, i.e. Key(keyName)
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             QByteArray *decrypted) Q_DECL_OVERRIDE;
 
 private:

--- a/plugins/sqlcipherplugin/sqlcipherplugin.h
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.h
@@ -149,18 +149,18 @@ public:
 
     Sailfish::Crypto::Result encrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key,
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             QByteArray *encrypted) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result decrypt(
             const QByteArray &data,
+            const QByteArray &iv,
             const Sailfish::Crypto::Key &key, // or keyreference, i.e. Key(keyName)
             Sailfish::Crypto::Key::BlockMode blockMode,
             Sailfish::Crypto::Key::EncryptionPadding padding,
-            Sailfish::Crypto::Key::Digest digest,
             QByteArray *decrypted) Q_DECL_OVERRIDE;
 
 private:

--- a/tests/Crypto/tst_crypto/tst_crypto.cpp
+++ b/tests/Crypto/tst_crypto/tst_crypto.cpp
@@ -146,12 +146,13 @@ void tst_crypto::generateKeyEncryptDecrypt()
 
     // test encrypting some plaintext with the generated key
     QByteArray plaintext = "Test plaintext data";
+    QByteArray initVector = "Test initialisation vector";
     QDBusPendingReply<Result, QByteArray> encryptReply = cm.encrypt(
             plaintext,
+            initVector,
             fullKey,
             Key::BlockModeCBC,
             Key::EncryptionPaddingNone,
-            Key::DigestSha256,
             CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(encryptReply);
     QVERIFY(encryptReply.isValid());
@@ -163,10 +164,10 @@ void tst_crypto::generateKeyEncryptDecrypt()
     // test decrypting the ciphertext, and ensure that the roundtrip works.
     QDBusPendingReply<Result, QByteArray> decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             fullKey,
             Key::BlockModeCBC,
             Key::EncryptionPaddingNone,
-            Key::DigestSha256,
             CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());

--- a/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
+++ b/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
@@ -224,20 +224,21 @@ void tst_cryptorequests::generateKeyEncryptDecrypt()
 
     // test encrypting some plaintext with the generated key
     QByteArray plaintext = "Test plaintext data";
+    QByteArray initVector = "Test initialisation vector";
     EncryptRequest er;
     er.setManager(&cm);
     QSignalSpy erss(&er, &EncryptRequest::statusChanged);
     QSignalSpy ercs(&er, &EncryptRequest::ciphertextChanged);
     er.setData(plaintext);
     QCOMPARE(er.data(), plaintext);
+    er.setInitialisationVector(initVector);
+    QCOMPARE(er.initialisationVector(), initVector);
     er.setKey(fullKey);
     QCOMPARE(er.key(), fullKey);
     er.setBlockMode(Key::BlockModeCBC);
     QCOMPARE(er.blockMode(), Key::BlockModeCBC);
     er.setPadding(Key::EncryptionPaddingNone);
     QCOMPARE(er.padding(), Key::EncryptionPaddingNone);
-    er.setDigest(Key::DigestSha256);
-    QCOMPARE(er.digest(), Key::DigestSha256);
     er.setCryptoPluginName(DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(er.cryptoPluginName(), DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(er.status(), Request::Inactive);
@@ -262,14 +263,14 @@ void tst_cryptorequests::generateKeyEncryptDecrypt()
     QSignalSpy drps(&dr, &DecryptRequest::plaintextChanged);
     dr.setData(ciphertext);
     QCOMPARE(dr.data(), ciphertext);
+    dr.setInitialisationVector(initVector);
+    QCOMPARE(dr.initialisationVector(), initVector);
     dr.setKey(fullKey);
     QCOMPARE(dr.key(), fullKey);
     dr.setBlockMode(Key::BlockModeCBC);
     QCOMPARE(dr.blockMode(), Key::BlockModeCBC);
     dr.setPadding(Key::EncryptionPaddingNone);
     QCOMPARE(dr.padding(), Key::EncryptionPaddingNone);
-    dr.setDigest(Key::DigestSha256);
-    QCOMPARE(dr.digest(), Key::DigestSha256);
     dr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(dr.cryptoPluginName(), DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(dr.status(), Request::Inactive);
@@ -430,20 +431,21 @@ void tst_cryptorequests::storedKeyRequests()
 
     // test encrypting some plaintext with the stored key.
     QByteArray plaintext = "Test plaintext data";
+    QByteArray initVector = "Test initialisation vector";
     EncryptRequest er;
     er.setManager(&cm);
     QSignalSpy erss(&er, &EncryptRequest::statusChanged);
     QSignalSpy ercs(&er, &EncryptRequest::ciphertextChanged);
     er.setData(plaintext);
     QCOMPARE(er.data(), plaintext);
+    er.setInitialisationVector(initVector);
+    QCOMPARE(er.initialisationVector(), initVector);
     er.setKey(keyReference);
     QCOMPARE(er.key(), keyReference);
     er.setBlockMode(Key::BlockModeCBC);
     QCOMPARE(er.blockMode(), Key::BlockModeCBC);
     er.setPadding(Key::EncryptionPaddingNone);
     QCOMPARE(er.padding(), Key::EncryptionPaddingNone);
-    er.setDigest(Key::DigestSha256);
-    QCOMPARE(er.digest(), Key::DigestSha256);
     er.setCryptoPluginName(DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(er.cryptoPluginName(), DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(er.status(), Request::Inactive);
@@ -468,14 +470,14 @@ void tst_cryptorequests::storedKeyRequests()
     QSignalSpy drps(&dr, &DecryptRequest::plaintextChanged);
     dr.setData(ciphertext);
     QCOMPARE(dr.data(), ciphertext);
+    dr.setInitialisationVector(initVector);
+    QCOMPARE(dr.initialisationVector(), initVector);
     dr.setKey(keyReference);
     QCOMPARE(dr.key(), keyReference);
     dr.setBlockMode(Key::BlockModeCBC);
     QCOMPARE(dr.blockMode(), Key::BlockModeCBC);
     dr.setPadding(Key::EncryptionPaddingNone);
     QCOMPARE(dr.padding(), Key::EncryptionPaddingNone);
-    dr.setDigest(Key::DigestSha256);
-    QCOMPARE(dr.digest(), Key::DigestSha256);
     dr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(dr.cryptoPluginName(), DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(dr.status(), Request::Inactive);

--- a/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
+++ b/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
@@ -129,12 +129,13 @@ void tst_cryptosecrets::secretsStoredKey()
 
     // test encrypting some plaintext with the stored key.
     QByteArray plaintext = "Test plaintext data";
+    QByteArray initVector = "Test initialisation vector";
     QDBusPendingReply<Sailfish::Crypto::Result, QByteArray> encryptReply = cm.encrypt(
             plaintext,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(encryptReply);
     QVERIFY(encryptReply.isValid());
@@ -146,10 +147,10 @@ void tst_cryptosecrets::secretsStoredKey()
     // test decrypting the ciphertext, and ensure that the roundtrip works.
     QDBusPendingReply<Sailfish::Crypto::Result, QByteArray> decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());
@@ -196,10 +197,10 @@ void tst_cryptosecrets::secretsStoredKey()
     // ensure that the deletion was cascaded to the keyEntries internal database table.
     decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());
@@ -230,10 +231,10 @@ void tst_cryptosecrets::secretsStoredKey()
 
     encryptReply = cm.encrypt(
             plaintext,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(encryptReply);
     QVERIFY(encryptReply.isValid());
@@ -244,10 +245,10 @@ void tst_cryptosecrets::secretsStoredKey()
 
     decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());
@@ -265,10 +266,10 @@ void tst_cryptosecrets::secretsStoredKey()
 
     decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());
@@ -336,12 +337,13 @@ void tst_cryptosecrets::cryptoStoredKey()
 
     // test encrypting some plaintext with the stored key.
     QByteArray plaintext = "Test plaintext data";
+    QByteArray initVector = "Test initialisation vector";
     QDBusPendingReply<Sailfish::Crypto::Result, QByteArray> encryptReply = cm.encrypt(
             plaintext,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(encryptReply);
     QVERIFY(encryptReply.isValid());
@@ -353,10 +355,10 @@ void tst_cryptosecrets::cryptoStoredKey()
     // test decrypting the ciphertext, and ensure that the roundtrip works.
     QDBusPendingReply<Sailfish::Crypto::Result, QByteArray> decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());
@@ -439,10 +441,10 @@ void tst_cryptosecrets::cryptoStoredKey()
     // ensure that the deletion was cascaded to the keyEntries internal database table.
     decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());
@@ -473,10 +475,10 @@ void tst_cryptosecrets::cryptoStoredKey()
 
     encryptReply = cm.encrypt(
             plaintext,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(encryptReply);
     QVERIFY(encryptReply.isValid());
@@ -487,10 +489,10 @@ void tst_cryptosecrets::cryptoStoredKey()
 
     decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());
@@ -508,10 +510,10 @@ void tst_cryptosecrets::cryptoStoredKey()
 
     decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());
@@ -565,10 +567,10 @@ void tst_cryptosecrets::cryptoStoredKey()
     // test encrypting some plaintext with the stored key.
     encryptReply = cm.encrypt(
             plaintext,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(encryptReply);
     QVERIFY(encryptReply.isValid());
@@ -580,10 +582,10 @@ void tst_cryptosecrets::cryptoStoredKey()
     // test decrypting the ciphertext, and ensure that the roundtrip works.
     decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());
@@ -664,10 +666,10 @@ void tst_cryptosecrets::cryptoStoredKey()
 
     decryptReply = cm.decrypt(
             encrypted,
+            initVector,
             keyReference,
             Sailfish::Crypto::Key::BlockModeCBC,
             Sailfish::Crypto::Key::EncryptionPaddingNone,
-            Sailfish::Crypto::Key::DigestSha256,
             Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test"));
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(decryptReply);
     QVERIFY(decryptReply.isValid());


### PR DESCRIPTION
Add support for user-supplied initialisation vector data, and remove
the unnecessary digest parameter.

Contributes to JB#40058