### PR TITLE
[sailfish-secrets] Allow plugin-target lock code request. Contributes to JB#36797

### DIFF
--- a/daemon/CryptoImpl/crypto_p.h
+++ b/daemon/CryptoImpl/crypto_p.h
@@ -18,6 +18,7 @@
 #include "Crypto/interactionparameters.h"
 #include "Crypto/keyderivationparameters.h"
 #include "Crypto/keypairgenerationparameters.h"
+#include "Crypto/lockcoderequest.h"
 
 #include <QtCore/QByteArray>
 #include <QtCore/QString>
@@ -238,6 +239,33 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "          <arg name=\"verified\" type=\"b\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
     "      </method>\n"
+    "      <method name=\"modifyLockCode\">\n"
+    "          <arg name=\"lockCodeTargetType\" type=\"(i)\" direction=\"in\" />\n"
+    "          <arg name=\"lockCodeTarget\" type=\"s\" direction=\"in\" />\n"
+    "          <arg name=\"interactionParameters\" type=\"(sss(i)sss(i)(i))\" direction=\"in\" />\n"
+    "          <arg name=\"result\" type=\"(iis)\" direction=\"out\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Crypto::LockCodeRequest::LockCodeTargetType\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::InteractionParameters\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
+    "      </method>\n"
+    "      <method name=\"provideLockCode\">\n"
+    "          <arg name=\"lockCodeTargetType\" type=\"(i)\" direction=\"in\" />\n"
+    "          <arg name=\"lockCodeTarget\" type=\"s\" direction=\"in\" />\n"
+    "          <arg name=\"interactionParameters\" type=\"(sss(i)sss(i)(i))\" direction=\"in\" />\n"
+    "          <arg name=\"result\" type=\"(iis)\" direction=\"out\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Crypto::LockCodeRequest::LockCodeTargetType\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::InteractionParameters\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
+    "      </method>\n"
+    "      <method name=\"forgetLockCode\">\n"
+    "          <arg name=\"lockCodeTargetType\" type=\"(i)\" direction=\"in\" />\n"
+    "          <arg name=\"lockCodeTarget\" type=\"s\" direction=\"in\" />\n"
+    "          <arg name=\"interactionParameters\" type=\"(sss(i)sss(i)(i))\" direction=\"in\" />\n"
+    "          <arg name=\"result\" type=\"(iis)\" direction=\"out\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Crypto::LockCodeRequest::LockCodeTargetType\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::InteractionParameters\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
+    "      </method>\n"
     "  </interface>\n"
     "")
 
@@ -401,6 +429,27 @@ public Q_SLOTS:
             QByteArray &generatedData,
             bool &verified);
 
+    void modifyLockCode(
+            Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
+            const Sailfish::Crypto::InteractionParameters &interactionParameters,
+            const QDBusMessage &message,
+            Sailfish::Crypto::Result &result);
+
+    void provideLockCode(
+            Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
+            const Sailfish::Crypto::InteractionParameters &interactionParameters,
+            const QDBusMessage &message,
+            Sailfish::Crypto::Result &result);
+
+    void forgetLockCode(
+            Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
+            const Sailfish::Crypto::InteractionParameters &interactionParameters,
+            const QDBusMessage &message,
+            Sailfish::Crypto::Result &result);
+
 private:
     Sailfish::Crypto::Daemon::ApiImpl::CryptoRequestQueue *m_requestQueue;
 };
@@ -448,7 +497,10 @@ enum RequestType {
     InitialiseCipherSessionRequest,
     UpdateCipherSessionAuthenticationRequest,
     UpdateCipherSessionRequest,
-    FinaliseCipherSessionRequest
+    FinaliseCipherSessionRequest,
+    ModifyLockCodeRequest,
+    ProvideLockCodeRequest,
+    ForgetLockCodeRequest
 };
 
 } // ApiImpl

--- a/daemon/CryptoImpl/cryptorequestprocessor.cpp
+++ b/daemon/CryptoImpl/cryptorequestprocessor.cpp
@@ -84,6 +84,8 @@ Daemon::ApiImpl::RequestProcessor::RequestProcessor(
             this, &Daemon::ApiImpl::RequestProcessor::secretsDeleteStoredKeyMetadataCompleted);
     connect(m_secrets, &Sailfish::Secrets::Daemon::ApiImpl::SecretsRequestQueue::userInputCompleted,
             this, &Daemon::ApiImpl::RequestProcessor::secretsUserInputCompleted);
+    connect(m_secrets, &Sailfish::Secrets::Daemon::ApiImpl::SecretsRequestQueue::cryptoPluginLockCodeRequestCompleted,
+            this, &Daemon::ApiImpl::RequestProcessor::secretsCryptoPluginLockCodeRequestCompleted);
 }
 
 bool
@@ -1459,6 +1461,128 @@ Daemon::ApiImpl::RequestProcessor::finaliseCipherSession(
                 verified);
 }
 
+Result
+Daemon::ApiImpl::RequestProcessor::modifyLockCode(
+        pid_t callerPid,
+        quint64 requestId,
+        LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+        const QString &lockCodeTarget,
+        const InteractionParameters &interactionParameters)
+{
+    Q_UNUSED(lockCodeTargetType); // ExtensionPlugin is the only supported type currently.
+
+    if (!m_cryptoPlugins.contains(lockCodeTarget)) {
+        return Result(Result::InvalidCryptographicServiceProvider,
+                      QStringLiteral("Invalid crypto plugin name specified as lock code target"));
+    }
+
+    // We call to the secrets side in order to perform the user interaction flows.
+    // The plugin interactions are implemented also on secrets side for simplicity.
+    Sailfish::Secrets::InteractionParameters uiParams;
+    uiParams.setPluginName(lockCodeTarget);
+    uiParams.setOperation(Sailfish::Secrets::InteractionParameters::ModifyLockPlugin);
+    uiParams.setAuthenticationPluginName(interactionParameters.authenticationPluginName());
+    uiParams.setPromptText(interactionParameters.promptText());
+    uiParams.setInputType(static_cast<Sailfish::Secrets::InteractionParameters::InputType>(interactionParameters.inputType()));
+    uiParams.setEchoMode(static_cast<Sailfish::Secrets::InteractionParameters::EchoMode>(interactionParameters.echoMode()));
+    Result retn = transformSecretsResult(m_secrets->modifyCryptoPluginLockCode(callerPid, requestId, lockCodeTarget, uiParams));
+    if (retn.code() == Result::Pending) {
+        // asynchronous flow required, will call back to secretsCryptoPluginLockCodeRequestCompleted().
+        m_pendingRequests.insert(requestId,
+                                 Daemon::ApiImpl::RequestProcessor::PendingRequest(
+                                     callerPid,
+                                     requestId,
+                                     Daemon::ApiImpl::ModifyLockCodeRequest,
+                                     QVariantList() << QVariant::fromValue<pid_t>(callerPid)
+                                                    << QVariant::fromValue<LockCodeRequest::LockCodeTargetType>(lockCodeTargetType)
+                                                    << QVariant::fromValue<QString>(lockCodeTarget)
+                                                    << QVariant::fromValue<InteractionParameters>(interactionParameters)));
+    }
+
+    return retn;
+}
+
+Result
+Daemon::ApiImpl::RequestProcessor::provideLockCode(
+        pid_t callerPid,
+        quint64 requestId,
+        LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+        const QString &lockCodeTarget,
+        const Sailfish::Crypto::InteractionParameters &interactionParameters)
+{
+    Q_UNUSED(lockCodeTargetType); // ExtensionPlugin is the only supported type currently.
+
+    if (!m_cryptoPlugins.contains(lockCodeTarget)) {
+        return Result(Result::InvalidCryptographicServiceProvider,
+                      QStringLiteral("Invalid crypto plugin name specified as lock code target"));
+    }
+
+    // We call to the secrets side in order to perform the user interaction flows.
+    // The plugin interactions are implemented also on secrets side for simplicity.
+    Sailfish::Secrets::InteractionParameters uiParams;
+    uiParams.setPluginName(lockCodeTarget);
+    uiParams.setOperation(Sailfish::Secrets::InteractionParameters::UnlockPlugin);
+    uiParams.setAuthenticationPluginName(interactionParameters.authenticationPluginName());
+    uiParams.setPromptText(interactionParameters.promptText());
+    uiParams.setInputType(static_cast<Sailfish::Secrets::InteractionParameters::InputType>(interactionParameters.inputType()));
+    uiParams.setEchoMode(static_cast<Sailfish::Secrets::InteractionParameters::EchoMode>(interactionParameters.echoMode()));
+    Result retn = transformSecretsResult(m_secrets->provideCryptoPluginLockCode(callerPid, requestId, lockCodeTarget, uiParams));
+    if (retn.code() == Result::Pending) {
+        // asynchronous flow required, will call back to secretsCryptoPluginLockCodeRequestCompleted().
+        m_pendingRequests.insert(requestId,
+                                 Daemon::ApiImpl::RequestProcessor::PendingRequest(
+                                     callerPid,
+                                     requestId,
+                                     Daemon::ApiImpl::ProvideLockCodeRequest,
+                                     QVariantList() << QVariant::fromValue<pid_t>(callerPid)
+                                                    << QVariant::fromValue<LockCodeRequest::LockCodeTargetType>(lockCodeTargetType)
+                                                    << QVariant::fromValue<QString>(lockCodeTarget)
+                                                    << QVariant::fromValue<InteractionParameters>(interactionParameters)));
+    }
+
+    return retn;
+}
+
+Result
+Daemon::ApiImpl::RequestProcessor::forgetLockCode(
+        pid_t callerPid,
+        quint64 requestId,
+        LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+        const QString &lockCodeTarget,
+        const Sailfish::Crypto::InteractionParameters &interactionParameters)
+{
+    Q_UNUSED(lockCodeTargetType); // ExtensionPlugin is the only supported type currently.
+
+    if (!m_cryptoPlugins.contains(lockCodeTarget)) {
+        return Result(Result::InvalidCryptographicServiceProvider,
+                      QStringLiteral("Invalid crypto plugin name specified as lock code target"));
+    }
+
+    // We call to the secrets side in order to perform the user interaction flows.
+    // The plugin interactions are implemented also on secrets side for simplicity.
+    Sailfish::Secrets::InteractionParameters uiParams;
+    uiParams.setPluginName(lockCodeTarget);
+    uiParams.setOperation(Sailfish::Secrets::InteractionParameters::LockPlugin);
+    uiParams.setAuthenticationPluginName(interactionParameters.authenticationPluginName());
+    uiParams.setPromptText(interactionParameters.promptText());
+    uiParams.setInputType(static_cast<Sailfish::Secrets::InteractionParameters::InputType>(interactionParameters.inputType()));
+    uiParams.setEchoMode(static_cast<Sailfish::Secrets::InteractionParameters::EchoMode>(interactionParameters.echoMode()));
+    Result retn = transformSecretsResult(m_secrets->forgetCryptoPluginLockCode(callerPid, requestId, lockCodeTarget, uiParams));
+    if (retn.code() == Result::Pending) {
+        // asynchronous flow required, will call back to secretsCryptoPluginLockCodeRequestCompleted().
+        m_pendingRequests.insert(requestId,
+                                 Daemon::ApiImpl::RequestProcessor::PendingRequest(
+                                     callerPid,
+                                     requestId,
+                                     Daemon::ApiImpl::ForgetLockCodeRequest,
+                                     QVariantList() << QVariant::fromValue<pid_t>(callerPid)
+                                                    << QVariant::fromValue<LockCodeRequest::LockCodeTargetType>(lockCodeTargetType)
+                                                    << QVariant::fromValue<QString>(lockCodeTarget)
+                                                    << QVariant::fromValue<InteractionParameters>(interactionParameters)));
+    }
+
+    return retn;
+}
 
 // asynchronous operation (retrieve stored key) has completed.
 void Daemon::ApiImpl::RequestProcessor::secretsStoredKeyCompleted(
@@ -1698,5 +1822,37 @@ void Daemon::ApiImpl::RequestProcessor::secretsUserInputCompleted(
         }
     } else {
         qCWarning(lcSailfishCryptoDaemon) << "Secrets completed userInput() operation for unknown request:" << requestId;
+    }
+}
+
+// asynchronous operation (crypto plugin lock code request) has completed.
+void Daemon::ApiImpl::RequestProcessor::secretsCryptoPluginLockCodeRequestCompleted(
+        quint64 requestId,
+        const Sailfish::Secrets::Result &result)
+{
+    // look up the pending request in our list
+    if (m_pendingRequests.contains(requestId)) {
+        // transform the error code.
+        Result returnResult(transformSecretsResult(result));
+
+        // call the appropriate method to complete the request
+        Daemon::ApiImpl::RequestProcessor::PendingRequest pr = m_pendingRequests.take(requestId);
+        switch (pr.requestType) {
+            case ModifyLockCodeRequest:   // flow on
+            case ProvideLockCodeRequest:  // flow on
+            case ForgetLockCodeRequest: {
+                // nothing more to do, return the result directly.
+                QList<QVariant> outParams;
+                outParams << QVariant::fromValue<Result>(returnResult);
+                m_requestQueue->requestFinished(requestId, outParams);
+                break;
+            }
+            default: {
+                qCWarning(lcSailfishCryptoDaemon) << "Secrets completed crypto plugin lock code operation for request:" << requestId << "of invalid type:" << pr.requestType;
+                break;
+            }
+        }
+    } else {
+        qCWarning(lcSailfishCryptoDaemon) << "Secrets completed crypto plugin lock code operation for unknown request:" << requestId;
     }
 }

--- a/daemon/CryptoImpl/cryptorequestprocessor_p.h
+++ b/daemon/CryptoImpl/cryptorequestprocessor_p.h
@@ -17,6 +17,7 @@
 #include "Crypto/keypairgenerationparameters.h"
 #include "Crypto/keyderivationparameters.h"
 #include "Crypto/interactionparameters.h"
+#include "Crypto/lockcoderequest.h"
 
 #include "CryptoImpl/crypto_p.h"
 
@@ -226,6 +227,27 @@ public:
             QByteArray *generatedData,
             bool *verified);
 
+    Sailfish::Crypto::Result modifyLockCode(
+            pid_t callerPid,
+            quint64 requestId,
+            Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
+            const Sailfish::Crypto::InteractionParameters &interactionParameters);
+
+    Sailfish::Crypto::Result provideLockCode(
+            pid_t callerPid,
+            quint64 requestId,
+            Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
+            const Sailfish::Crypto::InteractionParameters &interactionParameters);
+
+    Sailfish::Crypto::Result forgetLockCode(
+            pid_t callerPid,
+            quint64 requestId,
+            Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
+            const Sailfish::Crypto::InteractionParameters &interactionParameters);
+
 public Q_SLOTS:
     void secretsStoreKeyCompleted(
             quint64 requestId,
@@ -253,6 +275,10 @@ public Q_SLOTS:
             quint64 requestId,
             const Sailfish::Secrets::Result &result,
             const QByteArray &userInput);
+
+    void secretsCryptoPluginLockCodeRequestCompleted(
+            quint64 requestId,
+            const Sailfish::Secrets::Result &result);
 
 private:
     struct PendingRequest {

--- a/daemon/SecretsImpl/bookkeepingdatabase_p.h
+++ b/daemon/SecretsImpl/bookkeepingdatabase_p.h
@@ -179,6 +179,7 @@ public:
 private:
     Sailfish::Secrets::Daemon::Sqlite::Database m_db;
     bool m_initialised;
+    bool m_autotestMode;
 };
 
 } // ApiImpl

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -17,6 +17,7 @@
 #include "Secrets/extensionplugins.h"
 #include "Secrets/secretmanager.h"
 #include "Secrets/result.h"
+#include "Secrets/lockcoderequest.h"
 
 #include "Crypto/result.h"
 #include "Crypto/key.h"
@@ -189,39 +190,39 @@ class SecretsDBusObject : public QObject, protected QDBusContext
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Secrets::Result\" />\n"
     "      </method>\n"
     "      <method name=\"modifyLockCode\">\n"
-    "          <arg name=\"secretName\" type=\"s\" direction=\"in\" />\n"
-    "          <arg name=\"collectionName\" type=\"s\" direction=\"in\" />\n"
+    "          <arg name=\"lockCodeTargetType\" type=\"(i)\" direction=\"in\" />\n"
+    "          <arg name=\"lockCodeTarget\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"interactionParameters\" type=\"(sss(i)sss(i)(i))\" direction=\"in\" />\n"
     "          <arg name=\"userInteractionMode\" type=\"(i)\" direction=\"in\" />\n"
     "          <arg name=\"interactionServiceAddress\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iis)\" direction=\"out\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Secrets::LockCodeRequest::LockCodeTargetType\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Secrets::InteractionParameters\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Secrets::SecretManager::AccessControlMode\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In4\" value=\"Sailfish::Secrets::SecretManager::UserInteractionMode\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Secrets::SecretManager::UserInteractionMode\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Secrets::Result\" />\n"
     "      </method>\n"
     "      <method name=\"provideLockCode\">\n"
-    "          <arg name=\"secretName\" type=\"s\" direction=\"in\" />\n"
-    "          <arg name=\"collectionName\" type=\"s\" direction=\"in\" />\n"
+    "          <arg name=\"lockCodeTargetType\" type=\"(i)\" direction=\"in\" />\n"
+    "          <arg name=\"lockCodeTarget\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"interactionParameters\" type=\"(sss(i)sss(i)(i))\" direction=\"in\" />\n"
     "          <arg name=\"userInteractionMode\" type=\"(i)\" direction=\"in\" />\n"
     "          <arg name=\"interactionServiceAddress\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iis)\" direction=\"out\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Secrets::LockCodeRequest::LockCodeTargetType\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Secrets::InteractionParameters\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Secrets::SecretManager::AccessControlMode\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In4\" value=\"Sailfish::Secrets::SecretManager::UserInteractionMode\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Secrets::SecretManager::UserInteractionMode\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Secrets::Result\" />\n"
     "      </method>\n"
     "      <method name=\"forgetLockCode\">\n"
-    "          <arg name=\"secretName\" type=\"s\" direction=\"in\" />\n"
-    "          <arg name=\"collectionName\" type=\"s\" direction=\"in\" />\n"
+    "          <arg name=\"lockCodeTargetType\" type=\"(i)\" direction=\"in\" />\n"
+    "          <arg name=\"lockCodeTarget\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"interactionParameters\" type=\"(sss(i)sss(i)(i))\" direction=\"in\" />\n"
     "          <arg name=\"userInteractionMode\" type=\"(i)\" direction=\"in\" />\n"
     "          <arg name=\"interactionServiceAddress\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iis)\" direction=\"out\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Secrets::LockCodeRequest::LockCodeTargetType\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Secrets::InteractionParameters\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Secrets::SecretManager::AccessControlMode\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In4\" value=\"Sailfish::Secrets::SecretManager::UserInteractionMode\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Secrets::SecretManager::UserInteractionMode\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Secrets::Result\" />\n"
     "      </method>\n"
     "  </interface>\n"
@@ -349,30 +350,30 @@ public Q_SLOTS:
             const QDBusMessage &message,
             Sailfish::Secrets::Result &result);
 
-    // modify a lock code (re-key an encrypted collection or standalone secret)
+    // modify a lock code (re-key a plugin, encrypted collection or standalone secret)
     void modifyLockCode(
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
             const QDBusMessage &message,
             Sailfish::Secrets::Result &result);
 
-    // provide a lock code (unlock an encrypted collection or standalone secret)
+    // provide a lock code (unlock a plugin, encrypted collection or standalone secret)
     void provideLockCode(
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
             const QDBusMessage &message,
             Sailfish::Secrets::Result &result);
 
-    // forget a lock code (lock an encrypted collection or standalone secret)
+    // forget a lock code (lock a plugin, encrypted collection or standalone secret)
     void forgetLockCode(
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -448,6 +448,9 @@ public: // Crypto API helper methods.
     Sailfish::Secrets::Result deleteStoredKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier);
     Sailfish::Secrets::Result deleteStoredKeyMetadata(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier);
     Sailfish::Secrets::Result userInput(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Secrets::InteractionParameters &uiParams);
+    Sailfish::Secrets::Result modifyCryptoPluginLockCode(pid_t callerPid, quint64 cryptoRequestId, const QString &cryptoPluginName, const Sailfish::Secrets::InteractionParameters &uiParams);
+    Sailfish::Secrets::Result provideCryptoPluginLockCode(pid_t callerPid, quint64 cryptoRequestId, const QString &cryptoPluginName, const Sailfish::Secrets::InteractionParameters &uiParams);
+    Sailfish::Secrets::Result forgetCryptoPluginLockCode(pid_t callerPid, quint64 cryptoRequestId, const QString &cryptoPluginName, const Sailfish::Secrets::InteractionParameters &uiParams);
 Q_SIGNALS:
     void storedKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &serialisedKey, const QMap<QString,QString> &filterData);
     void storeKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);
@@ -455,6 +458,7 @@ Q_SIGNALS:
     void deleteStoredKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);
     void deleteStoredKeyMetadataCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);
     void userInputCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &userInput);
+    void cryptoPluginLockCodeRequestCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);
 private:
     enum CryptoApiHelperRequestType {
         InvalidCryptoApiHelperRequest = 0,
@@ -468,7 +472,10 @@ private:
         StoreKeyCryptoApiHelperRequest,
         StoreKeyMetadataCryptoApiHelperRequest,
         DeleteStoredKeyMetadataCryptoApiHelperRequest,
-        UserInputCryptoApiHelperRequest
+        UserInputCryptoApiHelperRequest,
+        ModifyLockCodeCryptoApiHelperRequest,
+        ProvideLockCodeCryptoApiHelperRequest,
+        ForgetLockCodeCryptoApiHelperRequest
     };
     QMap<quint64, CryptoApiHelperRequestType> m_cryptoApiHelperRequests; // crypto request id to crypto api call type.
 };

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -422,9 +422,13 @@ public: // For use by the secrets request processor to handle device-locked coll
     bool testLockCode(const QByteArray &lockCode);
     QByteArray saltData() const;
     bool noLockCode() const;
+    void setNoLockCode(bool value);
     const QByteArray bkdbLockKey() const;
     const QByteArray deviceLockKey() const;
 
+    Sailfish::Secrets::Result lockCryptoPlugin(const QString &pluginName);
+    Sailfish::Secrets::Result unlockCryptoPlugin(const QString &pluginName, const QByteArray &lockCode);
+    Sailfish::Secrets::Result setLockCodeCryptoPlugin(const QString &pluginName, const QByteArray &oldCode, const QByteArray &newCode);
     bool lockCryptoPlugins();
     bool unlockCryptoPlugins(const QByteArray &lockCode);
     bool setLockCodeCryptoPlugins(const QByteArray &oldCode, const QByteArray &newCode);

--- a/daemon/SecretsImpl/secretsrequestprocessor_p.h
+++ b/daemon/SecretsImpl/secretsrequestprocessor_p.h
@@ -28,6 +28,7 @@
 #include "Secrets/secret.h"
 #include "Secrets/interactionparameters.h"
 #include "Secrets/extensionplugins.h"
+#include "Secrets/lockcoderequest.h"
 
 #include "SecretsImpl/secrets_p.h"
 #include "SecretsImpl/applicationpermissions_p.h"
@@ -197,32 +198,32 @@ public:
             const Sailfish::Secrets::Secret::Identifier &identifier,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode);
 
-    // modify a lock code (re-key an encrypted collection or standalone secret)
+    // modify a lock code (re-key a plugin, encrypted collection or standalone secret)
     Sailfish::Secrets::Result modifyLockCode(
             pid_t callerPid,
             quint64 requestId,
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParams,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress);
 
-    // provide a lock code (unlock an encrypted collection or standalone secret)
+    // provide a lock code (unlock a plugin, encrypted collection or standalone secret)
     Sailfish::Secrets::Result provideLockCode(
             pid_t callerPid,
             quint64 requestId,
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParams,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress);
 
-    // forget a lock code (lock an encrypted collection or standalone secret)
+    // forget a lock code (lock a plugin, encrypted collection or standalone secret)
     Sailfish::Secrets::Result forgetLockCode(
             pid_t callerPid,
             quint64 requestId,
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParams,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress);
@@ -484,8 +485,8 @@ private:
     Sailfish::Secrets::Result modifyLockCodeWithLockCode(
             pid_t callerPid,
             quint64 requestId,
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParams,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
@@ -494,8 +495,8 @@ private:
     Sailfish::Secrets::Result modifyLockCodeWithLockCodes(
             pid_t callerPid,
             quint64 requestId,
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParams,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
@@ -505,8 +506,8 @@ private:
     Sailfish::Secrets::Result provideLockCodeWithLockCode(
             pid_t callerPid,
             quint64 requestId,
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParams,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,

--- a/database/database.cpp
+++ b/database/database.cpp
@@ -355,6 +355,12 @@ bool Database::open(
     return true;
 }
 
+void Database::close()
+{
+    m_database.close();
+    m_preparedQueries.clear();
+}
+
 Database::operator QSqlDatabase &()
 {
     return m_database;

--- a/database/database_p.h
+++ b/database/database_p.h
@@ -96,6 +96,7 @@ public:
               int currentSchemaVersion,
               const QString &connectionName,
               bool autoTest);
+    void close();
 
     operator QSqlDatabase &();
     operator QSqlDatabase const &() const;

--- a/lib/Crypto/Crypto.pro
+++ b/lib/Crypto/Crypto.pro
@@ -29,6 +29,7 @@ PUBLIC_HEADERS += \
     $$PWD/key.h \
     $$PWD/keyderivationparameters.h \
     $$PWD/keypairgenerationparameters.h \
+    $$PWD/lockcoderequest.h \
     $$PWD/plugininforequest.h \
     $$PWD/request.h \
     $$PWD/result.h \
@@ -61,6 +62,7 @@ PRIVATE_HEADERS += \
     $$PWD/key_p.h \
     $$PWD/keyderivationparameters_p.h \
     $$PWD/keypairgenerationparameters_p.h \
+    $$PWD/lockcoderequest_p.h \
     $$PWD/plugininforequest_p.h \
     $$PWD/result_p.h \
     $$PWD/seedrandomdatageneratorrequest_p.h \
@@ -92,6 +94,7 @@ SOURCES += \
     $$PWD/key.cpp \
     $$PWD/keyderivationparameters.cpp \
     $$PWD/keypairgenerationparameters.cpp \
+    $$PWD/lockcoderequest.cpp \
     $$PWD/plugininforequest.cpp \
     $$PWD/request.cpp \
     $$PWD/result.cpp \

--- a/lib/Crypto/cryptodaemonconnection.cpp
+++ b/lib/Crypto/cryptodaemonconnection.cpp
@@ -16,6 +16,7 @@
 #include "Crypto/extensionplugins.h"
 #include "Crypto/storedkeyrequest.h"
 #include "Crypto/cipherrequest.h"
+#include "Crypto/lockcoderequest.h"
 
 #include <QtDBus/QDBusReply>
 #include <QtDBus/QDBusInterface>
@@ -181,6 +182,7 @@ void Sailfish::Crypto::CryptoDaemonConnection::registerDBusTypes()
     qRegisterMetaType<Sailfish::Crypto::KeyPairGenerationParameters::KeyPairType>("Sailfish::Crypto::KeyPairGenerationParameters::KeyPairType");
     qRegisterMetaType<Sailfish::Crypto::KeyDerivationParameters>("Sailfish::Crypto::KeyDerivationParameters");
     qRegisterMetaType<Sailfish::Crypto::InteractionParameters>("Sailfish::Crypto::InteractionParameters");
+    qRegisterMetaType<Sailfish::Crypto::LockCodeRequest::LockCodeTargetType>("Sailfish::Crypto::LockCodeRequest::LockCodeTargetType");
 
     qDBusRegisterMetaType<Sailfish::Crypto::Key::Origin>();
     qDBusRegisterMetaType<Sailfish::Crypto::CryptoManager::Algorithm>();
@@ -209,4 +211,5 @@ void Sailfish::Crypto::CryptoDaemonConnection::registerDBusTypes()
     qDBusRegisterMetaType<Sailfish::Crypto::KeyPairGenerationParameters::KeyPairType>();
     qDBusRegisterMetaType<Sailfish::Crypto::KeyDerivationParameters>();
     qDBusRegisterMetaType<Sailfish::Crypto::InteractionParameters>();
+    qDBusRegisterMetaType<Sailfish::Crypto::LockCodeRequest::LockCodeTargetType>();
 }

--- a/lib/Crypto/cryptomanager.cpp
+++ b/lib/Crypto/cryptomanager.cpp
@@ -13,6 +13,7 @@
 #include "Crypto/keypairgenerationparameters.h"
 #include "Crypto/keyderivationparameters.h"
 #include "Crypto/interactionparameters.h"
+#include "Crypto/lockcoderequest.h"
 
 #include <QtDBus/QDBusInterface>
 #include <QtDBus/QDBusConnection>
@@ -465,6 +466,70 @@ CryptoManagerPrivate::finaliseCipherSession(
     return reply;
 }
 
+
+QDBusPendingReply<Result>
+CryptoManagerPrivate::modifyLockCode(
+        LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+        const QString &lockCodeTarget,
+        const InteractionParameters &interactionParameters)
+{
+    if (!m_interface) {
+        return QDBusPendingReply<Result>(
+                    QDBusMessage::createError(QDBusError::Other,
+                                              QStringLiteral("Not connected to daemon")));
+    }
+
+    QDBusPendingReply<Result> reply
+            = m_interface->asyncCallWithArgumentList(
+                "modifyLockCode",
+                QVariantList() << QVariant::fromValue<LockCodeRequest::LockCodeTargetType>(lockCodeTargetType)
+                               << QVariant::fromValue<QString>(lockCodeTarget)
+                               << QVariant::fromValue<InteractionParameters>(interactionParameters));
+    return reply;
+}
+
+QDBusPendingReply<Result>
+CryptoManagerPrivate::provideLockCode(
+        LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+        const QString &lockCodeTarget,
+        const InteractionParameters &interactionParameters)
+{
+    if (!m_interface) {
+        return QDBusPendingReply<Result>(
+                    QDBusMessage::createError(QDBusError::Other,
+                                              QStringLiteral("Not connected to daemon")));
+    }
+
+    QDBusPendingReply<Result> reply
+            = m_interface->asyncCallWithArgumentList(
+                "provideLockCode",
+                QVariantList() << QVariant::fromValue<LockCodeRequest::LockCodeTargetType>(lockCodeTargetType)
+                               << QVariant::fromValue<QString>(lockCodeTarget)
+                               << QVariant::fromValue<InteractionParameters>(interactionParameters));
+    return reply;
+}
+
+QDBusPendingReply<Result>
+CryptoManagerPrivate::forgetLockCode(
+        LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+        const QString &lockCodeTarget,
+        const InteractionParameters &interactionParameters)
+{
+    if (!m_interface) {
+        return QDBusPendingReply<Result>(
+                    QDBusMessage::createError(QDBusError::Other,
+                                              QStringLiteral("Not connected to daemon")));
+    }
+
+    QDBusPendingReply<Result> reply
+            = m_interface->asyncCallWithArgumentList(
+                "forgetLockCode",
+                QVariantList() << QVariant::fromValue<LockCodeRequest::LockCodeTargetType>(lockCodeTargetType)
+                               << QVariant::fromValue<QString>(lockCodeTarget)
+                               << QVariant::fromValue<InteractionParameters>(interactionParameters));
+    return reply;
+}
+
 /*!
   \class CryptoManager
   \brief Allows clients to make requests of the system crypto service.
@@ -475,6 +540,7 @@ CryptoManagerPrivate::finaliseCipherSession(
 
   \list
   \li \l{PluginInfoRequest} to retrieve information about crypto plugins
+  \li \l{LockCodeRequest} to set the lock code for, lock, or unlock a crypto plugin
   \li \l{SeedRandomDataGeneratorRequest} to seed a crypto plugin's random number generator
   \li \l{GenerateRandomDataRequest} to generate random data
   \li \l{ValidateCertificateChainRequest} to validate certificates

--- a/lib/Crypto/cryptomanager.h
+++ b/lib/Crypto/cryptomanager.h
@@ -328,6 +328,7 @@ private:
     friend class GenerateKeyRequest;
     friend class GenerateRandomDataRequest;
     friend class GenerateStoredKeyRequest;
+    friend class LockCodeRequest;
     friend class PluginInfoRequest;
     friend class SeedRandomDataGeneratorRequest;
     friend class SignRequest;

--- a/lib/Crypto/cryptomanager_p.h
+++ b/lib/Crypto/cryptomanager_p.h
@@ -19,6 +19,7 @@
 #include "Crypto/keypairgenerationparameters.h"
 #include "Crypto/keyderivationparameters.h"
 #include "Crypto/interactionparameters.h"
+#include "Crypto/lockcoderequest.h"
 
 #include <QtDBus/QDBusContext>
 #include <QtDBus/QDBusPendingReply>
@@ -148,6 +149,21 @@ public:
             const QByteArray &data,
             const QString &cryptosystemProviderName,
             quint32 cipherSessionToken);
+
+    QDBusPendingReply<Sailfish::Crypto::Result> modifyLockCode(
+            Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
+            const Sailfish::Crypto::InteractionParameters &interactionParameters);
+
+    QDBusPendingReply<Sailfish::Crypto::Result> provideLockCode(
+            Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
+            const Sailfish::Crypto::InteractionParameters &interactionParameters);
+
+    QDBusPendingReply<Sailfish::Crypto::Result> forgetLockCode(
+            Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
+            const Sailfish::Crypto::InteractionParameters &interactionParameters);
 
 private:
     friend class CryptoManager;

--- a/lib/Crypto/interactionparameters.cpp
+++ b/lib/Crypto/interactionparameters.cpp
@@ -130,6 +130,27 @@ void InteractionParameters::setCollectionName(const QString &name)
 }
 
 /*!
+ * \brief Returns the name of the extension plugin which is associated with the user input request
+ */
+QString InteractionParameters::pluginName() const
+{
+    return d_ptr->m_pluginName;
+}
+
+/*!
+ * \brief Sets the name of the extension plugin which is associated with the user input request to \a name
+ *
+ * Note that in general, this parameter will be supplied by the secrets service,
+ * so any value set by the client application here will have no effect.
+ */
+void InteractionParameters::setPluginName(const QString &name)
+{
+    if (d_ptr->m_pluginName != name) {
+        d_ptr->m_pluginName = name;
+    }
+}
+
+/*!
  * \brief Returns the identifier of the client application making the request
  */
 QString InteractionParameters::applicationId() const
@@ -274,6 +295,7 @@ bool Sailfish::Crypto::operator==(const InteractionParameters &lhs, const Intera
 {
     return lhs.keyName() == rhs.keyName()
             && lhs.collectionName() == rhs.collectionName()
+            && lhs.pluginName() == rhs.pluginName()
             && lhs.applicationId() == rhs.applicationId()
             && lhs.operation() == rhs.operation()
             && lhs.authenticationPluginName() == rhs.authenticationPluginName()
@@ -301,6 +323,9 @@ bool Sailfish::Crypto::operator<(const InteractionParameters &lhs, const Interac
 
     if (lhs.keyName() != rhs.keyName())
         return lhs.keyName() < rhs.keyName();
+
+    if (lhs.pluginName() != rhs.pluginName())
+        return lhs.pluginName() < rhs.pluginName();
 
     if (lhs.operation() != rhs.operation())
         return lhs.operation() < rhs.operation();

--- a/lib/Crypto/interactionparameters.h
+++ b/lib/Crypto/interactionparameters.h
@@ -23,6 +23,7 @@ class SAILFISH_CRYPTO_API InteractionParameters {
     Q_GADGET
     Q_PROPERTY(QString keyName READ keyName WRITE setKeyName)
     Q_PROPERTY(QString collectionName READ collectionName WRITE setCollectionName)
+    Q_PROPERTY(QString pluginName READ pluginName WRITE setPluginName)
     Q_PROPERTY(QString applicationId READ applicationId WRITE setApplicationId)
     Q_PROPERTY(Operation operation READ operation WRITE setOperation)
     Q_PROPERTY(QString authenticationPluginName READ authenticationPluginName WRITE setAuthenticationPluginName)
@@ -59,28 +60,41 @@ public:
     Q_ENUM(EchoMode)
 
     enum Operation {
-        UnknownOperation = 0,
+        UnknownOperation    = 0,
 
-        RequestUserData  = 1,   // usually used in conjunction with StoreSecret, i.e. store data requested from user.
+        RequestUserData     = 1 << 0,   // usually used in conjunction with StoreSecret, i.e. store data requested from user.
 
-        CreateCollection = 2,
-        UnlockCollection = 4,
-        DeleteCollection = 8,
+        UnlockDatabase      = 1 << 1,
+        LockDatabase        = 1 << 2,
+        ModifyLockDatabase  = 1 << 3,
 
-        ReadSecret       = 16,
-        StoreSecret      = 32,
-        DeleteSecret     = 64,
+        UnlockPlugin        = 1 << 4,
+        LockPlugin          = 1 << 5,
+        ModifyLockPlugin    = 1 << 6,
 
-        Encrypt          = 128,
-        Decrypt          = 256,
-        Sign             = 512,
-        Verify           = 1024,
-        DeriveDigest     = 2048,
-        DeriveMac        = 4096,
-        DeriveKey        = 8192,
+        CreateCollection    = 1 << 7,
+        UnlockCollection    = 1 << 8,
+        LockCollection      = 1 << 9,
+        ModifyLockCollection= 1 << 10,
+        DeleteCollection    = 1 << 11,
+
+        ReadSecret          = 1 << 12,
+        StoreSecret         = 1 << 13,
+        UnlockSecret        = 1 << 14,
+        LockSecret          = 1 << 15,
+        ModifyLockSecret    = 1 << 16,
+        DeleteSecret        = 1 << 17,
+
+        Encrypt             = 1 << 18,
+        Decrypt             = 1 << 19,
+        Sign                = 1 << 20,
+        Verify              = 1 << 21,
+        DeriveDigest        = 1 << 22,
+        DeriveMac           = 1 << 23,
+        DeriveKey           = 1 << 24,
 
         // reserved
-        LastOperation    = 65536
+        LastOperation       = 1 << 30
     };
     Q_ENUM(Operation)
     Q_DECLARE_FLAGS(Operations, Operation)
@@ -97,6 +111,9 @@ public:
 
     QString collectionName() const;
     void setCollectionName(const QString &name);
+
+    QString pluginName() const;
+    void setPluginName(const QString &name);
 
     QString applicationId() const;
     void setApplicationId(const QString &id);

--- a/lib/Crypto/interactionparameters_p.h
+++ b/lib/Crypto/interactionparameters_p.h
@@ -25,6 +25,7 @@ public:
 
     QString m_keyName;
     QString m_collectionName;
+    QString m_pluginName;
     QString m_applicationId;
     Sailfish::Crypto::InteractionParameters::Operation m_operation = Sailfish::Crypto::InteractionParameters::UnknownOperation;
     QString m_authenticationPluginName;

--- a/lib/Crypto/lockcoderequest.cpp
+++ b/lib/Crypto/lockcoderequest.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2018 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#include "Crypto/lockcoderequest.h"
+#include "Crypto/lockcoderequest_p.h"
+
+#include "Crypto/cryptomanager.h"
+#include "Crypto/cryptomanager_p.h"
+#include "Crypto/serialisation_p.h"
+
+#include <QtDBus/QDBusPendingReply>
+#include <QtDBus/QDBusPendingCallWatcher>
+
+using namespace Sailfish::Crypto;
+
+LockCodeRequestPrivate::LockCodeRequestPrivate()
+    : m_lockCodeRequestType(LockCodeRequest::ModifyLockCode)
+    , m_lockCodeTargetType(LockCodeRequest::ExtensionPlugin)
+    , m_status(Request::Inactive)
+{
+}
+
+/*!
+ * \class LockCodeRequest
+ * \brief Allows a client to request that the system service either
+ *        unlock, lock, or modify the lock code associated with a plugin.
+ *
+ * \b{Note: most clients will never need to use this class, as the
+ * other request types automatically trigger locking and relocking
+ * flows as required.}
+ *
+ * The operation will be applied to the plugin specified by the
+ * \l{lockCodeTarget()}.  Only some plugins support these operations,
+ * and in some cases only privileged applications (such as the system
+ * settings application) may be permitted to perform these operations.
+ *
+ * If the \l{lockCodeRequestType()} specified is \l{ModifyLockCode}
+ * then the user will be prompted (via a system-mediated user interaction
+ * flow) for the current lock code, and if that matches the existing
+ * lock code, they will then be prompted for the new lock code.
+ *
+ * If the \l{lockCodeRequestType()} specified is \l{ProvideLockCode}
+ * then the user will be prompted (via a system-mediated user interaction
+ * flow) for the current lock code, which will be used to unlock the plugin.
+ *
+ * If the \l{lockCodeRequestType()} specified is \l{ForgetLockCode}
+ * then if the datum is currently unlocked, the user will be prompted (via a
+ * system-mediated user interaction flow) for the current lock code, and if
+ * it matches the actual lock code, the plugin will be locked.
+ *
+ * An example of modifying the lock code used for a particular plugin follows:
+ *
+ * \code
+ * // Require an alpha-numeric lock code to be provided
+ * Sailfish::Crypto::InteractionParameters uiParams;
+ * uiParams.setInputType(Sailfish::Crypto::InteractionParameters::AlphaNumericInput);
+ * uiParams.setEchoMode(Sailfish::Crypto::InteractionParameters::PasswordEcho);
+ *
+ * // Request that the collection be re-keyed.
+ * Sailfish::Crypto::CryptoManager cm;
+ * Sailfish::Crypto::LockCodeRequest lcr;
+ * lcr.setManager(&cm);
+ * lcr.setLockCodeRequestType(Sailfish::Crypto::LockCodeRequest::ModifyLockCode);
+ * lcr.setLockCodeTargetType(Sailfish::Crypto::LockCodeRequest::ExtensionPlugin);
+ * lcr.setLockCodeTarget(QLatin1String("some.crypto.extension.plugin.name"));
+ * lcr.setInteractionParameters(uiParams);
+ * lcr.startRequest(); // status() will change to Finished when complete
+ * \endcode
+ */
+
+/*!
+ * \brief Constructs a new LockCodeRequest object with the given \a parent.
+ */
+LockCodeRequest::LockCodeRequest(QObject *parent)
+    : Request(parent)
+    , d_ptr(new LockCodeRequestPrivate)
+{
+}
+
+/*!
+ * \brief Destroys the LockCodeRequest
+ */
+LockCodeRequest::~LockCodeRequest()
+{
+}
+
+/*!
+ * \brief Returns the type of lock code operation being requested
+ */
+LockCodeRequest::LockCodeRequestType LockCodeRequest::lockCodeRequestType() const
+{
+    Q_D(const LockCodeRequest);
+    return d->m_lockCodeRequestType;
+}
+
+/*!
+ * \brief Sets the type of lock code operation being requested to \a type
+ */
+void LockCodeRequest::setLockCodeRequestType(LockCodeRequest::LockCodeRequestType type)
+{
+    Q_D(LockCodeRequest);
+    if (d->m_status != Request::Active && d->m_lockCodeRequestType != type) {
+        d->m_lockCodeRequestType = type;
+        if (d->m_status == Request::Finished) {
+            d->m_status = Request::Inactive;
+            emit statusChanged();
+        }
+        emit lockCodeRequestTypeChanged();
+    }
+}
+
+/*!
+ * \brief Returns the type of the target of the lock code operation
+ */
+LockCodeRequest::LockCodeTargetType LockCodeRequest::lockCodeTargetType() const
+{
+    Q_D(const LockCodeRequest);
+    return d->m_lockCodeTargetType;
+}
+
+/*!
+ * \brief Sets the type of the target of the lock code operation to \a type
+ *
+ * Some plugins must be unlocked prior to use, and such plugins should
+ * document their semantics for their intended clients.
+ */
+void LockCodeRequest::setLockCodeTargetType(LockCodeRequest::LockCodeTargetType type)
+{
+    Q_D(LockCodeRequest);
+    if (d->m_status != Request::Active && d->m_lockCodeTargetType != type) {
+        d->m_lockCodeTargetType = type;
+        if (d->m_status == Request::Finished) {
+            d->m_status = Request::Inactive;
+            emit statusChanged();
+        }
+        emit lockCodeTargetTypeChanged();
+    }
+}
+
+/*!
+ * \brief Returns the user input parameters which should be used when requesting the secret data from the user
+ */
+InteractionParameters LockCodeRequest::interactionParameters() const
+{
+    Q_D(const LockCodeRequest);
+    return d->m_interactionParameters;
+}
+
+/*!
+ * \brief Sets the user input parameters which should be used when requesting the lock code from the user to \a params
+ *
+ * Note: specifying user input parameters implies that system-mediated user interaction
+ * flows are allowed by the calling application, and are required by the collection
+ * or standalone secret for which the lock code is being requested.
+ */
+void LockCodeRequest::setInteractionParameters(const InteractionParameters &params)
+{
+    Q_D(LockCodeRequest);
+    if (d->m_status != Request::Active && d->m_interactionParameters != params) {
+        d->m_interactionParameters = params;
+        if (d->m_status == Request::Finished) {
+            d->m_status = Request::Inactive;
+            emit statusChanged();
+        }
+        emit interactionParametersChanged();
+    }
+}
+
+// TODO: in the future support oldLockCodeInteractionParameters also?
+// e.g. to allow changing the type of lock code (from PIN to ALPHANUM, etc)?
+
+/*!
+ * \brief Returns the name of the target to which the lock code operation should be applied
+ */
+QString LockCodeRequest::lockCodeTarget() const
+{
+    Q_D(const LockCodeRequest);
+    return d->m_lockCodeTarget;
+}
+
+/*!
+ * \brief Sets the name of the target to which the lock code operation should be applied to \a name
+ */
+void LockCodeRequest::setLockCodeTarget(const QString &targetName)
+{
+    Q_D(LockCodeRequest);
+    if (d->m_status != Request::Active && d->m_lockCodeTarget != targetName) {
+        d->m_lockCodeTarget = targetName;
+        if (d->m_status == Request::Finished) {
+            d->m_status = Request::Inactive;
+            emit statusChanged();
+        }
+        emit lockCodeTargetChanged();
+    }
+}
+
+Request::Status LockCodeRequest::status() const
+{
+    Q_D(const LockCodeRequest);
+    return d->m_status;
+}
+
+Result LockCodeRequest::result() const
+{
+    Q_D(const LockCodeRequest);
+    return d->m_result;
+}
+
+CryptoManager *LockCodeRequest::manager() const
+{
+    Q_D(const LockCodeRequest);
+    return d->m_manager.data();
+}
+
+void LockCodeRequest::setManager(CryptoManager *manager)
+{
+    Q_D(LockCodeRequest);
+    if (d->m_manager.data() != manager) {
+        d->m_manager = manager;
+        emit managerChanged();
+    }
+}
+
+void LockCodeRequest::startRequest()
+{
+    Q_D(LockCodeRequest);
+    if (d->m_status != Request::Active && !d->m_manager.isNull()) {
+        d->m_status = Request::Active;
+        emit statusChanged();
+        if (d->m_result.code() != Result::Pending) {
+            d->m_result = Result(Result::Pending);
+            emit resultChanged();
+        }
+
+        QDBusPendingReply<Result> reply;
+        if (d->m_lockCodeRequestType == LockCodeRequest::ModifyLockCode) {
+            reply = d->m_manager->d_ptr->modifyLockCode(d->m_lockCodeTargetType,
+                                                        d->m_lockCodeTarget,
+                                                        d->m_interactionParameters);
+        } else if (d->m_lockCodeRequestType == LockCodeRequest::ProvideLockCode) {
+            reply = d->m_manager->d_ptr->provideLockCode(d->m_lockCodeTargetType,
+                                                         d->m_lockCodeTarget,
+                                                         d->m_interactionParameters);
+        } else { // ForgetLockCode
+            reply = d->m_manager->d_ptr->forgetLockCode(d->m_lockCodeTargetType,
+                                                        d->m_lockCodeTarget,
+                                                        d->m_interactionParameters);
+        }
+
+        if (!reply.isValid() && !reply.error().message().isEmpty()) {
+            d->m_status = Request::Finished;
+            d->m_result = Result(Result::CryptoManagerNotInitialisedError,
+                                 reply.error().message());
+            emit statusChanged();
+            emit resultChanged();
+        } else if (reply.isFinished()
+                // work around a bug in QDBusAbstractInterface / QDBusConnection...
+                && reply.argumentAt<0>().code() != Sailfish::Crypto::Result::Succeeded) {
+            d->m_status = Request::Finished;
+            d->m_result = reply.argumentAt<0>();
+            emit statusChanged();
+            emit resultChanged();
+        } else {
+            d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
+            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+                    [this] {
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingReply<Result> reply = *watcher;
+                this->d_ptr->m_status = Request::Finished;
+                this->d_ptr->m_result = reply.argumentAt<0>();
+                watcher->deleteLater();
+                emit this->statusChanged();
+                emit this->resultChanged();
+            });
+        }
+    }
+}
+
+void LockCodeRequest::waitForFinished()
+{
+    Q_D(LockCodeRequest);
+    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+        d->m_watcher->waitForFinished();
+    }
+}

--- a/lib/Crypto/lockcoderequest.h
+++ b/lib/Crypto/lockcoderequest.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2018 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#ifndef LIBSAILFISHCRYPTO_LOCKCODEREQUEST_H
+#define LIBSAILFISHCRYPTO_LOCKCODEREQUEST_H
+
+#include "Crypto/cryptoglobal.h"
+#include "Crypto/request.h"
+#include "Crypto/cryptomanager.h"
+#include "Crypto/interactionparameters.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QScopedPointer>
+#include <QtCore/QString>
+
+namespace Sailfish {
+
+namespace Crypto {
+
+class LockCodeRequestPrivate;
+class SAILFISH_CRYPTO_API LockCodeRequest : public Sailfish::Crypto::Request
+{
+    Q_OBJECT
+    Q_PROPERTY(LockCodeRequestType lockCodeRequestType READ lockCodeRequestType WRITE setLockCodeRequestType NOTIFY lockCodeRequestTypeChanged)
+    Q_PROPERTY(LockCodeTargetType lockCodeTargetType READ lockCodeTargetType WRITE setLockCodeTargetType NOTIFY lockCodeTargetTypeChanged)
+    Q_PROPERTY(QString lockCodeTarget READ lockCodeTarget WRITE setLockCodeTarget NOTIFY lockCodeTargetChanged)
+    Q_PROPERTY(Sailfish::Crypto::InteractionParameters interactionParameters READ interactionParameters WRITE setInteractionParameters NOTIFY interactionParametersChanged)
+
+public:
+    enum LockCodeRequestType {
+        ModifyLockCode = 0,
+        ProvideLockCode,
+        ForgetLockCode
+    };
+    Q_ENUM(LockCodeRequestType)
+
+    enum LockCodeTargetType {
+        ExtensionPlugin = 1,
+    };
+    Q_ENUM(LockCodeTargetType)
+
+    LockCodeRequest(QObject *parent = Q_NULLPTR);
+    ~LockCodeRequest();
+
+    LockCodeRequestType lockCodeRequestType() const;
+    void setLockCodeRequestType(LockCodeRequestType type);
+
+    LockCodeTargetType lockCodeTargetType() const;
+    void setLockCodeTargetType(LockCodeTargetType type);
+
+    QString lockCodeTarget() const;
+    void setLockCodeTarget(const QString &targetName);
+
+    InteractionParameters interactionParameters() const;
+    void setInteractionParameters(const InteractionParameters &params);
+
+    Sailfish::Crypto::Request::Status status() const Q_DECL_OVERRIDE;
+    Sailfish::Crypto::Result result() const Q_DECL_OVERRIDE;
+
+    Sailfish::Crypto::CryptoManager *manager() const Q_DECL_OVERRIDE;
+    void setManager(Sailfish::Crypto::CryptoManager *manager) Q_DECL_OVERRIDE;
+
+    void startRequest() Q_DECL_OVERRIDE;
+    void waitForFinished() Q_DECL_OVERRIDE;
+
+Q_SIGNALS:
+    void lockCodeRequestTypeChanged();
+    void lockCodeTargetTypeChanged();
+    void lockCodeTargetChanged();
+    void interactionParametersChanged();
+
+private:
+    QScopedPointer<LockCodeRequestPrivate> const d_ptr;
+    Q_DECLARE_PRIVATE(LockCodeRequest)
+};
+
+} // namespace Crypto
+
+} // namespace Sailfish
+
+#endif // LIBSAILFISHCRYPTO_LOCKCODEREQUEST_H

--- a/lib/Crypto/lockcoderequest_p.h
+++ b/lib/Crypto/lockcoderequest_p.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#ifndef LIBSAILFISHCRYPTO_LOCKCODEREQUEST_P_H
+#define LIBSAILFISHCRYPTO_LOCKCODEREQUEST_P_H
+
+#include "Crypto/cryptoglobal.h"
+#include "Crypto/lockcoderequest.h"
+#include "Crypto/cryptomanager.h"
+
+#include <QtCore/QPointer>
+#include <QtCore/QScopedPointer>
+#include <QtCore/QString>
+
+#include <QtDBus/QDBusPendingCallWatcher>
+
+namespace Sailfish {
+
+namespace Crypto {
+
+class LockCodeRequestPrivate
+{
+    Q_DISABLE_COPY(LockCodeRequestPrivate)
+
+public:
+    explicit LockCodeRequestPrivate();
+
+    QPointer<Sailfish::Crypto::CryptoManager> m_manager;
+    Sailfish::Crypto::LockCodeRequest::LockCodeRequestType m_lockCodeRequestType;
+    Sailfish::Crypto::LockCodeRequest::LockCodeTargetType m_lockCodeTargetType;
+    Sailfish::Crypto::InteractionParameters m_interactionParameters;
+    QString m_lockCodeTarget;
+
+    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    Sailfish::Crypto::Request::Status m_status;
+    Sailfish::Crypto::Result m_result;
+};
+
+} // namespace Crypto
+
+} // namespace Sailfish
+
+#endif // LIBSAILFISHCRYPTO_LOCKCODEREQUEST_P_H

--- a/lib/Crypto/serialisation.cpp
+++ b/lib/Crypto/serialisation.cpp
@@ -799,6 +799,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const InteractionParameters &
     argument.beginStructure();
     argument << request.keyName()
              << request.collectionName()
+             << request.pluginName()
              << request.applicationId()
              << request.operation()
              << request.authenticationPluginName()
@@ -814,6 +815,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, InteractionParame
 {
     QString keyName;
     QString collectionName;
+    QString pluginName;
     QString applicationId;
     InteractionParameters::Operation operation = InteractionParameters::UnknownOperation;
     QString authenticationPluginName;
@@ -825,6 +827,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, InteractionParame
     argument.beginStructure();
     argument >> keyName
              >> collectionName
+             >> pluginName
              >> applicationId
              >> operation
              >> authenticationPluginName
@@ -836,6 +839,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, InteractionParame
 
     request.setKeyName(keyName);
     request.setCollectionName(collectionName);
+    request.setPluginName(pluginName);
     request.setApplicationId(applicationId);
     request.setOperation(operation);
     request.setAuthenticationPluginName(authenticationPluginName);
@@ -952,6 +956,25 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, KeyPairGeneration
     KeyPairGenerationParametersPrivate::setSubclassParameters(kpgParams, subclassParameters);
     kpgParams.setCustomParameters(customParameters);
 
+    return argument;
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument, const LockCodeRequest::LockCodeTargetType &type)
+{
+    int itype = static_cast<int>(type);
+    argument.beginStructure();
+    argument << itype;
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, LockCodeRequest::LockCodeTargetType &type)
+{
+    int itype = 0;
+    argument.beginStructure();
+    argument >> itype;
+    argument.endStructure();
+    type = static_cast<LockCodeRequest::LockCodeTargetType>(itype);
     return argument;
 }
 

--- a/lib/Crypto/serialisation_p.h
+++ b/lib/Crypto/serialisation_p.h
@@ -24,6 +24,7 @@
 #include "Crypto/interactionparameters.h"
 #include "Crypto/keyderivationparameters.h"
 #include "Crypto/keypairgenerationparameters.h"
+#include "Crypto/lockcoderequest.h"
 
 #include <QtDBus/QDBusArgument>
 #include <QtDBus/QDBusMetaType>
@@ -97,6 +98,9 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto:
 
 QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::KeyPairGenerationParameters &kpgParams) SAILFISH_CRYPTO_API;
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::KeyPairGenerationParameters &kpgParams) SAILFISH_CRYPTO_API;
+
+QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::LockCodeRequest::LockCodeTargetType &type) SAILFISH_CRYPTO_API;
+const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::LockCodeRequest::LockCodeTargetType &type) SAILFISH_CRYPTO_API;
 
 } // Crypto
 

--- a/lib/Secrets/interactionparameters.cpp
+++ b/lib/Secrets/interactionparameters.cpp
@@ -134,6 +134,27 @@ void InteractionParameters::setCollectionName(const QString &name)
 }
 
 /*!
+ * \brief Returns the name of the extension plugin which is associated with the user input request
+ */
+QString InteractionParameters::pluginName() const
+{
+    return d_ptr->m_pluginName;
+}
+
+/*!
+ * \brief Sets the name of the extension plugin which is associated with the user input request to \a name
+ *
+ * Note that in general, this parameter will be supplied by the secrets service,
+ * so any value set by the client application here will have no effect.
+ */
+void InteractionParameters::setPluginName(const QString &name)
+{
+    if (d_ptr->m_pluginName != name) {
+        d_ptr->m_pluginName = name;
+    }
+}
+
+/*!
  * \brief Returns the identifier of the client application making the request
  */
 QString InteractionParameters::applicationId() const
@@ -278,6 +299,7 @@ bool Sailfish::Secrets::operator==(const InteractionParameters &lhs, const Inter
 {
     return lhs.secretName() == rhs.secretName()
             && lhs.collectionName() == rhs.collectionName()
+            && lhs.pluginName() == rhs.pluginName()
             && lhs.applicationId() == rhs.applicationId()
             && lhs.operation() == rhs.operation()
             && lhs.authenticationPluginName() == rhs.authenticationPluginName()
@@ -305,6 +327,9 @@ bool Sailfish::Secrets::operator<(const InteractionParameters &lhs, const Intera
 
     if (lhs.secretName() != rhs.secretName())
         return lhs.secretName() < rhs.secretName();
+
+    if (lhs.pluginName() != rhs.pluginName())
+        return lhs.pluginName() < rhs.pluginName();
 
     if (lhs.operation() != rhs.operation())
         return lhs.operation() < rhs.operation();

--- a/lib/Secrets/interactionparameters.h
+++ b/lib/Secrets/interactionparameters.h
@@ -23,6 +23,7 @@ class SAILFISH_SECRETS_API InteractionParameters {
     Q_GADGET
     Q_PROPERTY(QString secretName READ secretName WRITE setSecretName)
     Q_PROPERTY(QString collectionName READ collectionName WRITE setCollectionName)
+    Q_PROPERTY(QString pluginName READ pluginName WRITE setPluginName)
     Q_PROPERTY(QString applicationId READ applicationId WRITE setApplicationId)
     Q_PROPERTY(Operation operation READ operation WRITE setOperation)
     Q_PROPERTY(QString authenticationPluginName READ authenticationPluginName WRITE setAuthenticationPluginName)
@@ -67,26 +68,30 @@ public:
         LockDatabase        = 1 << 2,
         ModifyLockDatabase  = 1 << 3,
 
-        CreateCollection    = 1 << 4,
-        UnlockCollection    = 1 << 5,
-        LockCollection      = 1 << 6,
-        ModifyLockCollection= 1 << 7,
-        DeleteCollection    = 1 << 8,
+        UnlockPlugin        = 1 << 4,
+        LockPlugin          = 1 << 5,
+        ModifyLockPlugin    = 1 << 6,
 
-        ReadSecret          = 1 << 9,
-        StoreSecret         = 1 << 10,
-        UnlockSecret        = 1 << 11,
-        LockSecret          = 1 << 12,
-        ModifyLockSecret    = 1 << 13,
-        DeleteSecret        = 1 << 14,
+        CreateCollection    = 1 << 7,
+        UnlockCollection    = 1 << 8,
+        LockCollection      = 1 << 9,
+        ModifyLockCollection= 1 << 10,
+        DeleteCollection    = 1 << 11,
 
-        Encrypt             = 1 << 15,
-        Decrypt             = 1 << 16,
-        Sign                = 1 << 17,
-        Verify              = 1 << 18,
-        DeriveDigest        = 1 << 19,
-        DeriveMac           = 1 << 20,
-        DeriveKey           = 1 << 21,
+        ReadSecret          = 1 << 12,
+        StoreSecret         = 1 << 13,
+        UnlockSecret        = 1 << 14,
+        LockSecret          = 1 << 15,
+        ModifyLockSecret    = 1 << 16,
+        DeleteSecret        = 1 << 17,
+
+        Encrypt             = 1 << 18,
+        Decrypt             = 1 << 19,
+        Sign                = 1 << 20,
+        Verify              = 1 << 21,
+        DeriveDigest        = 1 << 22,
+        DeriveMac           = 1 << 23,
+        DeriveKey           = 1 << 24,
 
         // reserved
         LastOperation       = 1 << 30
@@ -106,6 +111,9 @@ public:
 
     QString collectionName() const;
     void setCollectionName(const QString &name);
+
+    QString pluginName() const;
+    void setPluginName(const QString &name);
 
     QString applicationId() const;
     void setApplicationId(const QString &id);

--- a/lib/Secrets/interactionparameters_p.h
+++ b/lib/Secrets/interactionparameters_p.h
@@ -25,6 +25,7 @@ public:
 
     QString m_secretName;
     QString m_collectionName;
+    QString m_pluginName;
     QString m_applicationId;
     Sailfish::Secrets::InteractionParameters::Operation m_operation = Sailfish::Secrets::InteractionParameters::UnknownOperation;
     QString m_authenticationPluginName;

--- a/lib/Secrets/lockcoderequest.h
+++ b/lib/Secrets/lockcoderequest.h
@@ -26,8 +26,8 @@ class SAILFISH_SECRETS_API LockCodeRequest : public Sailfish::Secrets::Request
 {
     Q_OBJECT
     Q_PROPERTY(LockCodeRequestType lockCodeRequestType READ lockCodeRequestType WRITE setLockCodeRequestType NOTIFY lockCodeRequestTypeChanged)
-    Q_PROPERTY(QString secretName READ secretName WRITE setSecretName NOTIFY secretNameChanged)
-    Q_PROPERTY(QString collectionName READ collectionName WRITE setCollectionName NOTIFY collectionNameChanged)
+    Q_PROPERTY(LockCodeTargetType lockCodeTargetType READ lockCodeTargetType WRITE setLockCodeTargetType NOTIFY lockCodeTargetTypeChanged)
+    Q_PROPERTY(QString lockCodeTarget READ lockCodeTarget WRITE setLockCodeTarget NOTIFY lockCodeTargetChanged)
     Q_PROPERTY(Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode READ userInteractionMode WRITE setUserInteractionMode NOTIFY userInteractionModeChanged)
     Q_PROPERTY(Sailfish::Secrets::InteractionParameters interactionParameters READ interactionParameters WRITE setInteractionParameters NOTIFY interactionParametersChanged)
 
@@ -39,17 +39,25 @@ public:
     };
     Q_ENUM(LockCodeRequestType)
 
+    enum LockCodeTargetType {
+        BookkeepingDatabase = 0,
+        ExtensionPlugin,
+        Collection,
+        StandaloneSecret
+    };
+    Q_ENUM(LockCodeTargetType)
+
     LockCodeRequest(QObject *parent = Q_NULLPTR);
     ~LockCodeRequest();
 
     LockCodeRequestType lockCodeRequestType() const;
     void setLockCodeRequestType(LockCodeRequestType type);
 
-    QString secretName() const;
-    void setSecretName(const QString &name);
+    LockCodeTargetType lockCodeTargetType() const;
+    void setLockCodeTargetType(LockCodeTargetType type);
 
-    QString collectionName() const;
-    void setCollectionName(const QString &name);
+    QString lockCodeTarget() const;
+    void setLockCodeTarget(const QString &targetName);
 
     Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode() const;
     void setUserInteractionMode(Sailfish::Secrets::SecretManager::UserInteractionMode mode);
@@ -68,8 +76,8 @@ public:
 
 Q_SIGNALS:
     void lockCodeRequestTypeChanged();
-    void secretNameChanged();
-    void collectionNameChanged();
+    void lockCodeTargetTypeChanged();
+    void lockCodeTargetChanged();
     void userInteractionModeChanged();
     void interactionParametersChanged();
 

--- a/lib/Secrets/lockcoderequest_p.h
+++ b/lib/Secrets/lockcoderequest_p.h
@@ -30,11 +30,11 @@ public:
     explicit LockCodeRequestPrivate();
 
     QPointer<Sailfish::Secrets::SecretManager> m_manager;
-    LockCodeRequest::LockCodeRequestType m_lockCodeRequestType;
+    Sailfish::Secrets::LockCodeRequest::LockCodeRequestType m_lockCodeRequestType;
+    Sailfish::Secrets::LockCodeRequest::LockCodeTargetType m_lockCodeTargetType;
     Sailfish::Secrets::SecretManager::UserInteractionMode m_userInteractionMode;
     Sailfish::Secrets::InteractionParameters m_interactionParameters;
-    QString m_secretName;
-    QString m_collectionName;
+    QString m_lockCodeTarget;
 
     QScopedPointer<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;

--- a/lib/Secrets/secretmanager.cpp
+++ b/lib/Secrets/secretmanager.cpp
@@ -508,8 +508,8 @@ SecretManagerPrivate::deleteSecret(
 
 QDBusPendingReply<Result>
 SecretManagerPrivate::modifyLockCode(
-        const QString &secretName,
-        const QString &collectionName,
+        LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+        const QString &lockCodeTarget,
         const InteractionParameters &interactionParameters,
         SecretManager::UserInteractionMode userInteractionMode)
 {
@@ -530,8 +530,8 @@ SecretManagerPrivate::modifyLockCode(
     QDBusPendingReply<Result> reply
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("modifyLockCode"),
-                QVariantList() << QVariant::fromValue<QString>(secretName)
-                               << QVariant::fromValue<QString>(collectionName)
+                QVariantList() << QVariant::fromValue<LockCodeRequest::LockCodeTargetType>(lockCodeTargetType)
+                               << QVariant::fromValue<QString>(lockCodeTarget)
                                << QVariant::fromValue<InteractionParameters>(interactionParameters)
                                << QVariant::fromValue<SecretManager::UserInteractionMode>(userInteractionMode)
                                << QVariant::fromValue<QString>(interactionServiceAddress));
@@ -540,8 +540,8 @@ SecretManagerPrivate::modifyLockCode(
 
 QDBusPendingReply<Result>
 SecretManagerPrivate::provideLockCode(
-        const QString &secretName,
-        const QString &collectionName,
+        LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+        const QString &lockCodeTarget,
         const InteractionParameters &interactionParameters,
         SecretManager::UserInteractionMode userInteractionMode)
 {
@@ -562,8 +562,8 @@ SecretManagerPrivate::provideLockCode(
     QDBusPendingReply<Result> reply
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("provideLockCode"),
-                QVariantList() << QVariant::fromValue<QString>(secretName)
-                               << QVariant::fromValue<QString>(collectionName)
+                QVariantList() << QVariant::fromValue<LockCodeRequest::LockCodeTargetType>(lockCodeTargetType)
+                               << QVariant::fromValue<QString>(lockCodeTarget)
                                << QVariant::fromValue<InteractionParameters>(interactionParameters)
                                << QVariant::fromValue<SecretManager::UserInteractionMode>(userInteractionMode)
                                << QVariant::fromValue<QString>(interactionServiceAddress));
@@ -572,8 +572,8 @@ SecretManagerPrivate::provideLockCode(
 
 QDBusPendingReply<Result>
 SecretManagerPrivate::forgetLockCode(
-        const QString &secretName,
-        const QString &collectionName,
+        LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+        const QString &lockCodeTarget,
         const InteractionParameters &interactionParameters,
         SecretManager::UserInteractionMode userInteractionMode)
 {
@@ -594,8 +594,8 @@ SecretManagerPrivate::forgetLockCode(
     QDBusPendingReply<Result> reply
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("forgetLockCode"),
-                QVariantList() << QVariant::fromValue<QString>(secretName)
-                               << QVariant::fromValue<QString>(collectionName)
+                QVariantList() << QVariant::fromValue<LockCodeRequest::LockCodeTargetType>(lockCodeTargetType)
+                               << QVariant::fromValue<QString>(lockCodeTarget)
                                << QVariant::fromValue<InteractionParameters>(interactionParameters)
                                << QVariant::fromValue<SecretManager::UserInteractionMode>(userInteractionMode)
                                << QVariant::fromValue<QString>(interactionServiceAddress));

--- a/lib/Secrets/secretmanager_p.h
+++ b/lib/Secrets/secretmanager_p.h
@@ -15,6 +15,7 @@
 #include "Secrets/extensionplugins.h"
 #include "Secrets/interactionview.h"
 #include "Secrets/interactionservice_p.h"
+#include "Secrets/lockcoderequest.h"
 
 #include <QtDBus/QDBusInterface>
 #include <QtDBus/QDBusContext>
@@ -136,22 +137,22 @@ public:
 
     // modify the passphrase used to encrypt a collection or standalone secret
     QDBusPendingReply<Sailfish::Secrets::Result> modifyLockCode(
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode);
 
     // provide the passphrase to unlock a collection or standalone secret
     QDBusPendingReply<Sailfish::Secrets::Result> provideLockCode(
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode);
 
     // forget the passphrase and relock a collection or standalone secret
     QDBusPendingReply<Sailfish::Secrets::Result> forgetLockCode(
-            const QString &secretName,
-            const QString &collectionName,
+            Sailfish::Secrets::LockCodeRequest::LockCodeTargetType lockCodeTargetType,
+            const QString &lockCodeTarget,
             const Sailfish::Secrets::InteractionParameters &interactionParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode);
 

--- a/lib/Secrets/secretsdaemonconnection.cpp
+++ b/lib/Secrets/secretsdaemonconnection.cpp
@@ -15,6 +15,7 @@
 #include "Secrets/result.h"
 #include "Secrets/secret.h"
 #include "Secrets/interactionparameters.h"
+#include "Secrets/lockcoderequest.h"
 
 #include <QtDBus/QDBusReply>
 #include <QtDBus/QDBusInterface>
@@ -174,6 +175,7 @@ void Sailfish::Secrets::SecretsDaemonConnection::registerDBusTypes()
     qRegisterMetaType<Sailfish::Secrets::InteractionParameters::EchoMode>("Sailfish::Secrets::InteractionParameters::EchoMode");
     qRegisterMetaType<Sailfish::Secrets::InteractionParameters::Operation>("Sailfish::Secrets::InteractionParameters::Operation");
     qRegisterMetaType<Sailfish::Secrets::InteractionResponse>("Sailfish::Secrets::InteractionResponse");
+    qRegisterMetaType<Sailfish::Secrets::LockCodeRequest::LockCodeTargetType>("Sailfish::Secrets::LockCodeRequest::LockCodeTargetType");
 
     qDBusRegisterMetaType<Sailfish::Secrets::SecretManager::UserInteractionMode>();
     qDBusRegisterMetaType<Sailfish::Secrets::SecretManager::AccessControlMode>();
@@ -199,4 +201,5 @@ void Sailfish::Secrets::SecretsDaemonConnection::registerDBusTypes()
     qDBusRegisterMetaType<Sailfish::Secrets::InteractionParameters::Operation>();
     qDBusRegisterMetaType<Sailfish::Secrets::InteractionParameters>();
     qDBusRegisterMetaType<Sailfish::Secrets::InteractionResponse>();
+    qDBusRegisterMetaType<Sailfish::Secrets::LockCodeRequest::LockCodeTargetType>();
 }

--- a/lib/Secrets/serialisation.cpp
+++ b/lib/Secrets/serialisation.cpp
@@ -415,6 +415,25 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, InteractionRespon
     return argument;
 }
 
+QDBusArgument &operator<<(QDBusArgument &argument, const LockCodeRequest::LockCodeTargetType &type)
+{
+    int itype = static_cast<int>(type);
+    argument.beginStructure();
+    argument << itype;
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, LockCodeRequest::LockCodeTargetType &type)
+{
+    int itype = 0;
+    argument.beginStructure();
+    argument >> itype;
+    argument.endStructure();
+    type = static_cast<LockCodeRequest::LockCodeTargetType>(itype);
+    return argument;
+}
+
 } // namespace Secrets
 
 } // namespace Sailfish

--- a/lib/Secrets/serialisation.cpp
+++ b/lib/Secrets/serialisation.cpp
@@ -345,6 +345,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const InteractionParameters &
     argument.beginStructure();
     argument << request.secretName()
              << request.collectionName()
+             << request.pluginName()
              << request.applicationId()
              << request.operation()
              << request.authenticationPluginName()
@@ -360,6 +361,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, InteractionParame
 {
     QString secretName;
     QString collectionName;
+    QString pluginName;
     QString applicationId;
     InteractionParameters::Operation operation = InteractionParameters::UnknownOperation;
     QString authenticationPluginName;
@@ -371,6 +373,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, InteractionParame
     argument.beginStructure();
     argument >> secretName
              >> collectionName
+             >> pluginName
              >> applicationId
              >> operation
              >> authenticationPluginName
@@ -382,6 +385,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, InteractionParame
 
     request.setSecretName(secretName);
     request.setCollectionName(collectionName);
+    request.setPluginName(pluginName);
     request.setApplicationId(applicationId);
     request.setOperation(operation);
     request.setAuthenticationPluginName(authenticationPluginName);

--- a/lib/Secrets/serialisation_p.h
+++ b/lib/Secrets/serialisation_p.h
@@ -21,6 +21,7 @@
 #include "Secrets/secretmanager.h"
 #include "Secrets/interactionparameters.h"
 #include "Secrets/interactionresponse.h"
+#include "Secrets/lockcoderequest.h"
 
 #include <QtDBus/QDBusArgument>
 #include <QtDBus/QDBusMetaType>
@@ -68,6 +69,9 @@ QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Secrets::Inte
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Secrets::InteractionParameters &request) SAILFISH_SECRETS_API;
 QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Secrets::InteractionResponse &response) SAILFISH_SECRETS_API;
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Secrets::InteractionResponse &response) SAILFISH_SECRETS_API;
+
+QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Secrets::LockCodeRequest::LockCodeTargetType &type) SAILFISH_SECRETS_API;
+const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Secrets::LockCodeRequest::LockCodeTargetType &type) SAILFISH_SECRETS_API;
 
 } // namespace Secrets
 

--- a/plugins/inappauthplugin/plugin.cpp
+++ b/plugins/inappauthplugin/plugin.cpp
@@ -81,6 +81,43 @@ Daemon::Plugins::InAppPlugin::beginUserInputInteraction(
                                   Q_ARG(Sailfish::Secrets::Result, Sailfish::Secrets::Result(Sailfish::Secrets::Result::Succeeded)),
                                   Q_ARG(QByteArray, newLockCount % 2 == 1 ? QByteArray("masterlock") : QByteArray()));
         return Result(Result::Pending);
+    } else if (interactionParameters.promptText()
+               == QLatin1String("Provide the master unlock code for device secrets")) {
+        QMetaObject::invokeMethod(this, "userInputInteractionCompleted", Qt::QueuedConnection,
+                                  Q_ARG(uint, callerPid),
+                                  Q_ARG(qint64, requestId),
+                                  Q_ARG(Sailfish::Secrets::InteractionParameters, interactionParameters),
+                                  Q_ARG(QString, interactionServiceAddress),
+                                  Q_ARG(Sailfish::Secrets::Result, Sailfish::Secrets::Result(Sailfish::Secrets::Result::Succeeded)),
+                                  Q_ARG(QByteArray, QByteArray("masterlock")));
+        return Result(Result::Pending);
+    } else if (interactionParameters.promptText().startsWith(QLatin1String("Enter the old lock code for the plugin"))) {
+        QMetaObject::invokeMethod(this, "userInputInteractionCompleted", Qt::QueuedConnection,
+                                  Q_ARG(uint, callerPid),
+                                  Q_ARG(qint64, requestId),
+                                  Q_ARG(Sailfish::Secrets::InteractionParameters, interactionParameters),
+                                  Q_ARG(QString, interactionServiceAddress),
+                                  Q_ARG(Sailfish::Secrets::Result, Sailfish::Secrets::Result(Sailfish::Secrets::Result::Succeeded)),
+                                  Q_ARG(QByteArray, QByteArray()));
+        return Result(Result::Pending);
+    } else if (interactionParameters.promptText().startsWith(QLatin1String("Enter the new lock code for the plugin"))) {
+        QMetaObject::invokeMethod(this, "userInputInteractionCompleted", Qt::QueuedConnection,
+                                  Q_ARG(uint, callerPid),
+                                  Q_ARG(qint64, requestId),
+                                  Q_ARG(Sailfish::Secrets::InteractionParameters, interactionParameters),
+                                  Q_ARG(QString, interactionServiceAddress),
+                                  Q_ARG(Sailfish::Secrets::Result, Sailfish::Secrets::Result(Sailfish::Secrets::Result::Succeeded)),
+                                  Q_ARG(QByteArray, QByteArray("pluginlock")));
+        return Result(Result::Pending);
+    } else if (interactionParameters.promptText().startsWith(QLatin1String("Provide the unlock code for the plugin"))) {
+        QMetaObject::invokeMethod(this, "userInputInteractionCompleted", Qt::QueuedConnection,
+                                  Q_ARG(uint, callerPid),
+                                  Q_ARG(qint64, requestId),
+                                  Q_ARG(Sailfish::Secrets::InteractionParameters, interactionParameters),
+                                  Q_ARG(QString, interactionServiceAddress),
+                                  Q_ARG(Sailfish::Secrets::Result, Sailfish::Secrets::Result(Sailfish::Secrets::Result::Succeeded)),
+                                  Q_ARG(QByteArray, QByteArray("pluginlock")));
+        return Result(Result::Pending);
     }
 #endif
 

--- a/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
+++ b/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
@@ -1976,15 +1976,34 @@ void tst_cryptorequests::lockCode()
     QCOMPARE(lcr.lockCodeRequestType(), Sailfish::Crypto::LockCodeRequest::ModifyLockCode);
     lcr.setLockCodeTargetType(Sailfish::Crypto::LockCodeRequest::ExtensionPlugin);
     QCOMPARE(lcr.lockCodeTargetType(), Sailfish::Crypto::LockCodeRequest::ExtensionPlugin);
-    lcr.setLockCodeTarget(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
-    QCOMPARE(lcr.lockCodeTarget(), DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
+    lcr.setLockCodeTarget(DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
+    QCOMPARE(lcr.lockCodeTarget(), DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     lcr.setInteractionParameters(uiParams);
     QCOMPARE(lcr.interactionParameters(), uiParams);
     lcr.startRequest();
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(lcr);
     QCOMPARE(lcr.status(), Sailfish::Crypto::Request::Finished);
-    qDebug() << "XXXXXXXXXXXXXXXX - " << lcr.result().errorMessage();
-    QSKIP("TODO - explicit plugin locking not yet implemented!");
+    QCOMPARE(lcr.result().code(), Sailfish::Crypto::Result::Failed);
+    QCOMPARE(lcr.result().errorMessage(), QStringLiteral("Crypto plugin %1 does not support locking")
+                                                    .arg(DEFAULT_TEST_CRYPTO_PLUGIN_NAME));
+
+    uiParams.setPromptText(QLatin1String("Provide the lock code for the crypto plugin"));
+    lcr.setLockCodeRequestType(Sailfish::Crypto::LockCodeRequest::ProvideLockCode);
+    lcr.setInteractionParameters(uiParams);
+    lcr.startRequest();
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(lcr);
+    QCOMPARE(lcr.status(), Sailfish::Crypto::Request::Finished);
+    QCOMPARE(lcr.result().code(), Sailfish::Crypto::Result::Failed);
+    QCOMPARE(lcr.result().errorMessage(), QStringLiteral("Crypto plugin %1 does not support locking")
+                                                    .arg(DEFAULT_TEST_CRYPTO_PLUGIN_NAME));
+
+    lcr.setLockCodeRequestType(Sailfish::Crypto::LockCodeRequest::ForgetLockCode);
+    lcr.startRequest();
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(lcr);
+    QCOMPARE(lcr.status(), Sailfish::Crypto::Request::Finished);
+    QCOMPARE(lcr.result().code(), Sailfish::Crypto::Result::Failed);
+    QCOMPARE(lcr.result().errorMessage(), QStringLiteral("Crypto plugin %1 does not support locking")
+                                                    .arg(DEFAULT_TEST_CRYPTO_PLUGIN_NAME));
 }
 
 #include "tst_cryptorequests.moc"

--- a/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
+++ b/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
@@ -22,6 +22,7 @@
 #include "Crypto/generatekeyrequest.h"
 #include "Crypto/generaterandomdatarequest.h"
 #include "Crypto/generatestoredkeyrequest.h"
+#include "Crypto/lockcoderequest.h"
 #include "Crypto/plugininforequest.h"
 #include "Crypto/seedrandomdatageneratorrequest.h"
 #include "Crypto/signrequest.h"
@@ -103,6 +104,7 @@ private slots:
     void cipherBenchmark_data();
     void cipherBenchmark();
     void cipherTimeout();
+    void lockCode();
 
 private:
     void addCryptoTestData()
@@ -1958,6 +1960,31 @@ void tst_cryptorequests::cipherTimeout()
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(dcr);
     QCOMPARE(dcr.status(), Sailfish::Secrets::Request::Finished);
     QCOMPARE(dcr.result().code(), Sailfish::Secrets::Result::Succeeded);
+}
+
+void tst_cryptorequests::lockCode()
+{
+    Sailfish::Crypto::InteractionParameters uiParams;
+    uiParams.setAuthenticationPluginName(IN_APP_TEST_AUTHENTICATION_PLUGIN);
+    uiParams.setInputType(Sailfish::Crypto::InteractionParameters::AlphaNumericInput);
+    uiParams.setEchoMode(Sailfish::Crypto::InteractionParameters::NormalEcho);
+    uiParams.setPromptText(QLatin1String("Modify the lock code for the crypto plugin"));
+
+    Sailfish::Crypto::LockCodeRequest lcr;
+    lcr.setManager(&cm);
+    lcr.setLockCodeRequestType(Sailfish::Crypto::LockCodeRequest::ModifyLockCode);
+    QCOMPARE(lcr.lockCodeRequestType(), Sailfish::Crypto::LockCodeRequest::ModifyLockCode);
+    lcr.setLockCodeTargetType(Sailfish::Crypto::LockCodeRequest::ExtensionPlugin);
+    QCOMPARE(lcr.lockCodeTargetType(), Sailfish::Crypto::LockCodeRequest::ExtensionPlugin);
+    lcr.setLockCodeTarget(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
+    QCOMPARE(lcr.lockCodeTarget(), DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
+    lcr.setInteractionParameters(uiParams);
+    QCOMPARE(lcr.interactionParameters(), uiParams);
+    lcr.startRequest();
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(lcr);
+    QCOMPARE(lcr.status(), Sailfish::Crypto::Request::Finished);
+    qDebug() << "XXXXXXXXXXXXXXXX - " << lcr.result().errorMessage();
+    QSKIP("TODO - explicit plugin locking not yet implemented!");
 }
 
 #include "tst_cryptorequests.moc"

--- a/tests/Secrets/tst_secretsrequests/tst_secretsrequests.cpp
+++ b/tests/Secrets/tst_secretsrequests/tst_secretsrequests.cpp
@@ -1569,6 +1569,8 @@ void tst_secretsrequests::lockCode()
     QSignalSpy lcrss(&lcr, &LockCodeRequest::statusChanged);
     lcr.setLockCodeRequestType(LockCodeRequest::ModifyLockCode);
     QCOMPARE(lcr.lockCodeRequestType(), LockCodeRequest::ModifyLockCode);
+    lcr.setLockCodeTargetType(LockCodeRequest::BookkeepingDatabase);
+    QCOMPARE(lcr.lockCodeTargetType(), LockCodeRequest::BookkeepingDatabase);
     lcr.setUserInteractionMode(SecretManager::ApplicationInteraction);
     QCOMPARE(lcr.userInteractionMode(), SecretManager::ApplicationInteraction);
     InteractionParameters uiParams;
@@ -1576,8 +1578,7 @@ void tst_secretsrequests::lockCode()
     uiParams.setInputType(InteractionParameters::AlphaNumericInput);
     uiParams.setEchoMode(InteractionParameters::PasswordEcho);
     lcr.setInteractionParameters(uiParams);
-    lcr.setSecretName(QString());
-    lcr.setCollectionName(QString());
+    lcr.setLockCodeTarget(QString());
     lcr.startRequest();
     QCOMPARE(lcrss.count(), 1);
     QCOMPARE(lcr.status(), Request::Active);


### PR DESCRIPTION
Previously, we only supported the bookkeeping database, a collection,
or a standalone secret to be the target of a code code request.
This commit adds support for specifying an extension plugin as the
target of the request, in case a particular plugin needs to be
explicitly unlocked via a non-masterlock (bookkeeping database key)
lock code request.

Contributes to JB#36797