### PR TITLE
[sailfish-crypto] Add autotests for GCM mode (for AES encryption). Contributes to JB#40058

### DIFF
--- a/plugins/opensslcryptoplugin/evp/evp.c
+++ b/plugins/opensslcryptoplugin/evp/evp.c
@@ -90,6 +90,15 @@ const EVP_CIPHER *osslevp_aes_cipher(int block_mode, int key_length_bytes)
             fprintf(stderr, "%s: %d\n", "unsupported encryption size for OFB block mode", key_length_bits);
             return NULL;
         }
+    } else if (block_mode == 10) {  // Sailfish::Crypto::CryptoManager::BlockModeGcm
+        switch (key_length_bits) {
+        case 128: return EVP_aes_128_gcm();
+        case 192: return EVP_aes_192_gcm();
+        case 256: return EVP_aes_256_gcm();
+        default:
+            fprintf(stderr, "%s: %d\n", "unsupported encryption size for GCM block mode", key_length_bits);
+            return NULL;
+        }
     }
 
     fprintf(stderr, "%s\n", "unsupported encryption mode");

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
@@ -767,14 +767,14 @@ Daemon::Plugins::OpenSslCryptoPlugin::initialiseCipherSession(
             if (evp_cipher == NULL) {
                 EVP_CIPHER_CTX_free(evp_cipher_ctx);
                 return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginCipherSessionError,
-                                                QLatin1String("Invalid key size for AES CBC operation"));
+                                                QLatin1String("Cannot create cipher for AES encryption, check key size and block mode"));
             }
             if (EVP_EncryptInit_ex(evp_cipher_ctx, evp_cipher, NULL,
                                    reinterpret_cast<const unsigned char*>(fullKey.secretKey().constData()),
                                    reinterpret_cast<const unsigned char*>(initIV.constData())) != 1) {
                 EVP_CIPHER_CTX_free(evp_cipher_ctx);
                 return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginCipherSessionError,
-                                                QLatin1String("Unable to initialise encryption cipher context in AES 256 CBC mode"));
+                                                QLatin1String("Unable to initialise encryption cipher context in AES 256 mode"));
             }
         }
     } else if (operation == Sailfish::Crypto::CryptoManager::OperationDecrypt) {
@@ -788,14 +788,14 @@ Daemon::Plugins::OpenSslCryptoPlugin::initialiseCipherSession(
             if (evp_cipher == NULL) {
                 EVP_CIPHER_CTX_free(evp_cipher_ctx);
                 return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginCipherSessionError,
-                                                QLatin1String("Invalid key size for AES CBC operation"));
+                                                QLatin1String("Cannot create cipher for AES deccryption, check key size and block mode"));
             }
             if (EVP_DecryptInit_ex(evp_cipher_ctx, evp_cipher, NULL,
                                    reinterpret_cast<const unsigned char *>(fullKey.secretKey().constData()),
                                    reinterpret_cast<const unsigned char *>(initIV.constData())) != 1) {
                 EVP_CIPHER_CTX_free(evp_cipher_ctx);
                 return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginCipherSessionError,
-                                                QLatin1String("Unable to initialise decryption cipher context in AES 256 CBC mode"));
+                                                QLatin1String("Unable to initialise decryption cipher context in AES 256 mode"));
             }
         }
     } else {


### PR DESCRIPTION
WIP. The test fails at the moment because the decrypted plaintext has an extra 16 bytes on the end. Looking at the plugin, it looks like GCM decryption is implemented correctly as per the openssl docs, so this needs some investigation as to why it's failing.