### PR TITLE
Sign, verify and digest support for OpenSSL crypto plugin

### DIFF
--- a/lib/Crypto/cryptomanager.h
+++ b/lib/Crypto/cryptomanager.h
@@ -55,7 +55,8 @@ public:
         AlgorithmSquare         = 350,
         AlgorithmSerpent        = 360,
         AlgorithmPanama         = 370,
-    LastAlgorithm               = 4095 // reserve
+    LastSymmetricAlgorithm      = 4095, // reserve
+    LastAlgorithm               = LastSymmetricAlgorithm // reserve
     };
     Q_ENUM(Algorithm)
 

--- a/lib/Crypto/result.h
+++ b/lib/Crypto/result.h
@@ -56,12 +56,16 @@ public:
         EmptySecretKey = 30,
         EmptyPrivateKey,
         EmptyPublicKey,
+        EmptyData,
+        EmptySignature,
 
         CryptoPluginEncryptionError = 40,
         CryptoPluginDecryptionError,
         CryptoPluginRandomDataError,
         CryptoPluginCipherSessionError,
         CryptoPluginKeyGenerationError,
+        CryptoPluginSigningError,
+        CryptoPluginVerificationError,
 
         NetworkError = 98,
         NetworkSslError = 99,

--- a/lib/Crypto/result.h
+++ b/lib/Crypto/result.h
@@ -64,6 +64,7 @@ public:
         CryptoPluginRandomDataError,
         CryptoPluginCipherSessionError,
         CryptoPluginKeyGenerationError,
+        CryptoPluginDigestError,
         CryptoPluginSigningError,
         CryptoPluginVerificationError,
 

--- a/plugins/opensslcryptoplugin/evp/evp.c
+++ b/plugins/opensslcryptoplugin/evp/evp.c
@@ -329,3 +329,174 @@ int osslevp_aes_decrypt_ciphertext(int block_mode,
     plaintext_length = update_length + final_length;
     return plaintext_length;
 }
+
+/*
+    int osslevp_sign(const EVP_MD *digestFunc,
+                     EVP_PKEY *pkey,
+                     const void *bytes,
+                     size_t bytesCount,
+                     uint8_t **signature,
+                     size_t *signatureLength)
+    Implements signing according to:
+    https://wiki.openssl.org/index.php/EVP_Signing_and_Verifying
+    Arguments:
+    * digestFunc: should be the result of an EVP function, eg. EVP_sha256()
+    * pkey: the private key used for signing
+    * bytes: data to sign
+    * bytesCount: the number of bytes in 'bytes'
+    * signature: where the generated signature will be stored, which will have to be freed using OPENSSL_free
+    * signatureLength: where the length of the generated signature will be stored
+    Return value:
+    * 1 when the operation was successful.
+    * less than 0 when there was an error.
+ */
+int osslevp_sign(const EVP_MD *digestFunc,
+                 EVP_PKEY *pkey,
+                 const void *bytes,
+                 size_t bytesCount,
+                 uint8_t **signature,
+                 size_t *signatureLength)
+{
+    EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
+    if (!mdctx) {
+        ERR_print_errors_fp(stderr);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to allocate memory for MD context");
+        return -1;
+    }
+
+    int r = EVP_DigestSignInit(mdctx, NULL, digestFunc, NULL, pkey);
+    if (r != 1) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to initialise DigestSign");
+        return -1;
+    }
+
+    r = EVP_DigestSignUpdate(mdctx, bytes, bytesCount);
+    if (r != 1) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to update DigestSign");
+        return -1;
+    }
+
+    r = EVP_DigestSignFinal(mdctx, NULL, signatureLength);
+    if (r != 1) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to finalize DigestSign (1st call)");
+        return -1;
+    }
+
+    *signature = (uint8_t *) OPENSSL_malloc(*signatureLength);
+    if (!signature) {
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to allocate memory for signature");
+        return -1;
+    }
+
+    r = EVP_DigestSignFinal(mdctx, *signature, signatureLength);
+    if (r != 1) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        OPENSSL_free(*signature);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to finalize DigestSign (2nd call)");
+        return -1;
+    }
+
+    EVP_MD_CTX_destroy(mdctx);
+    return 1;
+}
+
+/*
+    int osslevp_verify(const EVP_MD *digestFunc,
+                       EVP_PKEY *pkey,
+                       const void *bytes,
+                       size_t bytesCount,
+                       const uint8_t *signature,
+                       size_t signatureLength)
+    Verifies a signature according to:
+    https://wiki.openssl.org/index.php/EVP_Signing_and_Verifying
+    Arguments:
+    * digestFunc: should be the result of an EVP function, eg. EVP_sha256()
+    * pkey: the public key used for verification (pair of the private key used for signing)
+    * bytes: data whose signature must be verified
+    * bytesCount: the number of bytes in 'bytes'
+    * signature: the signature which needs to be verified
+    * signatureLength: byte length of the signature to be verified
+    Return value:
+    * 1 when the operation was successful and the signature is correct.
+    * 0 when the operation was successful but the signature is NOT correct.
+    * less than 0 when there was an error and the operation was unsuccessful.
+ */
+int osslevp_verify(const EVP_MD *digestFunc,
+                   EVP_PKEY *pkey,
+                   const void *bytes,
+                   size_t bytesCount,
+                   const uint8_t *signature,
+                   size_t signatureLength)
+{
+    EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
+    if (!mdctx) {
+        ERR_print_errors_fp(stderr);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to allocate memory for MD context");
+        return -1;
+    }
+
+    int r = EVP_DigestVerifyInit(mdctx, NULL, digestFunc, NULL, pkey);
+    if (r != 1) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to initialise DigestVerify");
+        return -1;
+    }
+
+    r = EVP_DigestVerifyUpdate(mdctx, bytes, bytesCount);
+    if (r != 1) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to update DigestVerify");
+        return -1;
+    }
+
+    r = EVP_DigestVerifyFinal(mdctx, signature, signatureLength);
+    if (r < 0) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to finalize DigestVerify");
+        return r;
+    }
+
+    EVP_MD_CTX_destroy(mdctx);
+    return r;
+}

--- a/plugins/opensslcryptoplugin/evp/evp.c
+++ b/plugins/opensslcryptoplugin/evp/evp.c
@@ -331,14 +331,106 @@ int osslevp_aes_decrypt_ciphertext(int block_mode,
 }
 
 /*
+    int osslevp_digest(const EVP_MD *digestFunc,
+                       const void *bytes,
+                       size_t bytesCount,
+                       uint8_t **digest,
+                       size_t *digestLength)
+
+    Implements digests according to:
+    https://wiki.openssl.org/index.php/EVP_Message_Digests
+
+    Arguments:
+    * digestFunc: should be the result of an EVP function, eg. EVP_sha256()
+    * bytes: data to digest
+    * bytesCount: the number of bytes in 'bytes'
+    * digest: where the generated digest will be stored, which will have to be freed using OPENSSL_free
+    * digestLength: where the length of the generated digest will be stored
+
+    Return value:
+    * 1 when the operation was successful.
+    * less than 0 when there was an error.
+ */
+int osslevp_digest(const EVP_MD *digestFunc,
+                   const void *bytes,
+                   size_t bytesCount,
+                   uint8_t **digest,
+                   size_t *digestLength)
+{
+    EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
+    if (!mdctx) {
+        ERR_print_errors_fp(stderr);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to allocate memory for MD context");
+        return -1;
+    }
+
+    int r = EVP_DigestInit_ex(mdctx, digestFunc, NULL);
+    if (r != 1) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to initialise Digest");
+        return -1;
+    }
+
+    r = EVP_DigestUpdate(mdctx, bytes, bytesCount);
+    if (r != 1) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to update Digest");
+        return -1;
+    }
+
+    *digestLength = EVP_MD_size(digestFunc);
+    *digest = (uint8_t *) OPENSSL_malloc(*digestLength);
+    if (!digest) {
+        EVP_MD_CTX_destroy(mdctx);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to allocate memory for digest");
+        return -1;
+    }
+
+    unsigned int actualDigestLength = 0;
+    r = EVP_DigestFinal_ex(mdctx, *digest, &actualDigestLength);
+    if (r != 1) {
+        ERR_print_errors_fp(stderr);
+        EVP_MD_CTX_destroy(mdctx);
+        OPENSSL_free(*digest);
+        fprintf(stderr,
+                "%s: %s\n",
+                __FUNCTION__,
+                "failed to finalize DigestSign (2nd call)");
+        return -1;
+    }
+
+    // Set correct length to the output argument
+    *digestLength = actualDigestLength;
+
+    EVP_MD_CTX_destroy(mdctx);
+    return 1;
+}
+
+/*
     int osslevp_sign(const EVP_MD *digestFunc,
                      EVP_PKEY *pkey,
                      const void *bytes,
                      size_t bytesCount,
                      uint8_t **signature,
                      size_t *signatureLength)
+
     Implements signing according to:
     https://wiki.openssl.org/index.php/EVP_Signing_and_Verifying
+
     Arguments:
     * digestFunc: should be the result of an EVP function, eg. EVP_sha256()
     * pkey: the private key used for signing
@@ -346,6 +438,7 @@ int osslevp_aes_decrypt_ciphertext(int block_mode,
     * bytesCount: the number of bytes in 'bytes'
     * signature: where the generated signature will be stored, which will have to be freed using OPENSSL_free
     * signatureLength: where the length of the generated signature will be stored
+
     Return value:
     * 1 when the operation was successful.
     * less than 0 when there was an error.
@@ -433,8 +526,10 @@ int osslevp_sign(const EVP_MD *digestFunc,
                        size_t bytesCount,
                        const uint8_t *signature,
                        size_t signatureLength)
+
     Verifies a signature according to:
     https://wiki.openssl.org/index.php/EVP_Signing_and_Verifying
+
     Arguments:
     * digestFunc: should be the result of an EVP function, eg. EVP_sha256()
     * pkey: the public key used for verification (pair of the private key used for signing)
@@ -442,6 +537,7 @@ int osslevp_sign(const EVP_MD *digestFunc,
     * bytesCount: the number of bytes in 'bytes'
     * signature: the signature which needs to be verified
     * signatureLength: byte length of the signature to be verified
+
     Return value:
     * 1 when the operation was successful and the signature is correct.
     * 0 when the operation was successful but the signature is NOT correct.

--- a/plugins/opensslcryptoplugin/evp/evp_helpers_p.h
+++ b/plugins/opensslcryptoplugin/evp/evp_helpers_p.h
@@ -93,6 +93,14 @@ struct LibCrypto_BIO_Deleter
     }
 };
 
+struct LibCrypto_EVP_PKEY_Deleter
+{
+    static inline void cleanup(EVP_PKEY *pointer)
+    {
+        EVP_PKEY_free(pointer);
+    }
+};
+
 quint32 getNextCipherSessionToken(QMap<quint64, QMap<quint32, CipherSessionData*> > *sessions, quint64 clientId)
 {
     if (!sessions->contains(clientId)) {
@@ -123,5 +131,16 @@ bool validInitializationVector(const QByteArray &initVector,
     }
 
     return false;
+}
+
+const EVP_MD *getEvpDigestFunction(Sailfish::Crypto::CryptoManager::DigestFunction digestFunction) {
+    switch (digestFunction) {
+    case Sailfish::Crypto::CryptoManager::DigestSha256:
+        return EVP_sha256();
+        break;
+    default:
+        return Q_NULLPTR;
+        break;
+    }
 }
 

--- a/plugins/opensslcryptoplugin/evp/evp_p.h
+++ b/plugins/opensslcryptoplugin/evp/evp_p.h
@@ -47,6 +47,12 @@ int osslevp_aes_decrypt_ciphertext(int block_mode,
                                    int ciphertext_length,
                                    unsigned char **decrypted);
 
+int osslevp_digest(const EVP_MD *digestFunc,
+                 const void *bytes,
+                 size_t bytesCount,
+                 uint8_t **digest,
+                 size_t *digestLength);
+
 int osslevp_sign(const EVP_MD *digestFunc,
                  EVP_PKEY *pkey,
                  const void *bytes,

--- a/plugins/opensslcryptoplugin/evp/evp_p.h
+++ b/plugins/opensslcryptoplugin/evp/evp_p.h
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include <openssl/conf.h>
 #include <openssl/evp.h>
@@ -45,6 +46,20 @@ int osslevp_aes_decrypt_ciphertext(int block_mode,
                                    const unsigned char *ciphertext,
                                    int ciphertext_length,
                                    unsigned char **decrypted);
+
+int osslevp_sign(const EVP_MD *digestFunc,
+                 EVP_PKEY *pkey,
+                 const void *bytes,
+                 size_t bytesCount,
+                 uint8_t **signature,
+                 size_t *signatureLength);
+
+int osslevp_verify(const EVP_MD *digestFunc,
+                   EVP_PKEY *pkey,
+                   const void *bytes,
+                   size_t bytesCount,
+                   const uint8_t *signature,
+                   size_t signatureLength);
 
 #ifdef __cplusplus
 }

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
@@ -157,7 +157,10 @@ QMap<Sailfish::Crypto::CryptoManager::Algorithm, QVector<Sailfish::Crypto::Crypt
 Daemon::Plugins::OpenSslCryptoPlugin::supportedSignaturePaddings() const
 {
     QMap<Sailfish::Crypto::CryptoManager::Algorithm, QVector<Sailfish::Crypto::CryptoManager::SignaturePadding> > retn;
-    retn.insert(Sailfish::Crypto::CryptoManager::AlgorithmAes, QVector<Sailfish::Crypto::CryptoManager::SignaturePadding>() << Sailfish::Crypto::CryptoManager::SignaturePaddingNone);
+
+    retn.insert(Sailfish::Crypto::CryptoManager::AlgorithmRsa,
+                QVector<Sailfish::Crypto::CryptoManager::SignaturePadding>() << Sailfish::Crypto::CryptoManager::SignaturePaddingNone);
+
     return retn;
 }
 
@@ -165,7 +168,10 @@ QMap<Sailfish::Crypto::CryptoManager::Algorithm, QVector<Sailfish::Crypto::Crypt
 Daemon::Plugins::OpenSslCryptoPlugin::supportedDigests() const
 {
     QMap<Sailfish::Crypto::CryptoManager::Algorithm, QVector<Sailfish::Crypto::CryptoManager::DigestFunction> > retn;
-    retn.insert(Sailfish::Crypto::CryptoManager::AlgorithmAes, QVector<Sailfish::Crypto::CryptoManager::DigestFunction>() << Sailfish::Crypto::CryptoManager::DigestSha256);
+
+    retn.insert(Sailfish::Crypto::CryptoManager::AlgorithmRsa,
+                QVector<Sailfish::Crypto::CryptoManager::DigestFunction>() << Sailfish::Crypto::CryptoManager::DigestSha256);
+
     return retn;
 }
 
@@ -190,7 +196,15 @@ Daemon::Plugins::OpenSslCryptoPlugin::supportedOperations() const
 {
     // TODO: should this be algorithm specific?  not sure?
     QMap<Sailfish::Crypto::CryptoManager::Algorithm, Sailfish::Crypto::CryptoManager::Operations> retn;
-    retn.insert(Sailfish::Crypto::CryptoManager::AlgorithmAes, Sailfish::Crypto::CryptoManager::OperationEncrypt | Sailfish::Crypto::CryptoManager::OperationDecrypt);
+
+    retn.insert(Sailfish::Crypto::CryptoManager::AlgorithmAes,
+                Sailfish::Crypto::CryptoManager::OperationEncrypt |
+                Sailfish::Crypto::CryptoManager::OperationDecrypt);
+
+    retn.insert(Sailfish::Crypto::CryptoManager::AlgorithmRsa,
+                Sailfish::Crypto::CryptoManager::OperationSign |
+                Sailfish::Crypto::CryptoManager::OperationVerify);
+
     return retn;
 }
 
@@ -287,7 +301,7 @@ Daemon::Plugins::OpenSslCryptoPlugin::generateKey(
         }
 
         QScopedPointer<BIO, LibCrypto_BIO_Deleter> pubbio(BIO_new(BIO_s_mem()));
-        if (PEM_write_bio_RSAPublicKey(pubbio.data(), rsa.data()) != 1) {
+        if (PEM_write_bio_RSA_PUBKEY(pubbio.data(), rsa.data()) != 1) {
             return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginKeyGenerationError,
                                             QLatin1String("Failed to write public key data to memory"));
         }
@@ -415,14 +429,72 @@ Daemon::Plugins::OpenSslCryptoPlugin::sign(
         Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
         QByteArray *signature)
 {
-    // TODO: support more operations and algorithms in this plugin!
-    Q_UNUSED(data);
-    Q_UNUSED(key);
-    Q_UNUSED(padding);
-    Q_UNUSED(digestFunction);
-    Q_UNUSED(signature);
-    return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedOperation,
-                                    QLatin1String("TODO: sign"));
+    if (signature == Q_NULLPTR) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginSigningError,
+                                        QLatin1String("Given output argument 'signature' was nullptr."));
+    }
+
+    if (data.length() == 0) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::EmptyData,
+                                        QLatin1String("Can't sign data if there is no data."));
+    }
+
+    if (key.privateKey().length() == 0) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::EmptyPrivateKey,
+                                        QLatin1String("Can't verify without private key."));
+    }
+
+    if (padding != Sailfish::Crypto::CryptoManager::SignaturePaddingNone) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedOperation,
+                                        QLatin1String("TODO: signature padding other than None"));
+    }
+
+    // Get the EVP digest function
+    const EVP_MD *evpDigestFunc = getEvpDigestFunction(digestFunction);
+    if (!evpDigestFunc) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedDigest,
+                                        QLatin1String("Unsupported digest function chosen."));
+    }
+
+    QScopedPointer<BIO, LibCrypto_BIO_Deleter> bio(BIO_new(BIO_s_mem()));
+
+    // Use BIO to write private key data
+    int r = BIO_write(bio.data(), key.privateKey().data(), key.privateKey().length());
+    if (r == 0 || r != key.privateKey().length()) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginSigningError,
+                                        QLatin1String("Failed to read private key data."));
+    }
+
+    // Read the private key data into an EVP_PKEY, which SHOULD handle different formats transparently.
+    // See https://www.openssl.org/docs/man1.1.0/crypto/PEM_read_bio_PrivateKey.html
+    EVP_PKEY *pkeyPtr = Q_NULLPTR;
+    PEM_read_bio_PrivateKey(bio.data(), &pkeyPtr, Q_NULLPTR, Q_NULLPTR);
+    if (pkeyPtr == Q_NULLPTR) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginSigningError,
+                                        QLatin1String("Failed to read private key from PEM format."));
+    }
+
+    QScopedPointer<EVP_PKEY, LibCrypto_EVP_PKEY_Deleter> pkey(pkeyPtr);
+
+    // Variables for storing the signature
+    uint8_t *signatureBytes = Q_NULLPTR;
+    size_t signatureLength = 0;
+
+    // Create signature
+    r = osslevp_sign(evpDigestFunc, pkeyPtr, data.data(), data.length(), &signatureBytes, &signatureLength);
+    if (r != 1) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginSigningError,
+                                        QLatin1String("Failed to sign."));
+    }
+
+    // Copy the signature into the given QByteArray
+    *signature = QByteArray((const char*) signatureBytes, (int) signatureLength);
+
+    // Free the signature allocated by openssl
+    OPENSSL_free(signatureBytes);
+
+    // Return result indicating success
+    return Sailfish::Crypto::Result(Sailfish::Crypto::Result::Succeeded);
 }
 
 Sailfish::Crypto::Result
@@ -434,15 +506,66 @@ Daemon::Plugins::OpenSslCryptoPlugin::verify(
         Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
         bool *verified)
 {
-    // TODO: support more operations and algorithms in this plugin!
-    Q_UNUSED(signature);
-    Q_UNUSED(data);
-    Q_UNUSED(key);
-    Q_UNUSED(padding);
-    Q_UNUSED(digestFunction);
-    Q_UNUSED(verified);
-    return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedOperation,
-                                    QLatin1String("TODO: verify"));
+    if (verified == Q_NULLPTR) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginVerificationError,
+                                        QLatin1String("Given output argument 'verified' was nullptr."));
+    }
+
+    if (signature.length() == 0) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::EmptySignature,
+                                        QLatin1String("Can't verify without signature."));
+    }
+
+    if (key.publicKey().length() == 0) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::EmptyPublicKey,
+                                        QLatin1String("Can't verify without public key."));
+    }
+
+    if (padding != Sailfish::Crypto::CryptoManager::SignaturePaddingNone) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedOperation,
+                                        QLatin1String("TODO: signature padding other than None"));
+    }
+
+    // Get the EVP digest function
+    const EVP_MD *evpDigestFunc = getEvpDigestFunction(digestFunction);
+    if (!evpDigestFunc) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedDigest,
+                                        QLatin1String("Unsupported digest function chosen."));
+    }
+
+    QScopedPointer<BIO, LibCrypto_BIO_Deleter> bio(BIO_new(BIO_s_mem()));
+
+    // Use BIO to write public key data
+    int r = BIO_write(bio.data(), key.publicKey().data(), key.publicKey().length());
+    if (r != key.publicKey().length()) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginVerificationError,
+                                        QLatin1String("Failed to read public key data."));
+    }
+
+    // Read the public key data into an EVP_PKEY
+    EVP_PKEY *pkeyPtr = Q_NULLPTR;
+    PEM_read_bio_PUBKEY(bio.data(), &pkeyPtr, Q_NULLPTR, Q_NULLPTR);
+    if (pkeyPtr == Q_NULLPTR) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginVerificationError,
+                                        QLatin1String("Failed to read public key from PEM format."));
+    }
+
+    QScopedPointer<EVP_PKEY, LibCrypto_EVP_PKEY_Deleter> pkey(pkeyPtr);
+
+    // Verify the signature
+    r = osslevp_verify(evpDigestFunc, pkeyPtr, data.data(), data.length(), (const uint8_t*) signature.data(), (size_t) signature.length());
+    if (r == 1) {
+        // Verification performed without error, signature matched.
+        *verified = true;
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::Succeeded);
+    } else if (r == 0) {
+        // Verification performed without error, but signature didn't match.
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::Succeeded);
+    } else {
+        // Verification had errors.
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginVerificationError,
+                                        QLatin1String("Error occoured while verifying the given signature."));
+    }
 }
 
 Sailfish::Crypto::Result

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
@@ -412,13 +412,47 @@ Daemon::Plugins::OpenSslCryptoPlugin::calculateDigest(
         Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
         QByteArray *digest)
 {
-    // TODO: support more operations and algorithms in this plugin!
-    Q_UNUSED(data);
-    Q_UNUSED(padding);
-    Q_UNUSED(digestFunction);
-    Q_UNUSED(digest);
-    return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedOperation,
-                                    QLatin1String("TODO: calculateDigest"));
+    if (digest == Q_NULLPTR) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginDigestError,
+                                        QLatin1String("Given output argument 'digest' was nullptr."));
+    }
+
+    if (data.length() == 0) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::EmptyData,
+                                        QLatin1String("Can't digest data if there is no data."));
+    }
+
+    if (padding != Sailfish::Crypto::CryptoManager::SignaturePaddingNone) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedOperation,
+                                        QLatin1String("TODO: digest padding other than None"));
+    }
+
+    // Get the EVP digest function
+    const EVP_MD *evpDigestFunc = getEvpDigestFunction(digestFunction);
+    if (!evpDigestFunc) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::UnsupportedDigest,
+                                        QLatin1String("Unsupported digest function chosen."));
+    }
+
+    // Variables for storing the digest
+    uint8_t *digestBytes = Q_NULLPTR;
+    size_t digestLength = 0;
+
+    // Create digest
+    int r = osslevp_digest(evpDigestFunc, data.data(), data.length(), &digestBytes, &digestLength);
+    if (r != 1) {
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::CryptoPluginDigestError,
+                                        QLatin1String("Failed to digest."));
+    }
+
+    // Copy the digest into the given QByteArray
+    *digest = QByteArray((const char*) digestBytes, (int) digestLength);
+
+    // Free the digest allocated by openssl
+    OPENSSL_free(digestBytes);
+
+    // Return result indicating success
+    return Sailfish::Crypto::Result(Sailfish::Crypto::Result::Succeeded);
 }
 
 Sailfish::Crypto::Result

--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -214,6 +214,7 @@ cp -R lib/Crypto/doc/html/* %{buildroot}/%{_docdir}/Sailfish/Crypto/
 /opt/tests/Sailfish/Crypto/tst_crypto
 /opt/tests/Sailfish/Crypto/tst_cryptorequests
 /opt/tests/Sailfish/Crypto/tst_cryptosecrets
+/opt/tests/Sailfish/Crypto/tst_evp
 %{_libdir}/Sailfish/Crypto/libsailfishcrypto-testopenssl.so
 
 %files -n libsailfishcryptoplugin

--- a/tests/Crypto/Crypto.pro
+++ b/tests/Crypto/Crypto.pro
@@ -2,4 +2,5 @@ TEMPLATE = subdirs
 SUBDIRS = \
     $$PWD/tst_crypto \
     $$PWD/tst_cryptorequests \
-    $$PWD/tst_cryptosecrets
+    $$PWD/tst_cryptosecrets \
+    $$PWD/tst_evp

--- a/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
+++ b/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
@@ -12,7 +12,9 @@
 #include <QObject>
 #include <QElapsedTimer>
 #include <QFile>
+#include <QtCore/QCryptographicHash>
 
+#include "Crypto/calculatedigestrequest.h"
 #include "Crypto/cipherrequest.h"
 #include "Crypto/decryptrequest.h"
 #include "Crypto/deletestoredkeyrequest.h"
@@ -90,6 +92,7 @@ private slots:
     void generateKeyEncryptDecrypt();
     void validateCertificateChain();
     void signVerify();
+    void calculateDigest();
     void storedKeyRequests_data();
     void storedKeyRequests();
     void storedDerivedKeyRequests_data();
@@ -489,6 +492,42 @@ void tst_cryptorequests::signVerify()
     QCOMPARE(vr.result().code(), Result::Succeeded);
     QCOMPARE(vrvs.count(), 1);
     QCOMPARE(vr.verified(), true);
+}
+
+void tst_cryptorequests::calculateDigest()
+{
+    QByteArray plaintext = "Test plaintext data";
+
+    CalculateDigestRequest cdr;
+    cdr.setManager(&cm);
+    QSignalSpy cdrss(&cdr, &CalculateDigestRequest::statusChanged);
+    QSignalSpy cdrds(&cdr, &CalculateDigestRequest::digestChanged);
+    QCOMPARE(cdr.status(), Request::Inactive);
+    cdr.setData(plaintext);
+    QCOMPARE(cdr.data(), plaintext);
+    cdr.setDigestFunction(CryptoManager::DigestSha256);
+    QCOMPARE(cdr.digestFunction(), CryptoManager::DigestSha256);
+    cdr.setPadding(CryptoManager::SignaturePaddingNone);
+    QCOMPARE(cdr.padding(), CryptoManager::SignaturePaddingNone);
+    cdr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
+    QCOMPARE(cdr.cryptoPluginName(), DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
+
+    cdr.startRequest();
+    QCOMPARE(cdrss.count(), 1);
+    QCOMPARE(cdr.status(), Request::Active);
+    QCOMPARE(cdr.result().code(), Result::Pending);
+    QCOMPARE(cdrds.count(), 0);
+
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(cdr);
+    QCOMPARE(cdrss.count(), 2);
+    QCOMPARE(cdr.status(), Request::Finished);
+
+    QCOMPARE(cdr.result().code(), Result::Succeeded);
+    QCOMPARE(cdrds.count(), 1);
+
+    QByteArray digest = cdr.digest();
+    QVERIFY2(digest.length() != 0, "Calculated digest should NOT be empty.");
+    QCOMPARE(digest, QCryptographicHash::hash(plaintext, QCryptographicHash::Sha256));
 }
 
 void tst_cryptorequests::storedKeyRequests_data()

--- a/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
+++ b/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
@@ -381,23 +381,67 @@ void tst_cryptorequests::validateCertificateChain()
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(vcr);
     QCOMPARE(vcrss.count(), 2);
     QCOMPARE(vcr.status(), Request::Finished);
+    QTest::qWait(250);
     QSKIP("TODO - certificate validation not yet implemented!");
 }
 
 void tst_cryptorequests::signVerify()
 {
-    // TODO: sign/verify not yet implemented in test plugin.
-    QByteArray plaintext = "Test plaintext data", signature;
+    // Generate RSA key for signing
+    // ----------------------------
+
+    // Create key template
+    Key keyTemplate;
+    keyTemplate.setSize(1024);
+    keyTemplate.setAlgorithm(CryptoManager::AlgorithmRsa);
+    keyTemplate.setOrigin(Key::OriginDevice);
+    keyTemplate.setOperations(CryptoManager::OperationSign);
+    keyTemplate.setFilterData(QLatin1String("test"), QLatin1String("true"));
+
+    // Create key pair generation params, make sure it's valid
+    RsaKeyPairGenerationParameters keyPairGenParams;
+    keyPairGenParams.setModulusLength(1024);
+    keyPairGenParams.setKeyPairType(KeyPairGenerationParameters::KeyPairRsa);
+    QVERIFY2(keyPairGenParams.isValid(), "Key pair generation params are invalid.");
+
+    // Create generate key request, execute, make sure it's okay
+    GenerateKeyRequest gkr;
+    gkr.setManager(&cm);
+    gkr.setKeyPairGenerationParameters(keyPairGenParams);
+    gkr.setKeyTemplate(keyTemplate);
+    gkr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
+    gkr.startRequest();
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(gkr);
+    QCOMPARE(gkr.status(), Request::Finished);
+    QCOMPARE(gkr.result().code(), Result::Succeeded);
+
+    // Grab generated key, make sure it's sane
+    Key fullKey = gkr.generatedKey();
+    QVERIFY(!fullKey.privateKey().isEmpty());
+    QVERIFY(!fullKey.publicKey().isEmpty());
+
+    // Sign a test plaintext
+    // ----------------------------
+
+    QByteArray plaintext = "Test plaintext data";
 
     SignRequest sr;
     sr.setManager(&cm);
     QSignalSpy srss(&sr, &SignRequest::statusChanged);
     QSignalSpy srvs(&sr, &SignRequest::signatureChanged);
+
+    sr.setKey(fullKey);
+    QCOMPARE(sr.key(), fullKey);
+    sr.setPadding(CryptoManager::SignaturePaddingNone);
+    QCOMPARE(sr.padding(), CryptoManager::SignaturePaddingNone);
+    sr.setDigestFunction(CryptoManager::DigestSha256);
+    QCOMPARE(sr.digestFunction(), CryptoManager::DigestSha256);
     sr.setData(plaintext);
     QCOMPARE(sr.data(), plaintext);
     sr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(sr.cryptoPluginName(), DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(sr.status(), Request::Inactive);
+
     sr.startRequest();
     QCOMPARE(srss.count(), 1);
     QCOMPARE(sr.status(), Request::Active);
@@ -406,21 +450,33 @@ void tst_cryptorequests::signVerify()
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(sr);
     QCOMPARE(srss.count(), 2);
     QCOMPARE(sr.status(), Request::Finished);
-    // NOT YET IMPLEMENTED!
-    //QCOMPARE(sr.result().code(), Result::Succeeded);
-    //QCOMPARE(srvs.count(), 1);
-    //signature = sr.signature();
+
+    QCOMPARE(sr.result().code(), Result::Succeeded);
+    QCOMPARE(srvs.count(), 1);
+    QByteArray signature = sr.signature();
+
+    // Verify the test signature
+    // ----------------------------
 
     VerifyRequest vr;
     vr.setManager(&cm);
     QSignalSpy vrss(&vr, &VerifyRequest::statusChanged);
     QSignalSpy vrvs(&vr, &VerifyRequest::verifiedChanged);
     QCOMPARE(vr.verified(), false);
+    QCOMPARE(vr.status(), Request::Inactive);
+    vr.setKey(fullKey);
+    QCOMPARE(vr.key(), fullKey);
     vr.setData(plaintext);
     QCOMPARE(vr.data(), plaintext);
+    vr.setSignature(signature);
+    QCOMPARE(vr.signature(), signature);
+    vr.setDigestFunction(CryptoManager::DigestSha256);
+    QCOMPARE(vr.digestFunction(), CryptoManager::DigestSha256);
+    vr.setPadding(CryptoManager::SignaturePaddingNone);
+    QCOMPARE(vr.padding(), CryptoManager::SignaturePaddingNone);
     vr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
     QCOMPARE(vr.cryptoPluginName(), DEFAULT_TEST_CRYPTO_PLUGIN_NAME);
-    QCOMPARE(vr.status(), Request::Inactive);
+
     vr.startRequest();
     QCOMPARE(vrss.count(), 1);
     QCOMPARE(vr.status(), Request::Active);
@@ -429,12 +485,10 @@ void tst_cryptorequests::signVerify()
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(vr);
     QCOMPARE(vrss.count(), 2);
     QCOMPARE(vr.status(), Request::Finished);
-    // NOT YET IMPLEMENTED!
-    //QCOMPARE(vr.result().code(), Result::Succeeded);
-    //QCOMPARE(vrvs.count(), 1);
-    //QCOMPARE(vr.verified(), true);
 
-    QSKIP("TODO - sign/verify not yet implemented!");
+    QCOMPARE(vr.result().code(), Result::Succeeded);
+    QCOMPARE(vrvs.count(), 1);
+    QCOMPARE(vr.verified(), true);
 }
 
 void tst_cryptorequests::storedKeyRequests_data()

--- a/tests/Crypto/tst_evp/tst_evp.cpp
+++ b/tests/Crypto/tst_evp/tst_evp.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2017 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#include "tst_evp.h"
+#include "evp_p.h"
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/bn.h>
+#include <openssl/rsa.h>
+#include <openssl/pem.h>
+#include <openssl/bio.h>
+#include <openssl/x509.h>
+
+#include <cassert>
+
+/*!
+ * Before each test case, generates a new private-public key pair using
+ * the OpenSSL command line. Then reads these keys into QByteArrays.
+ */
+void tst_evp::init()
+{
+    qDebug() << "creating test private key file";
+    QProcess proc1;
+    proc1.start("openssl",
+               QStringList({"genpkey", "-algorithm", "RSA", "-out", privateKeyFileName, "-pkeyopt", "rsa_keygen_bits:2048" }),
+               QIODevice::ReadWrite);
+    proc1.waitForFinished(5000);
+
+    qDebug() << "extracting test public key file";
+    QProcess proc2;
+    proc2.start("openssl",
+               QStringList({"rsa", "-pubout", "-in", privateKeyFileName, "-out", publicKeyFileName }),
+               QIODevice::ReadWrite);
+    proc2.waitForFinished(5000);
+
+    // Read private key
+    QFile privateKeyFile(privateKeyFileName);
+    bool isopen = privateKeyFile.open(QIODevice::ReadOnly);
+    QVERIFY2(isopen, "private key file should be open");
+    privateKey = privateKeyFile.readAll();
+    privateKeyFile.close();
+
+    // Read public key
+    QFile publicKeyFile(publicKeyFileName);
+    isopen = publicKeyFile.open(QIODevice::ReadOnly);
+    QVERIFY2(isopen, "public key file should be open");
+    publicKey = publicKeyFile.readAll();
+    publicKeyFile.close();
+}
+
+void tst_evp::cleanup()
+{
+    // Clean up private key file
+    QFile privateKeyFile(privateKeyFileName);
+    if (privateKeyFile.exists()) {
+        qDebug() << "deleting test private key file";
+        privateKeyFile.remove();
+    }
+
+    // Clean up public key file
+    QFile publicKeyFile(publicKeyFileName);
+    if (publicKeyFile.exists()) {
+        qDebug() << "deleting test public key file";
+        publicKeyFile.remove();
+    }
+}
+
+QByteArray tst_evp::generateTestData(size_t size) {
+    QFile file("/dev/urandom");
+    file.open(QIODevice::ReadOnly);
+    QByteArray result = file.read(size);
+    return result;
+}
+
+/*!
+ * Tests a sign case.
+ * Makes sure that our EVP usage is correct and generates correct output.
+ */
+void tst_evp::testSign()
+{
+    // Create some test data
+    QByteArray testData = generateTestData(512);
+
+    // Use both methods to sign it
+    QByteArray s1 = signWithCommandLine(testData);
+    QByteArray s2 = signWithEvp(testData);
+
+    // Assert that both signatures are non-zero long, and they are the same
+    QVERIFY(s1.length() > 0);
+    QVERIFY(s2.length() > 0);
+    QCOMPARE(s2, s1);
+}
+
+/*!
+ * Tests a correct verify case, ie. when the correct signature is
+ * used when verifying.
+ * Makes sure that our EVP usage is correct and generates correct output.
+ */
+void tst_evp::testVerifyCorrect()
+{
+    // Create some test data
+    QByteArray testData = generateTestData(512);
+
+    // Use both methods to sign it
+    QByteArray s1 = signWithCommandLine(testData);
+    QByteArray s2 = signWithEvp(testData);
+
+    // Assert that both signatures are non-zero long, and they are the same
+    QVERIFY(s1.length() > 0);
+    QVERIFY(s2.length() > 0);
+    QCOMPARE(s2, s1);
+
+    // Verify using both methods
+    bool ok1 = verifyWithCommandLine(testData, s1);
+    bool ok2 = verifyWithEvp(testData, s1);
+
+    // Assert that both are successful
+    QVERIFY(ok1);
+    QVERIFY(ok2);
+    QCOMPARE(ok2, ok1);
+}
+
+/*!
+ * Tests a correct verify case, ie. when the signature is tampered with
+ * before verifying. Expected not to succeed.
+ * Makes sure that our EVP usage is correct and generates correct output.
+ */
+void tst_evp::testVerifyIncorrect()
+{
+    // Create some test data
+    QByteArray testData = generateTestData(512);
+
+    // Use both methods to sign it
+    QByteArray s1 = signWithCommandLine(testData);
+    QByteArray s2 = signWithEvp(testData);
+
+    // Assert that both signatures are non-zero long, and they are the same
+    QVERIFY(s1.length() > 0);
+    QVERIFY(s2.length() > 0);
+    QCOMPARE(s2, s1);
+
+    // Tamper with the signature
+    s1[4] = ~s1[4];
+
+    // Verify using both methods
+    bool ok1 = verifyWithCommandLine(testData, s1);
+    bool ok2 = verifyWithEvp(testData, s1);
+
+    // Assert that both verifications are unsuccessful
+    QVERIFY(!ok1);
+    QVERIFY(!ok2);
+    QCOMPARE(ok2, ok1);
+}
+
+/*!
+ * \brief Creates an SHA-256 signature using the OpenSSL command line.
+ * \param data The data which needs to be signed.
+ * \return Signature.
+ */
+QByteArray tst_evp::signWithCommandLine(const QByteArray &data) {
+    const char *testDataFileName = "testdata.bin";
+    const char *testSignatureFileName = "test-signature.sha256";
+
+    QFile file(testDataFileName);
+    file.open(QIODevice::WriteOnly);
+    file.write(data);
+    file.waitForBytesWritten(5000);
+    file.close();
+
+    QProcess proc;
+    proc.start("openssl",
+               QStringList({"dgst", "-sha256", "-sign", privateKeyFileName, "-out", testSignatureFileName, testDataFileName}),
+               QIODevice::ReadWrite);
+    proc.waitForFinished(5000);
+
+    QFile signatureFile(testSignatureFileName);
+    signatureFile.open(QIODevice::ReadOnly);
+    QByteArray result = signatureFile.readAll();
+    signatureFile.close();
+
+    // Remove test data file and signature file
+    file.remove();
+    signatureFile.remove();
+
+    return result;
+}
+
+/*!
+ * \brief Verifies an SHA-256 signature using the OpenSSL command line.
+ * \param data The data which was signed.
+ * \param signature The signature.
+ * \return true if the signature is correct, false otherwise.
+ */
+bool tst_evp::verifyWithCommandLine(const QByteArray &data, const QByteArray &signature)
+{
+    const char *testDataFileName = "testdata.bin";
+    const char *testSignatureFileName = "test-signature.sha256";
+
+    QFile file(testDataFileName);
+    file.open(QIODevice::WriteOnly);
+    file.write(data);
+    file.waitForBytesWritten(5000);
+    file.close();
+
+    QFile signatureFile(testSignatureFileName);
+    signatureFile.open(QIODevice::WriteOnly);
+    signatureFile.write(signature);
+    signatureFile.close();
+
+    QProcess proc;
+    proc.start("openssl",
+               QStringList({"dgst", "-sha256", "-verify", publicKeyFileName, "-signature", testSignatureFileName, testDataFileName}),
+               QIODevice::ReadWrite);
+    proc.waitForFinished(5000);
+    QString result = proc.readAll();
+
+    // Remove test data file and signature file
+    file.remove();
+    signatureFile.remove();
+
+    return result == "Verified OK\n";
+}
+
+/*!
+ * \brief Creates an SHA-256 signature using the sailfish-crypto EVP code.
+ * \param data The data which needs to be signed.
+ * \return Signature.
+ */
+QByteArray tst_evp::signWithEvp(const QByteArray &data) {
+    BIO *bio = BIO_new(BIO_s_mem());
+    EVP_PKEY *pkey = EVP_PKEY_new();
+    const EVP_MD *digestFunc = EVP_sha256();
+
+    int r = BIO_write(bio, privateKey.data(), privateKey.length());
+    assert(r == privateKey.length());
+    PEM_read_bio_PrivateKey(bio, &pkey, nullptr, nullptr);
+
+    uint8_t *signature;
+    size_t signatureLength;
+
+    r = osslevp_sign(digestFunc, pkey, data.data(), data.length(), &signature, &signatureLength);
+    assert(r == 1);
+    BIO_free(bio);
+    EVP_PKEY_free(pkey);
+
+    QByteArray result((const char*) signature, (int) signatureLength);
+    OPENSSL_free(signature);
+
+    return result;
+}
+
+/*!
+ * \brief Verifies an SHA-256 signature using the sailfish-crypto EVP code.
+ * \param data The data which was signed.
+ * \param signature The signature.
+ * \return true if the signature is correct, false otherwise.
+ */
+bool tst_evp::verifyWithEvp(const QByteArray &data, const QByteArray &signature)
+{
+    BIO *bio = BIO_new(BIO_s_mem());
+    EVP_PKEY *pkey = EVP_PKEY_new();
+    const EVP_MD *digestFunc = EVP_sha256();
+
+    int r = BIO_write(bio, publicKey.data(), publicKey.length());
+    assert(r == publicKey.length());
+    PEM_read_bio_PUBKEY(bio, &pkey, nullptr, nullptr);
+
+    r = osslevp_verify(digestFunc, pkey, data.data(), data.length(), reinterpret_cast<const uint8_t*>(signature.data()), signature.length());
+    assert(r >= 0);
+    BIO_free(bio);
+    EVP_PKEY_free(pkey);
+
+    return r == 1;
+}
+
+QTEST_MAIN(tst_evp)

--- a/tests/Crypto/tst_evp/tst_evp.h
+++ b/tests/Crypto/tst_evp/tst_evp.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#include <QtTest>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QProcess>
+#include <QtCore/QByteArray>
+#include <QtCore/QFile>
+#include <QtCore/QDebug>
+
+#include "evp_p.h"
+
+class tst_evp : public QObject
+{
+    Q_OBJECT
+    static constexpr const char *privateKeyFileName = "private_key.pem";
+    static constexpr const char *publicKeyFileName = "public_key.pem";
+    QByteArray privateKey;
+    QByteArray publicKey;
+
+public slots:
+    void init();
+    void cleanup();
+
+private slots:
+    void testSign();
+    void testVerifyCorrect();
+    void testVerifyIncorrect();
+
+private:
+    QByteArray generateTestData(size_t size);
+    QByteArray signWithCommandLine(const QByteArray &data);
+    QByteArray signWithEvp(const QByteArray &data);
+    bool verifyWithCommandLine(const QByteArray &data, const QByteArray &signature);
+    bool verifyWithEvp(const QByteArray &data, const QByteArray &signature);
+
+};

--- a/tests/Crypto/tst_evp/tst_evp.h
+++ b/tests/Crypto/tst_evp/tst_evp.h
@@ -28,6 +28,7 @@ public slots:
     void cleanup();
 
 private slots:
+    void testDigest();
     void testSign();
     void testVerifyCorrect();
     void testVerifyIncorrect();
@@ -38,5 +39,6 @@ private:
     QByteArray signWithEvp(const QByteArray &data);
     bool verifyWithCommandLine(const QByteArray &data, const QByteArray &signature);
     bool verifyWithEvp(const QByteArray &data, const QByteArray &signature);
-
+    QByteArray digestWithCommandLine(const QByteArray &data);
+    QByteArray digestWithEvp(const QByteArray &data);
 };

--- a/tests/Crypto/tst_evp/tst_evp.pro
+++ b/tests/Crypto/tst_evp/tst_evp.pro
@@ -1,0 +1,20 @@
+TEMPLATE = app
+TARGET = tst_evp
+target.path = /opt/tests/Sailfish/Crypto/
+
+QT += testlib
+CONFIG += link_pkgconfig
+PKGCONFIG += openssl
+
+INCLUDEPATH += $$PWD/../../../plugins/opensslcryptoplugin/evp
+DEPENDPATH  += $$PWD/../../../plugins/opensslcryptoplugin/evp
+
+HEADERS += \
+    $$PWD/../../../plugins/opensslcryptoplugin/evp/evp_p.h \
+    tst_evp.h
+
+SOURCES += \
+    $$PWD/../../../plugins/opensslcryptoplugin/evp/evp.c \
+    tst_evp.cpp
+
+INSTALLS += target


### PR DESCRIPTION
Adds support for:
* Signing with RSA private key
* Verifying a signature with an RSA public key
* Calculating a digest

Tests:
* end-to-end tests in `tst_cryptorequests` for signing, verify and digest
* openssl command line tests to ensure that our EVP code is sane

Current limitations:
* only supports `PaddingNone`
* no support for MAC (message authentication codes)

I believe this is now ready to be merged.