### PR TITLE
[sailfish-secrets] Add missing Qt5QuickTest dependencies and cleanup extras. Contributes to JB#36797

### DIFF
--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -34,7 +34,6 @@ BuildRequires:  qt5-tools
 %package tests
 Summary:    Unit tests for the Sailfish OS Secrets Library.
 Group:      System/Libraries
-BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(Qt5QuickTest)
 Requires: qt5-qtdeclarative-import-qttest
 Requires: qt5-qtdeclarative-devel-tools
@@ -83,7 +82,7 @@ BuildRequires:  qt5-tools
 %package -n libsailfishcrypto-tests
 Summary:    Unit tests for the libsailfishcrypto library.
 Group:      System/Libraries
-BuildRequires:  pkgconfig(Qt5Test)
+BuildRequires: pkgconfig(Qt5QuickTest)
 Requires:   libsailfishcrypto = %{version}-%{release}
 
 %description -n libsailfishcrypto-tests

--- a/tests/qml/tst_qml_signing/tst_qml_signing.pro
+++ b/tests/qml/tst_qml_signing/tst_qml_signing.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = tst_qml_signing
 target.path = /opt/tests/Sailfish/Crypto/
 
-QT += testlib core gui qml quick
+QT += testlib quick
 CONFIG += qmltestcase
 
 SOURCES += \


### PR DESCRIPTION
Have Qt5QuickTest build requirement in each test package.