### PR TITLE
[sailfish-secrets] Fix libcrypto linking to sqlcipherplugin and opensslplugin. Contributes to JB#41547

### DIFF
--- a/daemon/SecretsImpl/SecretsImpl.pri
+++ b/daemon/SecretsImpl/SecretsImpl.pri
@@ -1,6 +1,5 @@
 INCLUDEPATH += $$PWD
 DEPENDPATH = $$INCLUDEPATH
-PKGCONFIG += libcrypto
 
 include($$PWD/../../database/database.pri)
 

--- a/plugins/opensslplugin/opensslplugin.pro
+++ b/plugins/opensslplugin/opensslplugin.pro
@@ -1,7 +1,8 @@
 TEMPLATE = lib
-CONFIG += plugin hide_symbols
+CONFIG += plugin hide_symbols link_pkgconfig
 TARGET = sailfishsecrets-openssl
 TARGET = $$qtLibraryTarget($$TARGET)
+PKGCONFIG += libcrypto
 
 include($$PWD/../../common.pri)
 include($$PWD/../../lib/libsailfishsecrets.pri)

--- a/plugins/sqlcipherplugin/sqlcipherplugin.pro
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.pro
@@ -1,7 +1,8 @@
 TEMPLATE = lib
-CONFIG += plugin hide_symbols
+CONFIG += plugin hide_symbols link_pkgconfig
 TARGET = sailfishsecrets-sqlcipher
 TARGET = $$qtLibraryTarget($$TARGET)
+PKGCONFIG += libcrypto
 
 include($$PWD/../../common.pri)
 include($$PWD/../../lib/libsailfishsecrets.pri)


### PR DESCRIPTION
Now sailfish-secrets can be started without test packages being installed as service.