### PR TITLE
[sailfish-secrets] Make opensslcrypto plugin to link with libcrypt.

### DIFF
--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -96,6 +96,7 @@ BuildRequires:  qt5-tools
 Summary:    Unit tests for the libsailfishcrypto library.
 Group:      System/Libraries
 BuildRequires: pkgconfig(Qt5QuickTest)
+BuildRequires: pkgconfig(libcrypto)
 Requires:   libsailfishcrypto = %{version}-%{release}
 
 %description -n libsailfishcrypto-tests

--- a/tests/plugins/testopensslcryptoplugin/testopensslcryptoplugin.pro
+++ b/tests/plugins/testopensslcryptoplugin/testopensslcryptoplugin.pro
@@ -1,5 +1,5 @@
 TEMPLATE = lib
-CONFIG += plugin link_pkgconfig
+CONFIG += plugin hide_symbols link_pkgconfig
 TARGET = sailfishcrypto-testopenssl
 TARGET = $$qtLibraryTarget($$TARGET)
 PKGCONFIG += libcrypto


### PR DESCRIPTION
The previous PR from @rainemak missed the plugin in crypto ;)