### PR TITLE
[sailfish-secrets] Write command line tool. Contributes to JB#36797

### DIFF
--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -213,6 +213,18 @@ Requires:   libsailfishcryptopluginapi = %{version}-%{release}
 %{summary}.
 
 
+%package -n sailfishsecrets-tool
+Summary:    Command line tool to interact with the Sailfish OS Secrets and Crypto service
+Group:      Applications/System
+BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5DBus)
+Requires:   libsailfishcrypto = %{version}-%{release}
+Requires:   libsailfishsecrets = %{version}-%{release}
+
+%description -n sailfishsecrets-tool
+%{summary}.
+
+
 %package -n qt5-plugin-sqldriver-sqlcipher
 Summary:    QtSql driver plugin using SQLCipher.
 Group:      System/Libraries
@@ -358,6 +370,10 @@ ln -s ../sailfish-secretsd.service %{buildroot}/%{user_unitdir}/user-session.tar
 %files -n %{secretsdaemon}-cryptoplugins
 %defattr(-,root,root,-)
 %{_libdir}/Sailfish/Crypto/libsailfishcrypto-openssl.so
+
+%files -n sailfishsecrets-tool
+%defattr(-,root,root,-)
+%{_bindir}/secrets-tool
 
 %files -n qt5-plugin-sqldriver-sqlcipher
 %defattr(-,root,root,-)

--- a/sailfish-secrets.pro
+++ b/sailfish-secrets.pro
@@ -1,10 +1,11 @@
 TEMPLATE = subdirs
-SUBDIRS = lib qml daemon plugins tests 3rdparty
+SUBDIRS = lib qml daemon plugins tests tools 3rdparty
 
 qml.depends = lib
 daemon.depends = lib
 plugins.depends = lib
 tests.depends = lib
+tools.depends = lib
 
 OTHER_FILES += \
     $$PWD/LICENSE \

--- a/tools/secrets-tool/commandhelper.cpp
+++ b/tools/secrets-tool/commandhelper.cpp
@@ -1,0 +1,691 @@
+/*
+ * Copyright (C) 2018 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#include "commandhelper.h"
+
+#include <Secrets/interactionparameters.h>
+#include <Secrets/plugininforequest.h>
+#include <Secrets/collectionnamesrequest.h>
+#include <Secrets/createcollectionrequest.h>
+#include <Secrets/deletecollectionrequest.h>
+#include <Secrets/storesecretrequest.h>
+#include <Secrets/storedsecretrequest.h>
+#include <Secrets/deletesecretrequest.h>
+
+#include <Crypto/interactionparameters.h>
+#include <Crypto/keypairgenerationparameters.h>
+#include <Crypto/keyderivationparameters.h>
+#include <Crypto/plugininforequest.h>
+#include <Crypto/storedkeyidentifiersrequest.h>
+#include <Crypto/generatestoredkeyrequest.h>
+#include <Crypto/deletestoredkeyrequest.h>
+#include <Crypto/signrequest.h>
+#include <Crypto/verifyrequest.h>
+#include <Crypto/encryptrequest.h>
+#include <Crypto/decryptrequest.h>
+#include <Crypto/generateinitializationvectorrequest.h>
+
+#include <QtCore/QFile>
+#include <QtCore/QByteArray>
+#include <QtDebug>
+
+#define EXITCODE_SUCCESS 0
+#define EXITCODE_FAILED 1
+
+static Sailfish::Crypto::CryptoManager::Algorithm algorithmEnum(const QString &algo)
+{
+    if (algo == QStringLiteral("RSA")) {
+        return Sailfish::Crypto::CryptoManager::AlgorithmRsa;
+    } else if (algo == QStringLiteral("EC")) {
+        return Sailfish::Crypto::CryptoManager::AlgorithmEc;
+    } else if (algo == QStringLiteral("AES")) {
+        return Sailfish::Crypto::CryptoManager::AlgorithmAes;
+    } else if (algo == QStringLiteral("GOST")) {
+        return Sailfish::Crypto::CryptoManager::AlgorithmGost;
+    }
+
+    return Sailfish::Crypto::CryptoManager::AlgorithmRsa;
+}
+
+static Sailfish::Crypto::CryptoManager::DigestFunction digestEnum(const QString &dg)
+{
+    if (dg == QStringLiteral("SHA256")) {
+        return Sailfish::Crypto::CryptoManager::DigestSha256;
+    } else if (dg == QStringLiteral("SHA512")) {
+        return Sailfish::Crypto::CryptoManager::DigestSha512;
+    } else if (dg == QStringLiteral("GOST")) {
+        return Sailfish::Crypto::CryptoManager::DigestGost;
+    }
+
+    return Sailfish::Crypto::CryptoManager::DigestSha512;
+}
+
+CommandHelper::CommandHelper(bool autotestMode, QObject *parent)
+    : QObject(parent), m_step(0), m_exitCode(0), m_autotestMode(autotestMode)
+{
+    Sailfish::Secrets::PluginInfoRequest spir;
+    spir.setManager(&m_secretManager);
+    spir.startRequest();
+
+    Sailfish::Crypto::PluginInfoRequest cpir;
+    cpir.setManager(&m_cryptoManager);
+    cpir.startRequest();
+
+    spir.waitForFinished();
+    cpir.waitForFinished();
+
+    if (spir.result().code() != Sailfish::Secrets::Result::Succeeded) {
+        qInfo() << "Failed to request secrets plugin information!";
+        qInfo() << "Error:" << spir.result().errorCode() << spir.result().errorMessage();
+        m_exitCode = spir.result().errorCode();
+        return;
+    }
+
+    if (cpir.result().code() != Sailfish::Crypto::Result::Succeeded) {
+        qInfo() << "Failed to request crypto plugin information!";
+        qInfo() << "Error:" << cpir.result().errorCode() << cpir.result().errorMessage();
+        m_exitCode = cpir.result().errorCode();
+        return;
+    }
+
+    for (const Sailfish::Secrets::PluginInfo &pi : spir.authenticationPlugins()) {
+        m_authenticationPlugins.append(pi.name());
+    }
+    for (const Sailfish::Secrets::PluginInfo &pi : spir.encryptionPlugins()) {
+        m_encryptionPlugins.append(pi.name());
+    }
+    for (const Sailfish::Secrets::PluginInfo &pi : spir.storagePlugins()) {
+        m_storagePlugins.append(pi.name());
+    }
+    for (const Sailfish::Secrets::PluginInfo &pi : spir.encryptedStoragePlugins()) {
+        m_encryptedStoragePlugins.append(pi.name());
+    }
+    for (const Sailfish::Crypto::PluginInfo &pi : cpir.cryptoPlugins()) {
+        if (m_encryptedStoragePlugins.contains(pi.name())) {
+            m_cryptoStoragePlugins.append(pi.name());
+        } else {
+            m_cryptoPlugins.append(pi.name());
+        }
+    }
+}
+
+int CommandHelper::exitCode() const
+{
+    return m_exitCode;
+}
+
+void CommandHelper::emitFinished(int exitCode)
+{
+    m_exitCode = exitCode;
+    QMetaObject::invokeMethod(this, "finished", Qt::QueuedConnection);
+}
+
+void CommandHelper::start(const QString &command, const QStringList &args)
+{
+    m_command = command;
+
+    if (command == QStringLiteral("--list-algorithms")) {
+        const QStringList algorithms {
+            "RSA",
+            "EC",
+            "AES",
+            "GOST"
+        };
+        qInfo() << "Supported algorithms:";
+        for (const QString &value : algorithms) {
+            qInfo() << "\t" << value;
+        }
+        emitFinished(EXITCODE_SUCCESS);
+    } else if (command == QStringLiteral("--list-digests")) {
+        const QStringList digests {
+            "SHA256",
+            "SHA512",
+            "GOST"
+        };
+        qInfo() << "Supported digests:";
+        for (const QString &value : digests) {
+            qInfo() << "\t" << value;
+        }
+        emitFinished(EXITCODE_SUCCESS);
+    } else if (command == QStringLiteral("--list-plugins")) {
+        if (m_exitCode == 0) {
+            qInfo() << "Authentication plugins:";
+            for (const QString &value : m_authenticationPlugins) {
+                qInfo() << "\t" << value;
+            }
+            qInfo() << "Encryption plugins:";
+            for (const QString &value : m_encryptionPlugins) {
+                qInfo() << "\t" << value;
+            }
+            qInfo() << "Storage plugins:";
+            for (const QString &value : m_storagePlugins) {
+                qInfo() << "\t" << value;
+            }
+            qInfo() << "Encrypted storage plugins:";
+            for (const QString &value : m_encryptedStoragePlugins) {
+                qInfo() << "\t" << value;
+            }
+            qInfo() << "Crypto storage plugins:";
+            for (const QString &value : m_cryptoStoragePlugins) {
+                qInfo() << "\t" << value;
+            }
+            qInfo() << "Crypto plugins:";
+            for (const QString &value : m_cryptoPlugins) {
+                qInfo() << "\t" << value;
+            }
+        }
+        emitFinished(m_exitCode);
+    } else if (command == QStringLiteral("--list-collections")) {
+        Sailfish::Secrets::CollectionNamesRequest *r = new Sailfish::Secrets::CollectionNamesRequest;
+        r->setStoragePluginName(args.value(0));
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--create-collection")) {
+        Sailfish::Secrets::CreateCollectionRequest *r = new Sailfish::Secrets::CreateCollectionRequest;
+        r->setStoragePluginName(args.value(0));
+        r->setCollectionName(args.value(1));
+        r->setEncryptionPluginName(args.size() == 3
+                                   ? args.value(2)
+                                   : m_encryptedStoragePlugins.contains(args.value(0))
+                                        ? args.value(0)
+                                        : (Sailfish::Secrets::SecretManager::DefaultEncryptionPluginName + (m_autotestMode ? QStringLiteral(".test") : QString())));
+        r->setAuthenticationPluginName(Sailfish::Secrets::SecretManager::DefaultAuthenticationPluginName + (m_autotestMode ? QStringLiteral(".test") : QString()));
+        r->setCollectionLockType(Sailfish::Secrets::CreateCollectionRequest::CustomLock);
+        r->setCustomLockUnlockSemantic(Sailfish::Secrets::SecretManager::CustomLockAccessRelock);
+        r->setAccessControlMode(Sailfish::Secrets::SecretManager::NoAccessControlMode);
+        r->setUserInteractionMode(Sailfish::Secrets::SecretManager::SystemInteraction);
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--delete-collection")) {
+        Sailfish::Secrets::DeleteCollectionRequest *r = new Sailfish::Secrets::DeleteCollectionRequest;
+        r->setStoragePluginName(args.value(0));
+        r->setCollectionName(args.value(1));
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--list-secrets")) {
+        qInfo() << "This command is not yet implemented";
+        emitFinished(EXITCODE_FAILED);
+    } else if (command == QStringLiteral("--store-standalone-secret")) {
+        Sailfish::Secrets::InteractionParameters uiParams;
+        uiParams.setInputType(Sailfish::Secrets::InteractionParameters::AlphaNumericInput);
+        uiParams.setEchoMode(Sailfish::Secrets::InteractionParameters::NormalEcho);
+        Sailfish::Secrets::Secret secret(args.value(2), QString(), args.value(0));
+        Sailfish::Secrets::StoreSecretRequest *r = new Sailfish::Secrets::StoreSecretRequest;
+        r->setSecretStorageType(Sailfish::Secrets::StoreSecretRequest::StandaloneCustomLockSecret);
+        r->setEncryptionPluginName(args.value(1));
+        r->setAuthenticationPluginName(Sailfish::Secrets::SecretManager::DefaultAuthenticationPluginName + (m_autotestMode ? QStringLiteral(".test") : QString()));
+        r->setSecret(secret);
+        r->setCustomLockUnlockSemantic(Sailfish::Secrets::SecretManager::CustomLockAccessRelock);
+        r->setAccessControlMode(Sailfish::Secrets::SecretManager::NoAccessControlMode);
+        r->setUserInteractionMode(Sailfish::Secrets::SecretManager::SystemInteraction);
+        r->setInteractionParameters(uiParams);
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--store-collection-secret")) {
+        Sailfish::Secrets::InteractionParameters uiParams;
+        uiParams.setInputType(Sailfish::Secrets::InteractionParameters::AlphaNumericInput);
+        uiParams.setEchoMode(Sailfish::Secrets::InteractionParameters::NormalEcho);
+        Sailfish::Secrets::Secret secret(args.value(2), args.value(1), args.value(0));
+        Sailfish::Secrets::StoreSecretRequest *r = new Sailfish::Secrets::StoreSecretRequest;
+        r->setSecretStorageType(Sailfish::Secrets::StoreSecretRequest::CollectionSecret);
+        r->setAuthenticationPluginName(Sailfish::Secrets::SecretManager::DefaultAuthenticationPluginName + (m_autotestMode ? QStringLiteral(".test") : QString()));
+        r->setSecret(secret);
+        r->setUserInteractionMode(Sailfish::Secrets::SecretManager::SystemInteraction);
+        r->setInteractionParameters(uiParams);
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--get-standalone-secret")) {
+        Sailfish::Secrets::StoredSecretRequest *r = new Sailfish::Secrets::StoredSecretRequest;
+        r->setIdentifier(Sailfish::Secrets::Secret::Identifier(
+                             args.value(1), QString(), args.value(0)));
+        r->setUserInteractionMode(Sailfish::Secrets::SecretManager::SystemInteraction);
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--get-collection-secret")) {
+        Sailfish::Secrets::StoredSecretRequest *r = new Sailfish::Secrets::StoredSecretRequest;
+        r->setIdentifier(Sailfish::Secrets::Secret::Identifier(
+                             args.value(2), args.value(1), args.value(0)));
+        r->setUserInteractionMode(Sailfish::Secrets::SecretManager::SystemInteraction);
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--delete-standalone-secret")) {
+        Sailfish::Secrets::DeleteSecretRequest *r = new Sailfish::Secrets::DeleteSecretRequest;
+        r->setIdentifier(Sailfish::Secrets::Secret::Identifier(
+                             args.value(1), QString(), args.value(0)));
+        r->setUserInteractionMode(Sailfish::Secrets::SecretManager::SystemInteraction);
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--delete-collection-secret")) {
+        Sailfish::Secrets::DeleteSecretRequest *r = new Sailfish::Secrets::DeleteSecretRequest;
+        r->setIdentifier(Sailfish::Secrets::Secret::Identifier(
+                             args.value(2), args.value(1), args.value(0)));
+        r->setUserInteractionMode(Sailfish::Secrets::SecretManager::SystemInteraction);
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--list-keys")) {
+        Sailfish::Crypto::StoredKeyIdentifiersRequest *r = new Sailfish::Crypto::StoredKeyIdentifiersRequest;
+        r->setStoragePluginName(args.value(0));
+        if (args.size() > 1 && args.value(1).size()) {
+            r->setProperty("collectionName", args.value(1));
+        }
+        m_cryptoRequest.reset(r);
+        m_cryptoRequest->setManager(&m_cryptoManager);
+        connect(m_cryptoRequest.data(), &Sailfish::Crypto::Request::statusChanged,
+                this, &CommandHelper::cryptoRequestStatusChanged);
+        m_cryptoRequest->startRequest();
+    } else if (command == QStringLiteral("--generate-stored-key")) {
+        Sailfish::Crypto::Key keyTemplate;
+        keyTemplate.setIdentifier(Sailfish::Crypto::Key::Identifier(
+                args.value(3), args.value(2), args.value(1)));
+        keyTemplate.setAlgorithm(algorithmEnum(args.value(4)));
+        keyTemplate.setSize(args.value(5).toInt());
+
+        Sailfish::Crypto::RsaKeyPairGenerationParameters rsakpg;
+        if (keyTemplate.algorithm() == Sailfish::Crypto::CryptoManager::AlgorithmRsa) {
+            rsakpg.setModulusLength(keyTemplate.size());
+        }
+
+        Sailfish::Crypto::EcKeyPairGenerationParameters eckpg;
+        if (keyTemplate.algorithm() == Sailfish::Crypto::CryptoManager::AlgorithmEc) {
+            if (keyTemplate.size() <= 256) {
+                eckpg.setEllipticCurve(Sailfish::Crypto::CryptoManager::CurveNistP256);
+                keyTemplate.setSize(256);
+            } else if (keyTemplate.size() <= 384){
+                eckpg.setEllipticCurve(Sailfish::Crypto::CryptoManager::CurveNistP384);
+                keyTemplate.setSize(384);
+            } else {
+                eckpg.setEllipticCurve(Sailfish::Crypto::CryptoManager::CurveNistP521);
+                keyTemplate.setSize(521);
+            }
+        }
+
+        Sailfish::Crypto::InteractionParameters uiParams;
+        uiParams.setInputType(Sailfish::Crypto::InteractionParameters::AlphaNumericInput);
+        uiParams.setEchoMode(Sailfish::Crypto::InteractionParameters::NormalEcho);
+
+        Sailfish::Crypto::GenerateStoredKeyRequest *r = new Sailfish::Crypto::GenerateStoredKeyRequest;
+        r->setCryptoPluginName(args.value(0));
+        r->setInteractionParameters(uiParams);
+        r->setKeyTemplate(keyTemplate);
+        if (keyTemplate.algorithm() == Sailfish::Crypto::CryptoManager::AlgorithmRsa) {
+            r->setKeyPairGenerationParameters(rsakpg);
+        } else if (keyTemplate.algorithm() == Sailfish::Crypto::CryptoManager::AlgorithmEc) {
+            r->setKeyPairGenerationParameters(eckpg);
+        }
+
+        m_cryptoRequest.reset(r);
+        m_cryptoRequest->setManager(&m_cryptoManager);
+        connect(m_cryptoRequest.data(), &Sailfish::Crypto::Request::statusChanged,
+                this, &CommandHelper::cryptoRequestStatusChanged);
+        m_cryptoRequest->startRequest();
+    } else if (command == QStringLiteral("--derive-stored-key")) {
+        const QString saltDataFile = args.value(6);
+        if (saltDataFile.isEmpty()
+                || !QFile::exists(saltDataFile)) {
+            qInfo() << "Invalid salt data file specified!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        QFile saltFile(saltDataFile);
+        if (!saltFile.open(QIODevice::ReadOnly)) {
+            qInfo() << "Unable to open salt data file for reading!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        const QByteArray saltData = saltFile.read(16);
+        if (saltData.size() < 16) {
+            qInfo() << "Unable to read at least 16 bytes of salt data from salt file!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        Sailfish::Crypto::KeyDerivationParameters kdp;
+        kdp.setKeyDerivationFunction(Sailfish::Crypto::CryptoManager::KdfPkcs5Pbkdf2);
+        kdp.setKeyDerivationMac(Sailfish::Crypto::CryptoManager::MacHmac);
+        kdp.setKeyDerivationDigestFunction(Sailfish::Crypto::CryptoManager::DigestSha512);
+        kdp.setIterations(16384);
+        kdp.setSalt(saltData);
+        kdp.setOutputKeySize(args.value(5).toInt());
+
+        Sailfish::Crypto::Key keyTemplate;
+        keyTemplate.setIdentifier(Sailfish::Crypto::Key::Identifier(
+                args.value(3), args.value(2), args.value(1)));
+        keyTemplate.setAlgorithm(algorithmEnum(args.value(4)));
+        keyTemplate.setSize(args.value(5).toInt());
+
+        Sailfish::Crypto::InteractionParameters uiParams;
+        uiParams.setInputType(Sailfish::Crypto::InteractionParameters::AlphaNumericInput);
+        uiParams.setEchoMode(Sailfish::Crypto::InteractionParameters::NormalEcho);
+
+        Sailfish::Crypto::GenerateStoredKeyRequest *r = new Sailfish::Crypto::GenerateStoredKeyRequest;
+        r->setCryptoPluginName(args.value(0));
+        r->setInteractionParameters(uiParams);
+        r->setKeyTemplate(keyTemplate);
+        r->setKeyDerivationParameters(kdp);
+
+        m_cryptoRequest.reset(r);
+        m_cryptoRequest->setManager(&m_cryptoManager);
+        connect(m_cryptoRequest.data(), &Sailfish::Crypto::Request::statusChanged,
+                this, &CommandHelper::cryptoRequestStatusChanged);
+        m_cryptoRequest->startRequest();
+    } else if (command == QStringLiteral("--delete-key")) {
+        Sailfish::Crypto::DeleteStoredKeyRequest *r = new Sailfish::Crypto::DeleteStoredKeyRequest;
+        r->setIdentifier(Sailfish::Crypto::Key::Identifier(
+                args.value(2), args.value(1), args.value(0)));
+        m_cryptoRequest.reset(r);
+        m_cryptoRequest->setManager(&m_cryptoManager);
+        connect(m_cryptoRequest.data(), &Sailfish::Crypto::Request::statusChanged,
+                this, &CommandHelper::cryptoRequestStatusChanged);
+        m_cryptoRequest->startRequest();
+    } else if (command == QStringLiteral("--sign")) {
+        const QString signFileName = args.value(5);
+        if (signFileName.isEmpty()
+                || !QFile::exists(signFileName)) {
+            qInfo() << "Invalid filename specified!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        QFile signFile(signFileName);
+        if (!signFile.open(QIODevice::ReadOnly)) {
+            qInfo() << "Unable to open file for reading!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        const QByteArray signData = signFile.readAll();
+        if (signData.isEmpty()) {
+            qInfo() << "Unable to read data from file!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        Sailfish::Crypto::SignRequest *r = new Sailfish::Crypto::SignRequest;
+        r->setKey(Sailfish::Crypto::Key(
+                        args.value(3), args.value(2), args.value(1)));
+        r->setCryptoPluginName(args.value(0));
+        r->setPadding(Sailfish::Crypto::CryptoManager::SignaturePaddingNone);
+        r->setDigestFunction(digestEnum(args.value(4)));
+        r->setData(signData);
+        m_cryptoRequest.reset(r);
+        m_cryptoRequest->setManager(&m_cryptoManager);
+        connect(m_cryptoRequest.data(), &Sailfish::Crypto::Request::statusChanged,
+                this, &CommandHelper::cryptoRequestStatusChanged);
+        m_cryptoRequest->startRequest();
+    } else if (command == QStringLiteral("--verify")) {
+        const QString verifyFileName = args.value(5);
+        if (verifyFileName.isEmpty()
+                || !QFile::exists(verifyFileName)) {
+            qInfo() << "Invalid filename specified!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        QFile verifyFile(verifyFileName);
+        if (!verifyFile.open(QIODevice::ReadOnly)) {
+            qInfo() << "Unable to open file for reading!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        const QByteArray verifyData = verifyFile.readAll();
+        if (verifyData.isEmpty()) {
+            qInfo() << "Unable to read data from file!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+        const QString signatureFileName = args.value(6);
+        if (signatureFileName.isEmpty()
+                || !QFile::exists(signatureFileName)) {
+            qInfo() << "Invalid filename specified!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        QFile signatureFile(signatureFileName);
+        if (!signatureFile.open(QIODevice::ReadOnly)) {
+            qInfo() << "Unable to open signature file for reading!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        const QByteArray signatureData = signatureFile.readAll();
+        if (signatureData.isEmpty()) {
+            qInfo() << "Unable to read data from signature file!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        Sailfish::Crypto::VerifyRequest *r = new Sailfish::Crypto::VerifyRequest;
+        r->setKey(Sailfish::Crypto::Key(
+                        args.value(3), args.value(2), args.value(1)));
+        r->setCryptoPluginName(args.value(0));
+        r->setPadding(Sailfish::Crypto::CryptoManager::SignaturePaddingNone);
+        r->setDigestFunction(digestEnum(args.value(4)));
+        r->setData(verifyData);
+        r->setSignature(signatureData);
+        m_cryptoRequest.reset(r);
+        m_cryptoRequest->setManager(&m_cryptoManager);
+        connect(m_cryptoRequest.data(), &Sailfish::Crypto::Request::statusChanged,
+                this, &CommandHelper::cryptoRequestStatusChanged);
+        m_cryptoRequest->startRequest();
+    } else if (command == QStringLiteral("--encrypt")) {
+        const QString encryptFileName = args.value(4);
+        if (encryptFileName.isEmpty()
+                || !QFile::exists(encryptFileName)) {
+            qInfo() << "Invalid filename specified!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        QFile encryptFile(encryptFileName);
+        if (!encryptFile.open(QIODevice::ReadOnly)) {
+            qInfo() << "Unable to open file for reading!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        const QByteArray encryptData = encryptFile.readAll();
+        if (encryptData.isEmpty()) {
+            qInfo() << "Unable to read data from file!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        // Assume that the key is an AES key.
+        // (A better alternative is to first read the key metadata
+        // using a StoredKeyRequest, determining its algorithm etc,
+        // and then generating the appropriate IV using that info...)
+        Sailfish::Crypto::GenerateInitializationVectorRequest ivr;
+        ivr.setManager(&m_cryptoManager);
+        ivr.setAlgorithm(Sailfish::Crypto::CryptoManager::AlgorithmAes);
+        ivr.setBlockMode(Sailfish::Crypto::CryptoManager::BlockModeCbc);
+        ivr.setCryptoPluginName(args.value(0));
+        ivr.setKeySize(256); // for AES the IV size is 16 bytes, independent of key size.
+        ivr.startRequest();
+        ivr.waitForFinished();
+
+        Sailfish::Crypto::EncryptRequest *r = new Sailfish::Crypto::EncryptRequest;
+        r->setKey(Sailfish::Crypto::Key(
+                            args.value(3), args.value(2), args.value(1)));
+        r->setCryptoPluginName(args.value(0));
+        r->setPadding(Sailfish::Crypto::CryptoManager::EncryptionPaddingNone);
+        r->setBlockMode(Sailfish::Crypto::CryptoManager::BlockModeCbc);
+        r->setData(encryptData);
+        r->setInitialisationVector(ivr.generatedInitializationVector());
+        m_cryptoRequest.reset(r);
+        m_cryptoRequest->setManager(&m_cryptoManager);
+        connect(m_cryptoRequest.data(), &Sailfish::Crypto::Request::statusChanged,
+                this, &CommandHelper::cryptoRequestStatusChanged);
+        m_cryptoRequest->startRequest();
+    } else if (command == QStringLiteral("--decrypt")) {
+        const QString decryptFileName = args.value(4);
+        if (decryptFileName.isEmpty()
+                || !QFile::exists(decryptFileName)) {
+            qInfo() << "Invalid filename specified!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        QFile decryptFile(decryptFileName);
+        if (!decryptFile.open(QIODevice::ReadOnly)) {
+            qInfo() << "Unable to open file for reading!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        const QByteArray encodedData = decryptFile.readAll();
+        if (encodedData.isEmpty()) {
+            qInfo() << "Unable to read data from file!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        const QList<QByteArray> chunks = encodedData.split('\n');
+        if (chunks.size() < 2 || !chunks.first().startsWith("IV:")) {
+            qInfo() << "Encrypted data file has unknown format!";
+            emitFinished(EXITCODE_FAILED);
+            return;
+        }
+
+        const QByteArray iv = QByteArray::fromBase64(chunks.first().mid(3, -1));
+        QByteArray decryptData;
+        for (int i = 1; i < chunks.size(); ++i) {
+            decryptData.append(QByteArray::fromBase64(chunks.at(i)));
+        }
+
+        Sailfish::Crypto::DecryptRequest *r = new Sailfish::Crypto::DecryptRequest;
+        r->setKey(Sailfish::Crypto::Key(
+                            args.value(3), args.value(2), args.value(1)));
+        r->setCryptoPluginName(args.value(0));
+        r->setPadding(Sailfish::Crypto::CryptoManager::EncryptionPaddingNone);
+        r->setBlockMode(Sailfish::Crypto::CryptoManager::BlockModeCbc);
+        r->setData(decryptData);
+        r->setInitialisationVector(iv);
+        m_cryptoRequest.reset(r);
+        m_cryptoRequest->setManager(&m_cryptoManager);
+        connect(m_cryptoRequest.data(), &Sailfish::Crypto::Request::statusChanged,
+                this, &CommandHelper::cryptoRequestStatusChanged);
+        m_cryptoRequest->startRequest();
+    } else {
+        qInfo() << "Unknown command:" << command;
+        emitFinished(EXITCODE_FAILED);
+    }
+}
+
+void CommandHelper::secretsRequestStatusChanged()
+{
+    if (m_secretsRequest->status() != Sailfish::Secrets::Request::Finished) {
+        return; // not finished yet, ignore.
+    } else if (m_secretsRequest->result().code() != Sailfish::Secrets::Result::Succeeded) {
+        qInfo() << "Error:" << m_secretsRequest->result().errorCode() << m_secretsRequest->result().errorMessage();
+        emitFinished(static_cast<int>(m_secretsRequest->result().errorCode()));
+        return;
+    }
+
+    if (m_command == QStringLiteral("--list-collections")) {
+        Sailfish::Secrets::CollectionNamesRequest *r = qobject_cast<Sailfish::Secrets::CollectionNamesRequest*>(m_secretsRequest.data());
+        qInfo() << "Collections in" << r->storagePluginName();
+        for (const QString &cname : r->collectionNames()) {
+            qInfo() << "\t" << cname;
+        }
+    } else if (m_command == QStringLiteral("--get-standalone-secret")) {
+        Sailfish::Secrets::StoredSecretRequest *r = qobject_cast<Sailfish::Secrets::StoredSecretRequest*>(m_secretsRequest.data());
+        qInfo() << "Got standalone secret data:";
+        qInfo() << "\t" << r->secret().data();
+    } else if (m_command == QStringLiteral("--get-collection-secret")) {
+        Sailfish::Secrets::StoredSecretRequest *r = qobject_cast<Sailfish::Secrets::StoredSecretRequest*>(m_secretsRequest.data());
+        qInfo() << "Got collection secret data:";
+        qInfo() << "\t" << r->secret().data();
+    }
+
+    emitFinished(EXITCODE_SUCCESS);
+}
+
+void CommandHelper::cryptoRequestStatusChanged()
+{
+    if (m_cryptoRequest->status() != Sailfish::Crypto::Request::Finished) {
+        return; // not finished yet, ignore.
+    } else if (m_cryptoRequest->result().code() != Sailfish::Crypto::Result::Succeeded) {
+        qInfo() << "Error:" << m_cryptoRequest->result().errorCode() << m_cryptoRequest->result().errorMessage();
+        emitFinished(static_cast<int>(m_cryptoRequest->result().errorCode()));
+        return;
+    }
+
+    if (m_command == QStringLiteral("--list-keys")) {
+        Sailfish::Crypto::StoredKeyIdentifiersRequest *r = qobject_cast<Sailfish::Crypto::StoredKeyIdentifiersRequest*>(m_cryptoRequest.data());
+        const QString collectionName = r->property("collectionName").toString();
+        for (const Sailfish::Crypto::Key::Identifier &id : r->identifiers()) {
+            if (collectionName.isEmpty() || id.collectionName() == collectionName) {
+                qInfo() << "--------------------------------------------";
+                qInfo() << "Storage plugin:" << id.storagePluginName();
+                qInfo() << "    Collection:" << id.collectionName();
+                qInfo() << "          Name:" << id.name();
+            }
+        }
+    } else if (m_command == QStringLiteral("--sign")) {
+        Sailfish::Crypto::SignRequest *r = qobject_cast<Sailfish::Crypto::SignRequest*>(m_cryptoRequest.data());
+        QFile stdoutFile;
+        stdoutFile.open(stdout, QIODevice::WriteOnly, QFile::AutoCloseHandle);
+        stdoutFile.write(r->signature());
+    } else if (m_command == QStringLiteral("--verify")) {
+        Sailfish::Crypto::VerifyRequest *r = qobject_cast<Sailfish::Crypto::VerifyRequest*>(m_cryptoRequest.data());
+        if (r->verified()) {
+            qInfo() << "Verification SUCCEEDED!";
+        } else {
+            qInfo() << "Verification FAILED!";
+        }
+    } else if (m_command == QStringLiteral("--encrypt")) {
+        Sailfish::Crypto::EncryptRequest *r =qobject_cast<Sailfish::Crypto::EncryptRequest*>(m_cryptoRequest.data());
+        QFile stdoutFile;
+        stdoutFile.open(stdout, QIODevice::WriteOnly, QFile::AutoCloseHandle);
+        stdoutFile.write(QByteArray("IV:") + r->initialisationVector().toBase64() + QByteArray("\n"));
+        int handled = 0;
+        const QByteArray ciphertext = r->ciphertext();
+        while (handled < ciphertext.size()) {
+            const QByteArray chunk = ciphertext.mid(handled, 32);
+            stdoutFile.write(chunk.toBase64() + QByteArray("\n"));
+            handled += 32;
+        }
+    } else if (m_command == QStringLiteral("--decrypt")) {
+        Sailfish::Crypto::DecryptRequest *r = qobject_cast<Sailfish::Crypto::DecryptRequest*>(m_cryptoRequest.data());
+        QFile stdoutFile;
+        stdoutFile.open(stdout, QIODevice::WriteOnly, QFile::AutoCloseHandle);
+        stdoutFile.write(r->plaintext());
+    }
+
+    emitFinished(EXITCODE_SUCCESS);
+}

--- a/tools/secrets-tool/commandhelper.h
+++ b/tools/secrets-tool/commandhelper.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#ifndef SAILFISH_SECRETS_TOOL_COMMANDHELPER_H
+#define SAILFISH_SECRETS_TOOL_COMMANDHELPER_H
+
+#include <QtCore/QObject>
+#include <QtCore/QStringList>
+#include <QtCore/QString>
+#include <QtCore/QScopedPointer>
+
+#include <Secrets/secretmanager.h>
+#include <Secrets/request.h>
+
+#include <Crypto/cryptomanager.h>
+#include <Crypto/request.h>
+
+class CommandHelper : public QObject
+{
+    Q_OBJECT
+
+public:
+    CommandHelper(bool autotestMode, QObject *parent = Q_NULLPTR);
+    void start(const QString &command, const QStringList &args);
+    int exitCode() const;
+
+public Q_SLOTS:
+    void secretsRequestStatusChanged();
+    void cryptoRequestStatusChanged();
+
+Q_SIGNALS:
+    void finished();
+
+private:
+    void emitFinished(int exitCode);
+    QScopedPointer<Sailfish::Secrets::Request> m_secretsRequest;
+    QScopedPointer<Sailfish::Crypto::Request> m_cryptoRequest;
+    Sailfish::Secrets::SecretManager m_secretManager;
+    Sailfish::Crypto::CryptoManager m_cryptoManager;
+    QStringList m_authenticationPlugins;
+    QStringList m_encryptionPlugins;
+    QStringList m_storagePlugins;
+    QStringList m_encryptedStoragePlugins;
+    QStringList m_cryptoStoragePlugins;
+    QStringList m_cryptoPlugins;
+    QString m_command;
+    int m_step;
+    int m_exitCode;
+    bool m_autotestMode;
+};
+
+#endif // SAILFISH_SECRETS_TOOL_COMMANDHELPER_H

--- a/tools/secrets-tool/main.cpp
+++ b/tools/secrets-tool/main.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2018 Jolla Ltd.
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QFile>
+#include <QtCore/QStringList>
+#include <QtCore/QString>
+#include <QtCore/QByteArray>
+#include <QtDebug>
+
+#include "commandhelper.h"
+
+void customMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    QByteArray localMsg = msg.toLocal8Bit();
+    switch (type) {
+    case QtDebugMsg:
+        fprintf(stdout, "%s\n", localMsg.constData());
+        break;
+    case QtInfoMsg:
+        fprintf(stdout, "%s\n", localMsg.constData());
+        break;
+    case QtWarningMsg:
+        if (!context.file) {
+            fprintf(stderr, "%s\n", localMsg.constData());
+        } else if (!context.function) {
+            fprintf(stderr, "Warning: %s (%s:%u)\n", localMsg.constData(), context.file, context.line);
+        } else {
+            fprintf(stderr, "Warning: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        }
+        break;
+    case QtCriticalMsg:
+        fprintf(stderr, "Critical: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        break;
+    case QtFatalMsg:
+        fprintf(stderr, "Fatal: %s (%s:%u, %s)\n", localMsg.constData(), context.file, context.line, context.function);
+        abort();
+    }
+}
+
+Q_DECL_EXPORT int main(int argc, char *argv[])
+{
+    qInstallMessageHandler(customMessageHandler);
+    QCoreApplication app(argc, argv);
+    QStringList args(app.arguments());
+    const QString appName = args.takeFirst();
+
+    const QMap<QString, QString> paramDescriptions {
+        {"--list-algorithms", "List supported algorithms for Crypto keys" },
+        {"--list-digests", "List supported digests for sign and verify operations" },
+        {"--list-plugins", "List available plugins, organized by category" },
+        {"--list-collections", "List available collections (of secrets or keys) stored by a given storage plugin" },
+        {"--create-collection", "Create a collection in a particular storage plugin, encrypted by a particular encryption plugin"},
+        {"--delete-collection", "Delete a collection from a storage plugin" },
+        {"--list-secrets", "List the secrets stored by a storage plugin, optionally limited to a single collection" },
+        {"--store-standalone-secret", "Store a standalone secret in a particular storage plugin, encrypted by a particular encryption plugin" },
+        {"--store-collection-secret", "Store a secret in a particular collection" },
+        {"--get-standalone-secret", "Retrieve a specific standalone secret from the given storage plugin" },
+        {"--get-collection-secret", "Retrieve a specific secret from the given collection within the given storage plugin" },
+        {"--delete-standalone-secret", "Delete a particular standalone secret from a given storage plugin" },
+        {"--delete-collection-secret", "Delete a particular secret from a given collection in a given storage plugin" },
+        {"--list-keys", "List the Crypto keys stored by a paritcular storage plugin, optionally limited to a single collection" },
+        {"--generate-stored-key", "Generate and store a key within a particular collection of a given storage plugin" },
+        {"--derive-stored-key", "Derive a key from a user passphrase and store it within a particular collection of a given storage plugin" },
+        {"--delete-key", "Delete a particular Crypto key from a given collection of a given storage plugin" },
+        {"--sign", "Sign a particular file with a specified key, output to stdout" },
+        {"--verify", "Verify that a particular signature file contains a valid signature with the specified key for the given input file" },
+        {"--encrypt", "Encrypt a particular file with the specified key, output to stdout" },
+        {"--decrypt", "Decrypt a particular file with the specified key, output to stdout" },
+    };
+
+    const QMap<QString, QString> paramOptions {
+        {"--list-collections", "<storagePlugin>" },
+        {"--create-collection", "<storagePlugin> <collectionName> [<encryptionPlugin>]"},
+        {"--delete-collection", "<storagePlugin> <collectionName>" },
+        {"--list-secrets", "<storagePlugin> [<collectionName>]" },
+        {"--store-standalone-secret", "<storagePlugin> <encryptionPlugin> <secretName> [<secretData>]" },
+        {"--store-collection-secret", "<storagePlugin> <collectionName> <secretName> [<secretData>]" },
+        {"--get-standalone-secret", "<storagePlugin> <secretName>" },
+        {"--get-collection-secret", "<storagePlugin> <collectionName> <secretName>" },
+        {"--delete-standalone-secret", "<storagePlugin> <secretName>" },
+        {"--delete-collection-secret", "<storagePlugin> <collectionName> <secretName>" },
+        {"--list-keys", "<storagePlugin> [<collectionName>]" },
+        {"--generate-stored-key", "<cryptoPlugin> <storagePlugin> <collectionName> <keyName> <algorithm> <size>" },
+        {"--derive-stored-key", "<cryptoPlugin> <storagePlugin> <collectionName> <keyName> <algorithm> <size> <saltDataFile>" },
+        {"--delete-key", "<storagePlugin> <collectionName> <keyName>" },
+        {"--sign", "<cryptoPlugin> <storagePlugin> <collectionName> <keyName> <digest> <fileName>" },
+        {"--verify", "<cryptoPlugin> <storagePlugin> <collectionName> <keyName> <digest> <fileName> <signatureFileName>" },
+        {"--encrypt", "<cryptoPlugin> <storagePlugin> <collectionName> <keyName> <fileName>" },
+        {"--decrypt", "<cryptoPlugin> <storagePlugin> <collectionName> <keyName> <fileName>" },
+    };
+
+    const QMap<QString, int> paramOptionsMin {
+        {"--list-algorithms", 0 },
+        {"--list-digests", 0 },
+        {"--list-plugins", 0 },
+        {"--list-collections", 1 },
+        {"--create-collection", 2 },
+        {"--delete-collection", 2 },
+        {"--list-secrets", 1 },
+        {"--store-standalone-secret", 3 },
+        {"--store-collection-secret", 3 },
+        {"--get-standalone-secret", 2 },
+        {"--get-collection-secret", 3 },
+        {"--delete-standalone-secret", 2 },
+        {"--delete-collection-secret", 3 },
+        {"--list-keys", 1 },
+        {"--generate-stored-key", 6 },
+        {"--derive-stored-key", 7 },
+        {"--delete-key", 3 },
+        {"--sign", 6 },
+        {"--verify", 7 },
+        {"--encrypt", 5 },
+        {"--decrypt", 5 },
+    };
+
+    const QMap<QString, int> paramOptionsMax {
+        {"--list-algorithms", 0 },
+        {"--list-digests", 0 },
+        {"--list-plugins", 0 },
+        {"--list-collections", 1 },
+        {"--create-collection", 3 },
+        {"--delete-collection", 2 },
+        {"--list-secrets", 2 },
+        {"--store-standalone-secret", 4 },
+        {"--store-collection-secret", 4 },
+        {"--get-standalone-secret", 2 },
+        {"--get-collection-secret", 3 },
+        {"--delete-standalone-secret", 2 },
+        {"--delete-collection-secret", 3 },
+        {"--list-keys", 2 },
+        {"--generate-stored-key", 6 },
+        {"--derive-stored-key", 7 },
+        {"--delete-key", 3 },
+        {"--sign", 6 },
+        {"--verify", 7 },
+        {"--encrypt", 5 },
+        {"--decrypt", 5 },
+    };
+
+    const QMap<QString, QString> paramExamples {
+        {"--list-algorithms", "" },
+        {"--list-digests", "" },
+        {"--list-plugins", "" },
+        {"--list-collections", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher" },
+        {"--create-collection", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection" },
+        {"--delete-collection", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection" },
+        {"--list-secrets", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection" },
+        {"--store-standalone-secret", "org.sailfishos.secrets.plugin.storage.sqlite org.sailfishos.secrets.plugin.encryption.openssl MyStandaloneSecret" },
+        {"--store-collection-secret", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyCollectionSecret" },
+        {"--get-standalone-secret", "org.sailfishos.secrets.plugin.storage.sqlite MyStandaloneSecret" },
+        {"--get-collection-secret", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyCollectionSecret" },
+        {"--delete-standalone-secret", "org.sailfishos.secrets.plugin.storage.sqlite MyStandaloneSecret" },
+        {"--delete-collection-secret", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyCollectionSecret" },
+        {"--list-keys", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher" },
+        {"--generate-stored-key", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyRsaKey RSA 2048" },
+        {"--derive-stored-key", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyAesKey AES 256 salt.data" },
+        {"--delete-key", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyRsaKey" },
+        {"--sign", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyRsaKey SHA256 document.txt > document.txt.sig" },
+        {"--verify", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyRsaKey SHA256 document.txt document.txt.sig" },
+        {"--encrypt", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyAesKey document.txt > document.txt.enc" },
+        {"--decrypt", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyAesKey document.txt.enc > document.txt.dec" },
+    };
+
+    bool autotestMode = false;
+    if (args.size() && args.first() == QStringLiteral("--test")) {
+        args.takeFirst();
+        autotestMode = true;
+    }
+
+    if (args.size() == 0 || !paramDescriptions.contains(args[0])) {
+        // build the usage help text.
+        bool showOptionDescriptions = args.size() &&
+                (args[0] == QStringLiteral("--help") ||
+                 args[0] == QStringLiteral("--h") ||
+                 args[0] == QStringLiteral("-h"));
+        QStringList usage;
+        QMap<QString, QString>::const_iterator it = paramDescriptions.constBegin();
+        while (it != paramDescriptions.constEnd()) {
+            const QString descriptionLine = QStringLiteral("  ") + it.value();
+            const QString usageLine = QStringLiteral("  ") + it.key() + QStringLiteral(" ") + paramOptions.value(it.key());
+            const QString exampleLine = QStringLiteral("  ") + it.key() + QStringLiteral(" ") + paramExamples.value(it.key());
+            if (showOptionDescriptions) {
+                usage.append(descriptionLine);
+                usage.append(usageLine);
+                usage.append(QStringLiteral("  E.g.:"));
+                usage.append(exampleLine);
+                usage.append(QString());
+            } else {
+                usage.append(usageLine);
+            }
+            it++;
+        }
+
+        // then prepend the --help and -h options
+        if (showOptionDescriptions) {
+            usage.prepend(QString());
+            usage.prepend(QStringLiteral("  --help, -h"));
+            usage.prepend(QStringLiteral("  Display this help text"));
+        } else {
+            usage.prepend(QStringLiteral("  --help, -h"));
+        }
+
+        // and print the usage help text.
+        qInfo() << "Usage: secrets-tool [--test] [options]";
+        qInfo() << "";
+        qInfo() << "The --test flag should be provided if the daemon is running in --test mode.";
+        qInfo() << "";
+        qInfo() << "Options:";
+        Q_FOREACH (const QString &line, usage) {
+            qInfo() << line.toLocal8Bit().constData();
+        }
+        qInfo() << "";
+        return 0;
+    }
+
+    const QString command = args.takeFirst();
+    if (args.size() < paramOptionsMin.value(command)
+            || args.size() > paramOptionsMax.value(command)) {
+        qInfo() << "  Usage:" << appName << command << paramOptions.value(command);
+        qInfo() << "Example:" << appName << command << paramExamples.value(command);
+        return 1;
+    }
+
+    CommandHelper helper(autotestMode);
+    QObject::connect(&helper, &CommandHelper::finished,
+                     &app, &QCoreApplication::quit);
+    helper.start(command, args);
+    app.exec();
+    return helper.exitCode();
+}

--- a/tools/secrets-tool/manual-test.sh
+++ b/tools/secrets-tool/manual-test.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# This script must be run within a devel-su -p shell
+# The daemon must be running in autotest mode (with --test option)
+
+# Create a collection and test secret store/read/delete
+echo "Creating collection MyCollection, user passphrase required..."
+secrets-tool --test --create-collection org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection
+echo "Storing normal secret, user input required..."
+secrets-tool --test --store-collection-secret org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyCollectionSecret
+echo "Reading normal secret"
+secrets-tool --test --get-collection-secret org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyCollectionSecret
+echo "Deleting normal secret"
+secrets-tool --test --delete-collection-secret org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyCollectionSecret
+
+# Create an RSA key, and test sign/verify
+echo "Generating 2048-bit RSA key within MyCollection..."
+secrets-tool --test --generate-stored-key org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyRsaKey RSA 2048
+echo "Listing keys from MyCollection to ensure key generation succeeded..."
+secrets-tool --test --list-keys org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test
+echo "Generating test document to sign..."
+echo "This is a text document containing some plain text data which I would like signed or encrypted." > document.txt
+echo "Signing test document with RSA key..."
+secrets-tool --test --sign org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyRsaKey SHA256 document.txt > document.txt.sig
+echo "Verifying signature with RSA key..."
+secrets-tool --test --verify org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyRsaKey SHA256 document.txt document.txt.sig
+
+# Create an AES key, and test encrypt/decrypt
+echo "Generating salt data for AES key generation..."
+head -c 16 /dev/urandom > salt.data
+echo "Generating 256-bit AES key from passphrase..."
+secrets-tool --test --derive-stored-key org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyAesKey AES 256 salt.data
+echo "Listing keys from MyCollection to ensure key generation succeeded..."
+secrets-tool --test --list-keys org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test
+echo "Encrypting test document with AES key..."
+secrets-tool --test --encrypt org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyAesKey document.txt > document.txt.enc
+echo "Decrypting ciphertext with AES key..."
+secrets-tool --test --decrypt org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyAesKey document.txt.enc
+
+# Clean up by deleting the collection
+echo "Cleaning up - deleting MyCollection..."
+secrets-tool --test --delete-collection org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection

--- a/tools/secrets-tool/secrets-tool.pro
+++ b/tools/secrets-tool/secrets-tool.pro
@@ -1,0 +1,16 @@
+TEMPLATE = app
+TARGET = secrets-tool
+
+CONFIG += link_pkgconfig console
+PKGCONFIG += qt5-boostable Qt5Core Qt5DBus
+
+#PKGCONFIG += sailfishsecrets sailfishcrypto
+include($$PWD/../../lib/libsailfishsecrets.pri)
+include($$PWD/../../lib/libsailfishcrypto.pri)
+
+SOURCES += $$PWD/commandhelper.cpp $$PWD/main.cpp
+HEADERS += $$PWD/commandhelper.h
+OTHER_FILES += $$PWD/manual-test.sh
+
+target.path = /usr/bin
+INSTALLS += target

--- a/tools/tools.pro
+++ b/tools/tools.pro
@@ -1,0 +1,3 @@
+TEMPLATE = subdirs
+SUBDIRS += \
+    $$PWD/secrets-tool


### PR DESCRIPTION
This commit adds a command line tool which allows the user to perform
a variety of operations via the Secrets and Crypto APIs.

It can be used to manually test the various authentication and user
input flows, to manually verify that a particular plugin is working
as expected, or to perform useful operations (such as signing,
verification, encryption or decryption) via a particular plugin.

Contributes to JB#36797 and JB#40058