### PR TITLE
[sailfish-secrets] Use US spelling. Contributes to JB#40058

### DIFF
--- a/daemon/CryptoImpl/crypto.cpp
+++ b/daemon/CryptoImpl/crypto.cpp
@@ -9,7 +9,7 @@
 #include "cryptorequestprocessor_p.h"
 #include "logging_p.h"
 
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 #include "Crypto/cryptodaemonconnection_p.h"
 
 #include "Crypto/key.h"
@@ -479,7 +479,7 @@ void Daemon::ApiImpl::CryptoDBusObject::updateCipherSession(
                                   result);
 }
 
-void Daemon::ApiImpl::CryptoDBusObject::finaliseCipherSession(
+void Daemon::ApiImpl::CryptoDBusObject::finalizeCipherSession(
         const QByteArray &data,
         const QVariantMap &customParameters,
         const QString &cryptosystemProviderName,
@@ -496,7 +496,7 @@ void Daemon::ApiImpl::CryptoDBusObject::finaliseCipherSession(
     inParams << QVariant::fromValue<QVariantMap>(customParameters);
     inParams << QVariant::fromValue<QString>(cryptosystemProviderName);
     inParams << QVariant::fromValue<quint32>(cipherSessionToken);
-    m_requestQueue->handleRequest(Daemon::ApiImpl::FinaliseCipherSessionRequest,
+    m_requestQueue->handleRequest(Daemon::ApiImpl::FinalizeCipherSessionRequest,
                                   inParams,
                                   connection(),
                                   message,
@@ -647,7 +647,7 @@ QString Daemon::ApiImpl::CryptoRequestQueue::requestTypeToString(int type) const
         case InitializeCipherSessionRequest:   return QLatin1String("InitializeCipherSessionRequest");
         case UpdateCipherSessionAuthenticationRequest: return QLatin1String("UpdateCipherSessionAuthenticationRequest");
         case UpdateCipherSessionRequest:       return QLatin1String("UpdateCipherSessionRequest");
-        case FinaliseCipherSessionRequest:     return QLatin1String("FinaliseCipherSessionRequest");
+        case FinalizeCipherSessionRequest:     return QLatin1String("FinalizeCipherSessionRequest");
         case ModifyLockCodeRequest:            return QLatin1String("ModifyLockCodeRequest");
         case ProvideLockCodeRequest:           return QLatin1String("ProvideLockCodeRequest");
         case ForgetLockCodeRequest:            return QLatin1String("ForgetLockCodeRequest");
@@ -1229,15 +1229,15 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
             }
             break;
         }
-        case FinaliseCipherSessionRequest: {
-            qCDebug(lcSailfishCryptoDaemon) << "Handling FinaliseCipherSessionRequest from client:" << request->remotePid << ", request number:" << request->requestId;
+        case FinalizeCipherSessionRequest: {
+            qCDebug(lcSailfishCryptoDaemon) << "Handling FinalizeCipherSessionRequest from client:" << request->remotePid << ", request number:" << request->requestId;
             QByteArray generatedData;
             bool verified = false;
             QByteArray data = request->inParams.size() ? request->inParams.takeFirst().value<QByteArray>() : QByteArray();
             QVariantMap customParameters = request->inParams.size() ? request->inParams.takeFirst().value<QVariantMap>() : QVariantMap();
             QString cryptosystemProviderName = request->inParams.size() ? request->inParams.takeFirst().value<QString>() : QString();
             quint32 cipherSessionToken = request->inParams.size() ? request->inParams.takeFirst().value<quint32>() : 0;
-            Result result = m_requestProcessor->finaliseCipherSession(
+            Result result = m_requestProcessor->finalizeCipherSession(
                         request->remotePid,
                         request->requestId,
                         data,
@@ -1715,14 +1715,14 @@ void Daemon::ApiImpl::CryptoRequestQueue::handleFinishedRequest(
             }
             break;
         }
-        case FinaliseCipherSessionRequest: {
+        case FinalizeCipherSessionRequest: {
             Result result = request->outParams.size()
                     ? request->outParams.takeFirst().value<Result>()
                     : Result(Result::UnknownError,
-                             QLatin1String("Unable to determine result of FinaliseCipherSessionRequest request"));
+                             QLatin1String("Unable to determine result of FinalizeCipherSessionRequest request"));
             if (result.code() == Result::Pending) {
                 // shouldn't happen!
-                qCWarning(lcSailfishCryptoDaemon) << "FinaliseCipherSessionRequest:" << request->requestId << "finished as pending!";
+                qCWarning(lcSailfishCryptoDaemon) << "FinalizeCipherSessionRequest:" << request->requestId << "finished as pending!";
                 *completed = true;
             } else {
                 QByteArray generatedData = request->outParams.size()

--- a/daemon/CryptoImpl/crypto_p.h
+++ b/daemon/CryptoImpl/crypto_p.h
@@ -268,7 +268,7 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "          <arg name=\"generatedData\" type=\"ay\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
     "      </method>\n"
-    "      <method name=\"finaliseCipherSession\">\n"
+    "      <method name=\"finalizeCipherSession\">\n"
     "          <arg name=\"data\" type=\"ay\" direction=\"in\" />\n"
     "          <arg name=\"customParameters\" type=\"a{sv}\" direction=\"in\" />\n"
     "          <arg name=\"cryptosystemProviderName\" type=\"s\" direction=\"in\" />\n"
@@ -496,7 +496,7 @@ public Q_SLOTS:
             Sailfish::Crypto::Result &result,
             QByteArray &generatedData);
 
-    void finaliseCipherSession(
+    void finalizeCipherSession(
             const QByteArray &data,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,
@@ -581,7 +581,7 @@ enum RequestType {
     InitializeCipherSessionRequest,
     UpdateCipherSessionAuthenticationRequest,
     UpdateCipherSessionRequest,
-    FinaliseCipherSessionRequest,
+    FinalizeCipherSessionRequest,
     ModifyLockCodeRequest,
     ProvideLockCodeRequest,
     ForgetLockCodeRequest

--- a/daemon/CryptoImpl/cryptopluginfunctionwrappers.cpp
+++ b/daemon/CryptoImpl/cryptopluginfunctionwrappers.cpp
@@ -313,7 +313,7 @@ DataResult CryptoPluginFunctionWrapper::updateCipherSession(
     return DataResult(result, generatedData);
 }
 
-VerifiedDataResult CryptoPluginFunctionWrapper::finaliseCipherSession(
+VerifiedDataResult CryptoPluginFunctionWrapper::finalizeCipherSession(
         const PluginAndCustomParams &pluginAndCustomParams,
         quint64 clientId,
         const QByteArray &data,
@@ -321,7 +321,7 @@ VerifiedDataResult CryptoPluginFunctionWrapper::finaliseCipherSession(
 {
     bool verified = false;
     QByteArray generatedData;
-    Result result = pluginAndCustomParams.plugin->finaliseCipherSession(
+    Result result = pluginAndCustomParams.plugin->finalizeCipherSession(
                 clientId, data,
                 pluginAndCustomParams.customParameters,
                 cipherSessionToken,

--- a/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
+++ b/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
@@ -296,7 +296,7 @@ DataResult updateCipherSession(
         const QByteArray &data,
         quint32 cipherSessionToken);
 
-VerifiedDataResult finaliseCipherSession(
+VerifiedDataResult finalizeCipherSession(
         const PluginAndCustomParams &pluginAndCustomParams,
         quint64 clientId,
         const QByteArray &data,

--- a/daemon/CryptoImpl/cryptorequestprocessor.cpp
+++ b/daemon/CryptoImpl/cryptorequestprocessor.cpp
@@ -562,7 +562,7 @@ Daemon::ApiImpl::RequestProcessor::generateStoredKey_withKdfData(
                                 callerPid,
                                 requestId,
                                 kr.key.identifier(),
-                                Key::serialise(kr.key, Key::LossySerialisationMode),
+                                Key::serialize(kr.key, Key::LossySerializationMode),
                                 kr.key.filterData(),
                                 collectionDecryptionKey));
                 if (storeKeyResult.code() == Result::Failed) {
@@ -948,7 +948,7 @@ Daemon::ApiImpl::RequestProcessor::importStoredKey_withPassphrase(
                                                     callerPid,
                                                     requestId,
                                                     outputKey.identifier(),
-                                                    Key::serialise(outputKey, Key::LossySerialisationMode),
+                                                    Key::serialize(outputKey, Key::LossySerializationMode),
                                                     outputKey.filterData(),
                                                     collectionDecryptionKey));
                 if (result.code() != Result::Failed) {
@@ -1029,9 +1029,9 @@ Daemon::ApiImpl::RequestProcessor::storedKey(
         return Result(Result::Pending);
     }
 
-    QByteArray serialisedKey;
+    QByteArray serializedKey;
     QMap<QString, QString> filterData;
-    Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, identifier, &serialisedKey, &filterData));
+    Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, identifier, &serializedKey, &filterData));
     if (retn.code() == Result::Failed) {
         return retn;
     } else if (retn.code() == Result::Pending) {
@@ -1046,7 +1046,7 @@ Daemon::ApiImpl::RequestProcessor::storedKey(
         return retn;
     }
 
-    *key = Key::deserialise(serialisedKey);
+    *key = Key::deserialize(serializedKey);
     key->setFilterData(filterData);
     nullifyKeyFields(key, keyComponents);
     return retn;
@@ -1057,10 +1057,10 @@ Daemon::ApiImpl::RequestProcessor::storedKey2(
         quint64 requestId,
         Key::Components keyComponents,
         const Result &result,
-        const QByteArray &serialisedKey,
+        const QByteArray &serializedKey,
         const QMap<QString, QString> &filterData)
 {
-    Key retn(Key::deserialise(serialisedKey));
+    Key retn(Key::deserialize(serializedKey));
     retn.setFilterData(filterData);
     nullifyKeyFields(&retn, keyComponents);
 
@@ -1220,9 +1220,9 @@ Daemon::ApiImpl::RequestProcessor::sign(
             fullKey = key; // not a full key, but a reference to a key that the plugin stores.
         } else {
             // no, it is stored in some other plugin
-            QByteArray serialisedKey;
+            QByteArray serializedKey;
             QMap<QString, QString> filterData;
-            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serialisedKey, &filterData));
+            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serializedKey, &filterData));
             if (retn.code() == Result::Failed) {
                 return retn;
             } else if (retn.code() == Result::Pending) {
@@ -1240,7 +1240,7 @@ Daemon::ApiImpl::RequestProcessor::sign(
                 return retn;
             }
 
-            fullKey = Key::deserialise(serialisedKey);
+            fullKey = Key::deserialize(serializedKey);
         }
     } else {
         fullKey = key;
@@ -1272,7 +1272,7 @@ void
 Daemon::ApiImpl::RequestProcessor::sign2(
         quint64 requestId,
         const Result &result,
-        const QByteArray &serialisedKey,
+        const QByteArray &serializedKey,
         const QByteArray &data,
         CryptoManager::SignaturePadding padding,
         CryptoManager::DigestFunction digestFunction,
@@ -1294,7 +1294,7 @@ Daemon::ApiImpl::RequestProcessor::sign2(
                 CryptoPluginFunctionWrapper::sign,
                 PluginAndCustomParams(m_cryptoPlugins[cryptoPluginName], customParameters),
                 data,
-                Key::deserialise(serialisedKey),
+                Key::deserialize(serializedKey),
                 SignatureOptions(padding, digestFunction));
 
     watcher->setFuture(future);
@@ -1355,9 +1355,9 @@ Daemon::ApiImpl::RequestProcessor::verify(
             fullKey = key; // not a full key, but a reference to a key that the plugin stores.
         } else {
             // no, it is stored in some other plugin
-            QByteArray serialisedKey;
+            QByteArray serializedKey;
             QMap<QString, QString> filterData;
-            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serialisedKey, &filterData));
+            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serializedKey, &filterData));
             if (retn.code() == Result::Failed) {
                 return retn;
             } else if (retn.code() == Result::Pending) {
@@ -1376,7 +1376,7 @@ Daemon::ApiImpl::RequestProcessor::verify(
                 return retn;
             }
 
-            fullKey = Key::deserialise(serialisedKey);
+            fullKey = Key::deserialize(serializedKey);
         }
     } else {
         fullKey = key;
@@ -1409,7 +1409,7 @@ void
 Daemon::ApiImpl::RequestProcessor::verify2(
         quint64 requestId,
         const Result &result,
-        const QByteArray &serialisedKey,
+        const QByteArray &serializedKey,
         const QByteArray &signature,
         const QByteArray &data,
         CryptoManager::SignaturePadding padding,
@@ -1432,7 +1432,7 @@ Daemon::ApiImpl::RequestProcessor::verify2(
                 PluginAndCustomParams(m_cryptoPlugins[cryptoPluginName], customParameters),
                 signature,
                 data,
-                Key::deserialise(serialisedKey),
+                Key::deserialize(serializedKey),
                 SignatureOptions(padding, digestFunction));
 
     watcher->setFuture(future);
@@ -1496,9 +1496,9 @@ Daemon::ApiImpl::RequestProcessor::encrypt(
             fullKey = key; // not a full key, but a reference to a key that the plugin stores.
         } else {
             // no, it is stored in some other plugin
-            QByteArray serialisedKey;
+            QByteArray serializedKey;
             QMap<QString, QString> filterData;
-            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serialisedKey, &filterData));
+            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serializedKey, &filterData));
             if (retn.code() == Result::Failed) {
                 return retn;
             } else if (retn.code() == Result::Pending) {
@@ -1520,7 +1520,7 @@ Daemon::ApiImpl::RequestProcessor::encrypt(
                 return retn;
             }
 
-            fullKey = Key::deserialise(serialisedKey);
+            fullKey = Key::deserialize(serializedKey);
         }
     } else {
         fullKey = key;
@@ -1554,7 +1554,7 @@ void
 Daemon::ApiImpl::RequestProcessor::encrypt2(
         quint64 requestId,
         const Result &result,
-        const QByteArray &serialisedKey,
+        const QByteArray &serializedKey,
         const QByteArray &data,
         const QByteArray &iv,
         CryptoManager::BlockMode blockMode,
@@ -1573,11 +1573,11 @@ Daemon::ApiImpl::RequestProcessor::encrypt2(
     }
 
     bool ok = false;
-    Key fullKey = Key::deserialise(serialisedKey, &ok);
+    Key fullKey = Key::deserialize(serializedKey, &ok);
     if (!ok) {
         QList<QVariant> outParams;
-        outParams << QVariant::fromValue<Result>(Result(Result::SerialisationError,
-                                                        QLatin1String("Failed to deserialise key!")));
+        outParams << QVariant::fromValue<Result>(Result(Result::SerializationError,
+                                                        QLatin1String("Failed to deserialize key!")));
         outParams << QVariant::fromValue<QByteArray>(QByteArray());
         outParams << QVariant::fromValue<QByteArray>(QByteArray());
         m_requestQueue->requestFinished(requestId, outParams);
@@ -1657,9 +1657,9 @@ Daemon::ApiImpl::RequestProcessor::decrypt(
             fullKey = key; // not a full key, but a reference to a key that the plugin stores.
         } else {
             // no, it is stored in some other plugin
-            QByteArray serialisedKey;
+            QByteArray serializedKey;
             QMap<QString, QString> filterData;
-            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serialisedKey, &filterData));
+            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serializedKey, &filterData));
             if (retn.code() == Result::Failed) {
                 return retn;
             } else if (retn.code() == Result::Pending) {
@@ -1682,7 +1682,7 @@ Daemon::ApiImpl::RequestProcessor::decrypt(
                 return retn;
             }
 
-            fullKey = Key::deserialise(serialisedKey);
+            fullKey = Key::deserialize(serializedKey);
         }
     } else {
         fullKey = key;
@@ -1716,7 +1716,7 @@ void
 Daemon::ApiImpl::RequestProcessor::decrypt2(
         quint64 requestId,
         const Result &result,
-        const QByteArray &serialisedKey,
+        const QByteArray &serializedKey,
         const QByteArray &data,
         const QByteArray &iv,
         CryptoManager::BlockMode blockMode,
@@ -1740,7 +1740,7 @@ Daemon::ApiImpl::RequestProcessor::decrypt2(
                 CryptoPluginFunctionWrapper::decrypt,
                 PluginAndCustomParams(m_cryptoPlugins[cryptoPluginName], customParameters),
                 DataAndIV(data, iv),
-                Key::deserialise(serialisedKey),
+                Key::deserialize(serializedKey),
                 EncryptionOptions(blockMode, padding),
                 AuthDataAndTag(authenticationData, authenticationTag));
 
@@ -1805,9 +1805,9 @@ Daemon::ApiImpl::RequestProcessor::initializeCipherSession(
             fullKey = key; // not a full key, but a reference to a key that the plugin stores.
         } else {
             // no, it is stored in some other plugin
-            QByteArray serialisedKey;
+            QByteArray serializedKey;
             QMap<QString, QString> filterData;
-            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serialisedKey, &filterData));
+            Result retn = transformSecretsResult(m_secrets->storedKey(callerPid, requestId, key.identifier(), &serializedKey, &filterData));
             if (retn.code() == Result::Failed) {
                 return retn;
             } else if (retn.code() == Result::Pending) {
@@ -1829,7 +1829,7 @@ Daemon::ApiImpl::RequestProcessor::initializeCipherSession(
                 return retn;
             }
 
-            fullKey = Key::deserialise(serialisedKey);
+            fullKey = Key::deserialize(serializedKey);
         }
     } else {
         fullKey = key;
@@ -1867,7 +1867,7 @@ void
 Daemon::ApiImpl::RequestProcessor::initializeCipherSession2(
         quint64 requestId,
         const Result &result,
-        const QByteArray &serialisedKey,
+        const QByteArray &serializedKey,
         pid_t callerPid,
         const QByteArray &iv,
         CryptoManager::Operation operation,
@@ -1893,7 +1893,7 @@ Daemon::ApiImpl::RequestProcessor::initializeCipherSession2(
                 PluginAndCustomParams(m_cryptoPlugins[cryptoPluginName], customParameters),
                 callerPid,
                 iv,
-                Key::deserialise(serialisedKey),
+                Key::deserialize(serializedKey),
                 CipherSessionOptions(
                     operation,
                     blockMode,
@@ -1991,7 +1991,7 @@ Daemon::ApiImpl::RequestProcessor::updateCipherSession(
 }
 
 Result
-Daemon::ApiImpl::RequestProcessor::finaliseCipherSession(
+Daemon::ApiImpl::RequestProcessor::finalizeCipherSession(
         pid_t callerPid,
         quint64 requestId,
         const QByteArray &data,
@@ -2014,7 +2014,7 @@ Daemon::ApiImpl::RequestProcessor::finaliseCipherSession(
     QFutureWatcher<VerifiedDataResult> *watcher = new QFutureWatcher<VerifiedDataResult>(this);
     QFuture<VerifiedDataResult> future = QtConcurrent::run(
                 m_requestQueue->controller()->threadPoolForPlugin(cryptosystemProviderName).data(),
-                CryptoPluginFunctionWrapper::finaliseCipherSession,
+                CryptoPluginFunctionWrapper::finalizeCipherSession,
                 PluginAndCustomParams(cryptoPlugin, customParameters),
                 callerPid,
                 data,
@@ -2164,7 +2164,7 @@ Daemon::ApiImpl::RequestProcessor::forgetLockCode(
 void Daemon::ApiImpl::RequestProcessor::secretsStoredKeyCompleted(
         quint64 requestId,
         const Sailfish::Secrets::Result &result,
-        const QByteArray &serialisedKey,
+        const QByteArray &serializedKey,
         const QMap<QString, QString> &filterData)
 {
     // look up the pending request in our list
@@ -2178,7 +2178,7 @@ void Daemon::ApiImpl::RequestProcessor::secretsStoredKeyCompleted(
             case StoredKeyRequest: {
                 (void)pr.parameters.takeFirst(); // the identifier, we don't need it.
                 Key::Components keyComponents = pr.parameters.takeFirst().value<Key::Components>();
-                storedKey2(requestId, keyComponents, returnResult, serialisedKey, filterData);
+                storedKey2(requestId, keyComponents, returnResult, serializedKey, filterData);
                 break;
             }
             case SignRequest: {
@@ -2187,7 +2187,7 @@ void Daemon::ApiImpl::RequestProcessor::secretsStoredKeyCompleted(
                 CryptoManager::DigestFunction digestFunction = pr.parameters.takeFirst().value<CryptoManager::DigestFunction>();
                 QVariantMap customParameters = pr.parameters.takeFirst().value<QVariantMap>();
                 QString cryptoPluginName = pr.parameters.takeFirst().value<QString>();
-                sign2(requestId, returnResult, serialisedKey, data, padding, digestFunction, customParameters, cryptoPluginName);
+                sign2(requestId, returnResult, serializedKey, data, padding, digestFunction, customParameters, cryptoPluginName);
                 break;
             }
             case VerifyRequest: {
@@ -2197,7 +2197,7 @@ void Daemon::ApiImpl::RequestProcessor::secretsStoredKeyCompleted(
                 CryptoManager::DigestFunction digestFunction = pr.parameters.takeFirst().value<CryptoManager::DigestFunction>();
                 QVariantMap customParameters = pr.parameters.takeFirst().value<QVariantMap>();
                 QString cryptoPluginName = pr.parameters.takeFirst().value<QString>();
-                verify2(requestId, returnResult, serialisedKey, signature, data, padding, digestFunction, customParameters, cryptoPluginName);
+                verify2(requestId, returnResult, serializedKey, signature, data, padding, digestFunction, customParameters, cryptoPluginName);
                 break;
             }
             case EncryptRequest: {
@@ -2208,7 +2208,7 @@ void Daemon::ApiImpl::RequestProcessor::secretsStoredKeyCompleted(
                 QByteArray authenticationData = pr.parameters.takeFirst().value<QByteArray>();
                 QVariantMap customParameters = pr.parameters.takeFirst().value<QVariantMap>();
                 QString cryptoPluginName = pr.parameters.takeFirst().value<QString>();
-                encrypt2(requestId, returnResult, serialisedKey, data, iv, blockMode, padding, authenticationData, customParameters, cryptoPluginName);
+                encrypt2(requestId, returnResult, serializedKey, data, iv, blockMode, padding, authenticationData, customParameters, cryptoPluginName);
                 break;
             }
             case DecryptRequest: {
@@ -2220,7 +2220,7 @@ void Daemon::ApiImpl::RequestProcessor::secretsStoredKeyCompleted(
                 QByteArray authenticationTag = pr.parameters.takeFirst().value<QByteArray>();
                 QVariantMap customParameters = pr.parameters.takeFirst().value<QVariantMap>();
                 QString cryptoPluginName = pr.parameters.takeFirst().value<QString>();
-                decrypt2(requestId, returnResult, serialisedKey, data, iv, blockMode, padding, authenticationData, authenticationTag, customParameters, cryptoPluginName);
+                decrypt2(requestId, returnResult, serializedKey, data, iv, blockMode, padding, authenticationData, authenticationTag, customParameters, cryptoPluginName);
                 break;
             }
             case InitializeCipherSessionRequest: {
@@ -2233,7 +2233,7 @@ void Daemon::ApiImpl::RequestProcessor::secretsStoredKeyCompleted(
                 CryptoManager::DigestFunction digestFunction = pr.parameters.takeFirst().value<CryptoManager::DigestFunction>();
                 QVariantMap customParameters = pr.parameters.takeFirst().value<QVariantMap>();
                 QString cryptoPluginName = pr.parameters.takeFirst().value<QString>();
-                initializeCipherSession2(requestId, returnResult, serialisedKey,
+                initializeCipherSession2(requestId, returnResult, serializedKey,
                                          callerPid, iv, operation, blockMode,
                                          encryptionPadding, signaturePadding,
                                          digestFunction, customParameters, cryptoPluginName);

--- a/daemon/CryptoImpl/cryptorequestprocessor_p.h
+++ b/daemon/CryptoImpl/cryptorequestprocessor_p.h
@@ -256,7 +256,7 @@ public:
             quint32 cipherSessionToken,
             QByteArray *generatedData);
 
-    Sailfish::Crypto::Result finaliseCipherSession(
+    Sailfish::Crypto::Result finalizeCipherSession(
             pid_t callerPid,
             quint64 requestId,
             const QByteArray &data,
@@ -300,7 +300,7 @@ public Q_SLOTS:
     void secretsStoredKeyCompleted(
             quint64 requestId,
             const Sailfish::Secrets::Result &result,
-            const QByteArray &serialisedKey,
+            const QByteArray &serializedKey,
             const QMap<QString, QString> &filterData);
 
     void secretsDeleteStoredKeyCompleted(
@@ -336,7 +336,7 @@ private:
             quint64 requestId,
             Key::Components keyComponents,
             const Sailfish::Crypto::Result &result,
-            const QByteArray &serialisedKey,
+            const QByteArray &serializedKey,
             const QMap<QString, QString> &filterData);
 
     void generateStoredKey_afterPreCheck(
@@ -440,7 +440,7 @@ private:
     void sign2(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
-            const QByteArray &serialisedKey,
+            const QByteArray &serializedKey,
             const QByteArray &data,
             Sailfish::Crypto::CryptoManager::SignaturePadding padding,
             Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
@@ -450,7 +450,7 @@ private:
     void verify2(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
-            const QByteArray &serialisedKey,
+            const QByteArray &serializedKey,
             const QByteArray &signature,
             const QByteArray &data,
             Sailfish::Crypto::CryptoManager::SignaturePadding padding,
@@ -461,7 +461,7 @@ private:
     void encrypt2(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
-            const QByteArray &serialisedKey,
+            const QByteArray &serializedKey,
             const QByteArray &data,
             const QByteArray &iv,
             Sailfish::Crypto::CryptoManager::BlockMode blockMode,
@@ -473,7 +473,7 @@ private:
     void decrypt2(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
-            const QByteArray &serialisedKey,
+            const QByteArray &serializedKey,
             const QByteArray &data,
             const QByteArray &iv,
             Sailfish::Crypto::CryptoManager::BlockMode blockMode,
@@ -486,7 +486,7 @@ private:
     void initializeCipherSession2(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
-            const QByteArray &serialisedKey,
+            const QByteArray &serializedKey,
             pid_t callerPid,
             const QByteArray &iv,
             Sailfish::Crypto::CryptoManager::Operation operation,

--- a/daemon/SecretsImpl/pluginwrapper.cpp
+++ b/daemon/SecretsImpl/pluginwrapper.cpp
@@ -76,7 +76,7 @@ bool PluginWrapper::masterUnlock(const QByteArray &masterLockKey)
                                            << result.errorMessage();
         return false;
     }
-    return initialize(masterLockKey); // may need to synchronise data between metadataDb and plugin.
+    return initialize(masterLockKey); // may need to synchronize data between metadataDb and plugin.
 }
 
 bool PluginWrapper::setMasterLockKey(const QByteArray &oldMasterLockKey, const QByteArray &newMasterLockKey)
@@ -89,7 +89,7 @@ bool PluginWrapper::setMasterLockKey(const QByteArray &oldMasterLockKey, const Q
                                            << result.errorMessage();
         return false;
     }
-    return initialize(newMasterLockKey); // may need to synchronise data between metadataDb and plugin.
+    return initialize(newMasterLockKey); // may need to synchronize data between metadataDb and plugin.
 }
 
 bool PluginWrapper::supportsLocking() const
@@ -110,14 +110,14 @@ bool PluginWrapper::lock()
 bool PluginWrapper::unlock(const QByteArray &lockCode)
 {
     bool ps = m_plugin->unlock(lockCode);
-    initialize(); // may need to synchronise data between metadataDb and plugin.
+    initialize(); // may need to synchronize data between metadataDb and plugin.
     return ps;
 }
 
 bool PluginWrapper::setLockCode(const QByteArray &oldLockCode, const QByteArray &newLockCode)
 {
     bool ps = m_plugin->setLockCode(oldLockCode, newLockCode);
-    initialize(); // may need to synchronise data between metadataDb and plugin.
+    initialize(); // may need to synchronize data between metadataDb and plugin.
     return ps;
 }
 

--- a/daemon/SecretsImpl/secrets.cpp
+++ b/daemon/SecretsImpl/secrets.cpp
@@ -14,7 +14,7 @@
 #include "Secrets/result.h"
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretsdaemonconnection_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include "Crypto/keypairgenerationparameters.h"
 #include "Crypto/keyderivationparameters.h"

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -455,9 +455,9 @@ public: // Crypto API helper methods.
     // the first methods are synchronous:
     Sailfish::Secrets::Result storagePluginInfo(pid_t callerPid, quint64 cryptoRequestId, QVector<Sailfish::Secrets::PluginInfo> *info) const;
     // the others are asynchronous methods:
-    Sailfish::Secrets::Result storedKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier, QByteArray *serialisedKey, QMap<QString, QString> *filterData);
+    Sailfish::Secrets::Result storedKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier, QByteArray *serializedKey, QMap<QString, QString> *filterData);
     Sailfish::Secrets::Result storeKeyPreCheck(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier);
-    Sailfish::Secrets::Result storeKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier, const QByteArray &serialisedKey,
+    Sailfish::Secrets::Result storeKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier, const QByteArray &serializedKey,
                                        const QMap<QString, QString> &filterData, const QByteArray &collectionDecryptionKey);
     Sailfish::Secrets::Result deleteStoredKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier);
     Sailfish::Secrets::Result userInput(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Secrets::InteractionParameters &uiParams);
@@ -466,7 +466,7 @@ public: // Crypto API helper methods.
     Sailfish::Secrets::Result forgetCryptoPluginLockCode(pid_t callerPid, quint64 cryptoRequestId, const QString &cryptoPluginName, const Sailfish::Secrets::InteractionParameters &uiParams);
 
 Q_SIGNALS:
-    void storedKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &serialisedKey, const QMap<QString,QString> &filterData);
+    void storedKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &serializedKey, const QMap<QString,QString> &filterData);
     void storeKeyPreCheckCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &collectionDecryptionKey);
     void storeKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);
     void deleteStoredKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);

--- a/daemon/SecretsImpl/secretscryptohelpers.cpp
+++ b/daemon/SecretsImpl/secretscryptohelpers.cpp
@@ -143,7 +143,7 @@ Daemon::ApiImpl::SecretsRequestQueue::storeKey(
         pid_t callerPid,
         quint64 cryptoRequestId,
         const Sailfish::Crypto::Key::Identifier &identifier,
-        const QByteArray &serialisedKey,
+        const QByteArray &serializedKey,
         const QMap<QString, QString> &filterData,
         const QByteArray &collectionDecryptionKey)
 {
@@ -151,7 +151,7 @@ Daemon::ApiImpl::SecretsRequestQueue::storeKey(
     Secret secret(Secret::Identifier(identifier.name(), identifier.collectionName(), identifier.storagePluginName()));
     secret.setFilterData(filterData);
     secret.setType(Secret::TypeCryptoKey);
-    secret.setData(serialisedKey);
+    secret.setData(serializedKey);
     QList<QVariant> inParams;
     inParams << QVariant::fromValue<Secret>(secret)
              << QVariant::fromValue<SecretManager::UserInteractionMode>(SecretManager::SystemInteraction)
@@ -202,10 +202,10 @@ Daemon::ApiImpl::SecretsRequestQueue::storedKey(
         pid_t callerPid,
         quint64 cryptoRequestId,
         const Sailfish::Crypto::Key::Identifier &identifier,
-        QByteArray *serialisedKey,
+        QByteArray *serializedKey,
         QMap<QString, QString> *filterData)
 {
-    Q_UNUSED(serialisedKey); // this request is always asynchronous
+    Q_UNUSED(serializedKey); // this request is always asynchronous
     Q_UNUSED(filterData);
 
     // perform the "get collection secret" request, as a secrets-for-crypto request.

--- a/database/database.cpp
+++ b/database/database.cpp
@@ -396,7 +396,7 @@ bool Database::beginTransaction()
         return ::beginTransaction(m_database);
     } else if (oldSemaphoreValue == 1) {
         // already in an "outer" transaction.  This is fine, and is
-        // done within loadPlugins() code to minimise transactions on startup.
+        // done within loadPlugins() code to minimize transactions on startup.
         return true;
     } else {
         // this is always an error, we don't allow recursive transactions.

--- a/lib/Crypto/Crypto.pro
+++ b/lib/Crypto/Crypto.pro
@@ -43,7 +43,7 @@ PUBLIC_HEADERS += \
 
 INTERNAL_PUBLIC_HEADERS += \
     $$PWD/cryptodaemonconnection_p.h \
-    $$PWD/serialisation_p.h
+    $$PWD/serialization_p.h
 
 PRIVATE_HEADERS += \
     $$PWD/calculatedigestrequest_p.h \
@@ -102,7 +102,7 @@ SOURCES += \
     $$PWD/request.cpp \
     $$PWD/result.cpp \
     $$PWD/seedrandomdatageneratorrequest.cpp \
-    $$PWD/serialisation.cpp \
+    $$PWD/serialization.cpp \
     $$PWD/signrequest.cpp \
     $$PWD/storedkeyidentifiersrequest.cpp \
     $$PWD/storedkeyrequest.cpp \

--- a/lib/Crypto/calculatedigestrequest.cpp
+++ b/lib/Crypto/calculatedigestrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/cipherrequest.cpp
+++ b/lib/Crypto/cipherrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>
@@ -65,7 +65,7 @@ CipherRequest::CipherMode CipherRequest::cipherMode() const
  * The mode will be applied by the system crypto service to the cipher session.
  * In general, the client will want to initialize the cipher session, and then
  * repeatedly update the cipher session with data to be operated upon, and
- * then when finished with all data should finalise the cipher session.
+ * then when finished with all data should finalize the cipher session.
  *
  * The following example shows how to use a CipherRequest to encrypt a stream
  * of data using AES 256 encryption in CBC mode.  Note that it forces the
@@ -98,8 +98,8 @@ CipherRequest::CipherMode CipherRequest::cipherMode() const
  *     ciphertext.append(cr.generatedData());
  * }
  *
- * // Finalise the cipher session.
- * cr.setCipherMode(CipherRequest::FinaliseCipher);
+ * // Finalize the cipher session.
+ * cr.setCipherMode(CipherRequest::FinalizeCipher);
  * cr.startRequest();
  * cr.waitForFinished();
  * ciphertext.append(cr.generatedData());
@@ -134,32 +134,32 @@ CipherRequest::CipherMode CipherRequest::cipherMode() const
  *     plaintext.append(cr.generatedData());
  * }
  *
- * // Finalise the cipher session.
- * cr.setCipherMode(CipherRequest::FinaliseCipher);
+ * // Finalize the cipher session.
+ * cr.setCipherMode(CipherRequest::FinalizeCipher);
  * cr.startRequest();
  * cr.waitForFinished();
  * plaintext.append(cr.generatedData());
  * \endcode
  *
  * Note that authenticated encryption and decryption is slightly
- * different, as encryption finalisation produces an authentication tag, which must
- * be provided during decryption finalisation for verification.
+ * different, as encryption finalization produces an authentication tag, which must
+ * be provided during decryption finalization for verification.
  * For example, after encrypting data using BlockModeGcm:
  *
  * \code
- * // Finalise the GCM encryption cipher session.
- * cr.setCipherMode(CipherRequest::FinaliseCipher);
+ * // Finalize the GCM encryption cipher session.
+ * cr.setCipherMode(CipherRequest::FinalizeCipher);
  * cr.startRequest();
  * cr.waitForFinished();
  * QByteArray gcmTag = cr.generatedData();
  * \endcode
  *
- * and when decrypting, the authentication tag should be provided for finalisation
+ * and when decrypting, the authentication tag should be provided for finalization
  * and the verified flag should be checked carefully:
  *
  * \code
- * // Finalise the GCM decryption cipher session.
- * cr.setCipherMode(CipherRequest::FinaliseCipher);
+ * // Finalize the GCM decryption cipher session.
+ * cr.setCipherMode(CipherRequest::FinalizeCipher);
  * cr.setData(gcmTag);
  * cr.startRequest();
  * cr.waitForFinished();
@@ -167,7 +167,7 @@ CipherRequest::CipherMode CipherRequest::cipherMode() const
  * \endcode
  *
  * If \a mode is either CipherRequest::UpdateCipher or
- * CipherRequest::FinaliseCipher then when the request is finished
+ * CipherRequest::FinalizeCipher then when the request is finished
  * the generatedData() should contain the block of data which
  * was generated based upon the input data (that is, it will be
  * encrypted, decrypted, or signature data) or alternatively
@@ -446,7 +446,7 @@ QByteArray CipherRequest::generatedData() const
  * \brief Returns the true if the verify operation succeeded
  *
  * Note: this value is only valid if the status of the request is Request::Finished
- * and the cipher session has been finalised and the operation() was
+ * and the cipher session has been finalized and the operation() was
  * CryptoManager::OperationVerify.
  */
 bool CipherRequest::verified() const
@@ -681,10 +681,10 @@ void CipherRequest::startRequest()
             }
         } else {
             if (d->m_cipherSessionToken == 0) {
-                qWarning() << "Ignoring attempt to finalise uninitialized cipher session!";
+                qWarning() << "Ignoring attempt to finalize uninitialized cipher session!";
             } else {
                 QDBusPendingReply<Result, QByteArray, bool> reply =
-                        d->m_manager->d_ptr->finaliseCipherSession(
+                        d->m_manager->d_ptr->finalizeCipherSession(
                                 d->m_data,
                                 d->m_customParameters,
                                 d->m_cryptoPluginName,

--- a/lib/Crypto/cipherrequest.h
+++ b/lib/Crypto/cipherrequest.h
@@ -44,7 +44,7 @@ public:
         InitializeCipher = 0,
         UpdateCipherAuthentication,
         UpdateCipher,
-        FinaliseCipher,
+        FinalizeCipher,
     };
     Q_ENUM(CipherMode)
 

--- a/lib/Crypto/cryptodaemonconnection.cpp
+++ b/lib/Crypto/cryptodaemonconnection.cpp
@@ -7,7 +7,7 @@
 
 #include "Crypto/cryptodaemonconnection_p.h"
 #include "Crypto/cryptodaemonconnection_p_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/result.h"

--- a/lib/Crypto/cryptomanager.cpp
+++ b/lib/Crypto/cryptomanager.cpp
@@ -7,7 +7,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 #include "Crypto/key.h"
 #include "Crypto/keypairgenerationparameters.h"
 #include "Crypto/keyderivationparameters.h"
@@ -531,7 +531,7 @@ CryptoManagerPrivate::updateCipherSession(
 }
 
 QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, bool>
-CryptoManagerPrivate::finaliseCipherSession(
+CryptoManagerPrivate::finalizeCipherSession(
         const QByteArray &data,
         const QVariantMap &customParameters,
         const QString &cryptosystemProviderName,
@@ -545,7 +545,7 @@ CryptoManagerPrivate::finaliseCipherSession(
 
     QDBusPendingReply<Result, QByteArray, bool> reply
             = m_interface->asyncCallWithArgumentList(
-                "finaliseCipherSession",
+                "finalizeCipherSession",
                 QVariantList() << QVariant::fromValue<QByteArray>(data)
                                << QVariant::fromValue<QVariantMap>(customParameters)
                                << QVariant::fromValue<QString>(cryptosystemProviderName)

--- a/lib/Crypto/cryptomanager_p.h
+++ b/lib/Crypto/cryptomanager_p.h
@@ -176,7 +176,7 @@ public:
             const QString &cryptosystemProviderName,
             quint32 cipherSessionToken);
 
-    QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, bool> finaliseCipherSession(
+    QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, bool> finalizeCipherSession(
             const QByteArray &data,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,

--- a/lib/Crypto/decryptrequest.cpp
+++ b/lib/Crypto/decryptrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/deletestoredkeyrequest.cpp
+++ b/lib/Crypto/deletestoredkeyrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/encryptrequest.cpp
+++ b/lib/Crypto/encryptrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/generateinitializationvectorrequest.cpp
+++ b/lib/Crypto/generateinitializationvectorrequest.cpp
@@ -9,7 +9,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/generatekeyrequest.cpp
+++ b/lib/Crypto/generatekeyrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/generaterandomdatarequest.cpp
+++ b/lib/Crypto/generaterandomdatarequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/generatestoredkeyrequest.cpp
+++ b/lib/Crypto/generatestoredkeyrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/importkeyrequest.cpp
+++ b/lib/Crypto/importkeyrequest.cpp
@@ -9,7 +9,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/importstoredkeyrequest.cpp
+++ b/lib/Crypto/importstoredkeyrequest.cpp
@@ -9,7 +9,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/key.h
+++ b/lib/Crypto/key.h
@@ -142,12 +142,12 @@ public:
     Q_INVOKABLE void setFilterData(const QString &field, const QString &value);
     Q_INVOKABLE bool hasFilterData(const QString &field);
 
-    enum SerialisationMode {
-        LossySerialisationMode = 0, // don't serialise filter data or identifier, reduce known-plaintext surface.
-        LosslessSerialisationMode
+    enum SerializationMode {
+        LossySerializationMode = 0, // don't serialize filter data or identifier, reduce known-plaintext surface.
+        LosslessSerializationMode
     };
-    static QByteArray serialise(const Sailfish::Crypto::Key &key, SerialisationMode serialisationMode = LosslessSerialisationMode);
-    static Sailfish::Crypto::Key deserialise(const QByteArray &data, bool *ok = nullptr);
+    static QByteArray serialize(const Sailfish::Crypto::Key &key, SerializationMode serializationMode = LosslessSerializationMode);
+    static Sailfish::Crypto::Key deserialize(const QByteArray &data, bool *ok = nullptr);
 
 protected:
     QSharedDataPointer<KeyPrivate> d_ptr;

--- a/lib/Crypto/keypairgenerationparameters_p.h
+++ b/lib/Crypto/keypairgenerationparameters_p.h
@@ -29,7 +29,7 @@ public:
     QVariantMap m_customParameters;
     QVariantMap m_subclassParameters;
 
-    // for use in serialisation
+    // for use in serialization
     static QVariantMap subclassParameters(const KeyPairGenerationParameters &kpgParams);
     static void setSubclassParameters(KeyPairGenerationParameters &kpgParams, const QVariantMap &params);
 };

--- a/lib/Crypto/lockcoderequest.cpp
+++ b/lib/Crypto/lockcoderequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/plugininforequest.cpp
+++ b/lib/Crypto/plugininforequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 #include "Crypto/plugininfo.h"
 
 #include <QtDBus/QDBusPendingReply>

--- a/lib/Crypto/result.h
+++ b/lib/Crypto/result.h
@@ -38,7 +38,7 @@ public:
     enum ErrorCode {
         NoError = 0,
         UnknownError = 2,
-        SerialisationError = 3,
+        SerializationError = 3,
         StorageError = 4,
         DaemonError = 5,
 

--- a/lib/Crypto/seedrandomdatageneratorrequest.cpp
+++ b/lib/Crypto/seedrandomdatageneratorrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/serialization.cpp
+++ b/lib/Crypto/serialization.cpp
@@ -15,7 +15,7 @@
 #include "Crypto/keypairgenerationparameters.h"
 #include "Crypto/keypairgenerationparameters_p.h"
 
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 #include "Crypto/key_p.h"
 
 #include <QtDBus/QDBusArgument>
@@ -26,14 +26,14 @@
 #include <QtCore/QDataStream>
 #include <QtCore/QByteArray>
 
-Q_LOGGING_CATEGORY(lcSailfishCryptoSerialisation, "org.sailfishos.crypto.serialisation", QtWarningMsg)
+Q_LOGGING_CATEGORY(lcSailfishCryptoSerialization, "org.sailfishos.crypto.serialization", QtWarningMsg)
 
 namespace Sailfish {
 
 namespace Crypto {
 
 Key
-Key::deserialise(const QByteArray &data, bool *ok)
+Key::deserialize(const QByteArray &data, bool *ok)
 {
     QBuffer buffer;
     buffer.setData(data);
@@ -44,7 +44,7 @@ Key::deserialise(const QByteArray &data, bool *ok)
     quint32 magic;
     in >> magic;
     if (magic != 0x4B657900) {
-        qCWarning(lcSailfishCryptoSerialisation) << "Cannot deserialise key, bad magic number:" << magic;
+        qCWarning(lcSailfishCryptoSerialization) << "Cannot deserialize key, bad magic number:" << magic;
         if (ok) {
             *ok = false;
         }
@@ -54,7 +54,7 @@ Key::deserialise(const QByteArray &data, bool *ok)
     qint32 version;
     in >> version;
     if (version != 100) {
-        qCWarning(lcSailfishCryptoSerialisation) << "Cannot deserialise key, bad version number:" << version;
+        qCWarning(lcSailfishCryptoSerialization) << "Cannot deserialize key, bad version number:" << version;
         if (ok) {
             *ok = false;
         }
@@ -109,7 +109,7 @@ Key::deserialise(const QByteArray &data, bool *ok)
 }
 
 QByteArray
-Key::serialise(const Key &key, Key::SerialisationMode serialisationMode)
+Key::serialize(const Key &key, Key::SerializationMode serializationMode)
 {
     QByteArray byteArray;
     QBuffer buffer(&byteArray);
@@ -124,7 +124,7 @@ Key::serialise(const Key &key, Key::SerialisationMode serialisationMode)
     // Set the output format version
     out.setVersion(QDataStream::Qt_5_6);
 
-    if (serialisationMode == Key::LosslessSerialisationMode) {
+    if (serializationMode == Key::LosslessSerializationMode) {
         out << key.identifier().name();
         out << key.identifier().collectionName();
         out << key.identifier().storagePluginName();
@@ -146,7 +146,7 @@ Key::serialise(const Key &key, Key::SerialisationMode serialisationMode)
 
     out << key.customParameters();
 
-    if (serialisationMode == Key::LosslessSerialisationMode) {
+    if (serializationMode == Key::LosslessSerializationMode) {
         out << key.filterData();
     } else {
         out << Key::FilterData();
@@ -280,7 +280,7 @@ QDataStream& operator<<(QDataStream& out, const CryptoManager::Operations &v)
 QDBusArgument &operator<<(QDBusArgument &argument, const Key &key)
 {
     argument.beginStructure();
-    argument << Key::serialise(key);
+    argument << Key::serialize(key);
     argument.endStructure();
     return argument;
 }
@@ -291,7 +291,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, Key &key)
     argument.beginStructure();
     argument >> keydata;
     argument.endStructure();
-    key = Key::deserialise(keydata);
+    key = Key::deserialize(keydata);
     return argument;
 }
 

--- a/lib/Crypto/serialization_p.h
+++ b/lib/Crypto/serialization_p.h
@@ -5,8 +5,8 @@
  * BSD 3-Clause License, see LICENSE.
  */
 
-#ifndef LIBSAILFISHCRYPTO_SERIALISATION_H
-#define LIBSAILFISHCRYPTO_SERIALISATION_H
+#ifndef LIBSAILFISHCRYPTO_SERIALIZATION_H
+#define LIBSAILFISHCRYPTO_SERIALIZATION_H
 
 // WARNING!
 //
@@ -102,4 +102,4 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto:
 
 } // Sailfish
 
-#endif // LIBSAILFISHCRYPTO_SERIALISATION_H
+#endif // LIBSAILFISHCRYPTO_SERIALIZATION_H

--- a/lib/Crypto/signrequest.cpp
+++ b/lib/Crypto/signrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/storedkeyidentifiersrequest.cpp
+++ b/lib/Crypto/storedkeyidentifiersrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/storedkeyrequest.cpp
+++ b/lib/Crypto/storedkeyrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Crypto/verifyrequest.cpp
+++ b/lib/Crypto/verifyrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/CryptoPluginApi/extensionplugins.h
+++ b/lib/CryptoPluginApi/extensionplugins.h
@@ -182,7 +182,7 @@ public:
             quint32 cipherSessionToken,
             QByteArray *generatedData) = 0;
 
-    virtual Sailfish::Crypto::Result finaliseCipherSession(
+    virtual Sailfish::Crypto::Result finalizeCipherSession(
             quint64 clientId,
             const QByteArray &data,
             const QVariantMap &customParameters,

--- a/lib/Secrets/Secrets.pro
+++ b/lib/Secrets/Secrets.pro
@@ -36,7 +36,7 @@ PUBLIC_HEADERS += \
 
 INTERNAL_PUBLIC_HEADERS += \
     $$PWD/secretsdaemonconnection_p.h \
-    $$PWD/serialisation_p.h
+    $$PWD/serialization_p.h
 
 PRIVATE_HEADERS += \
     $$PWD/collectionnamesrequest_p.h \
@@ -79,7 +79,7 @@ SOURCES += \
     $$PWD/secret.cpp \
     $$PWD/secretsdaemonconnection.cpp \
     $$PWD/secretmanager.cpp \
-    $$PWD/serialisation.cpp \
+    $$PWD/serialization.cpp \
     $$PWD/storedsecretrequest.cpp \
     $$PWD/storesecretrequest.cpp \
     $$PWD/interactionrequestwatcher.cpp \

--- a/lib/Secrets/collectionnamesrequest.cpp
+++ b/lib/Secrets/collectionnamesrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Secrets/createcollectionrequest.cpp
+++ b/lib/Secrets/createcollectionrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Secrets/deletecollectionrequest.cpp
+++ b/lib/Secrets/deletecollectionrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Secrets/deletesecretrequest.cpp
+++ b/lib/Secrets/deletesecretrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Secrets/findsecretsrequest.cpp
+++ b/lib/Secrets/findsecretsrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Secrets/interactionrequest.cpp
+++ b/lib/Secrets/interactionrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Secrets/interactionrequestwatcher.cpp
+++ b/lib/Secrets/interactionrequestwatcher.cpp
@@ -8,7 +8,7 @@
 #include "Secrets/interactionrequestwatcher.h"
 #include "Secrets/interactionparameters.h"
 #include "Secrets/interactionresponse.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusServer>
 #include <QtDBus/QDBusConnection>

--- a/lib/Secrets/lockcoderequest.cpp
+++ b/lib/Secrets/lockcoderequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Secrets/plugininforequest.cpp
+++ b/lib/Secrets/plugininforequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Secrets/result.h
+++ b/lib/Secrets/result.h
@@ -37,7 +37,7 @@ public:
     enum ErrorCode {
         NoError = 0,
         UnknownError = 2,
-        SerialisationError = 3,
+        SerializationError = 3,
 
         PermissionsError = 10,
         IncorrectAuthenticationCodeError,

--- a/lib/Secrets/secretmanager.cpp
+++ b/lib/Secrets/secretmanager.cpp
@@ -7,7 +7,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 #include "Secrets/secret.h"
 #include "Secrets/plugininfo.h"
 

--- a/lib/Secrets/secretsdaemonconnection.cpp
+++ b/lib/Secrets/secretsdaemonconnection.cpp
@@ -7,7 +7,7 @@
 
 #include "Secrets/secretsdaemonconnection_p.h"
 #include "Secrets/secretsdaemonconnection_p_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/interactionparameters.h"

--- a/lib/Secrets/serialization.cpp
+++ b/lib/Secrets/serialization.cpp
@@ -5,7 +5,7 @@
  * BSD 3-Clause License, see LICENSE.
  */
 
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 #include "Secrets/secretmanager.h"
 #include "Secrets/secret.h"
 #include "Secrets/result.h"
@@ -17,7 +17,7 @@
 #include <QtCore/QString>
 #include <QtCore/QLoggingCategory>
 
-Q_LOGGING_CATEGORY(lcSailfishSecretsSerialisation, "org.sailfishos.secrets.serialisation", QtWarningMsg)
+Q_LOGGING_CATEGORY(lcSailfishSecretsSerialization, "org.sailfishos.secrets.serialization", QtWarningMsg)
 
 namespace Sailfish {
 

--- a/lib/Secrets/serialization_p.h
+++ b/lib/Secrets/serialization_p.h
@@ -5,8 +5,8 @@
  * BSD 3-Clause License, see LICENSE.
  */
 
-#ifndef LIBSAILFISHSECRETS_SERIALISATION_H
-#define LIBSAILFISHSECRETS_SERIALISATION_H
+#ifndef LIBSAILFISHSECRETS_SERIALIZATION_H
+#define LIBSAILFISHSECRETS_SERIALIZATION_H
 
 // WARNING!
 //
@@ -71,4 +71,4 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Secrets
 
 } // namespace Sailfish
 
-#endif // LIBSAILFISHSECRETS_SERIALISATION_H
+#endif // LIBSAILFISHSECRETS_SERIALIZATION_H

--- a/lib/Secrets/storedsecretrequest.cpp
+++ b/lib/Secrets/storedsecretrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/lib/Secrets/storesecretrequest.cpp
+++ b/lib/Secrets/storesecretrequest.cpp
@@ -10,7 +10,7 @@
 
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 #include <QtDBus/QDBusPendingReply>
 #include <QtDBus/QDBusPendingCallWatcher>

--- a/plugins/exampleusbtokenplugin/cryptoplugin.cpp
+++ b/plugins/exampleusbtokenplugin/cryptoplugin.cpp
@@ -395,7 +395,7 @@ ExampleUsbTokenPlugin::updateCipherSession(
 }
 
 Result
-ExampleUsbTokenPlugin::finaliseCipherSession(
+ExampleUsbTokenPlugin::finalizeCipherSession(
         quint64 clientId,
         const QByteArray &data,
         const QVariantMap &customParameters,
@@ -403,7 +403,7 @@ ExampleUsbTokenPlugin::finaliseCipherSession(
         QByteArray *generatedData,
         bool *verified)
 {
-    return m_usbInterface.finaliseCipherSession(
+    return m_usbInterface.finalizeCipherSession(
                 clientId,
                 data,
                 customParameters,

--- a/plugins/exampleusbtokenplugin/encryptedstorageplugin.cpp
+++ b/plugins/exampleusbtokenplugin/encryptedstorageplugin.cpp
@@ -127,7 +127,7 @@ ExampleUsbTokenPlugin::getSecret(
                       QStringLiteral("Unable to read stored key for getSecret"));
     }
 
-    *secret = Sailfish::Crypto::Key::serialise(key);
+    *secret = Sailfish::Crypto::Key::serialize(key);
     QMap<QString,QString> fd = key.filterData();
     *filterData = fd;
     return Result(Result::Succeeded);

--- a/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
+++ b/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
@@ -243,7 +243,7 @@ public:
             quint32 cipherSessionToken,
             QByteArray *generatedData) Q_DECL_OVERRIDE;
 
-    Sailfish::Crypto::Result finaliseCipherSession(
+    Sailfish::Crypto::Result finalizeCipherSession(
             quint64 clientId,
             const QByteArray &data,
             const QVariantMap &customParameters,

--- a/plugins/opensslcryptoplugin/evp/evp.cpp
+++ b/plugins/opensslcryptoplugin/evp/evp.cpp
@@ -739,13 +739,13 @@ int OpenSslEvp::sign(const EVP_MD *digestFunc,
     OSSLEVP_HANDLE_ERR(r != 1, r = -1, "failed to update DigestSign", err_free_mdctx);
 
     r = EVP_DigestSignFinal(mdctx, NULL, signatureLength);
-    OSSLEVP_HANDLE_ERR(r != 1, r = -1, "failed to finalise DigestSign (1st call)", err_free_mdctx);
+    OSSLEVP_HANDLE_ERR(r != 1, r = -1, "failed to finalize DigestSign (1st call)", err_free_mdctx);
 
     *signature = (uint8_t *) OPENSSL_malloc(*signatureLength);
     OSSLEVP_HANDLE_ERR(*signature == NULL, r = -1, "failed to allocate memory for signature", err_free_mdctx);
 
     r = EVP_DigestSignFinal(mdctx, *signature, signatureLength);
-    OSSLEVP_HANDLE_ERR(r != 1, r = -1; OPENSSL_free(*signature), "failed to finalise DigestSign (2nd call)", err_free_mdctx);
+    OSSLEVP_HANDLE_ERR(r != 1, r = -1; OPENSSL_free(*signature), "failed to finalize DigestSign (2nd call)", err_free_mdctx);
 
     err_free_mdctx:
     EVP_MD_CTX_destroy(mdctx);

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.h
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.h
@@ -188,7 +188,7 @@ public:
             quint32 cipherSessionToken,
             QByteArray *generatedData) Q_DECL_OVERRIDE;
 
-    Sailfish::Crypto::Result finaliseCipherSession(
+    Sailfish::Crypto::Result finalizeCipherSession(
             quint64 clientId,
             const QByteArray &data,
             const QVariantMap &customParameters,

--- a/plugins/sqlcipherplugin/cryptoplugin.cpp
+++ b/plugins/sqlcipherplugin/cryptoplugin.cpp
@@ -103,7 +103,7 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::generateAndStoreKey(
     Sailfish::Secrets::Result storeResult = setSecret(
                 fullKey.identifier().collectionName(),
                 fullKey.identifier().name(),
-                Sailfish::Crypto::Key::serialise(fullKey, Sailfish::Crypto::Key::LossySerialisationMode),
+                Sailfish::Crypto::Key::serialize(fullKey, Sailfish::Crypto::Key::LossySerializationMode),
                 filterData);
     if (storeResult.code() == Sailfish::Secrets::Result::Failed) {
         retn.setCode(Sailfish::Crypto::Result::Failed);
@@ -150,7 +150,7 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::importAndStoreKey(
     Sailfish::Secrets::Result storeResult = setSecret(
                 importedKey.identifier().collectionName(),
                 importedKey.identifier().name(),
-                Sailfish::Crypto::Key::serialise(importedKey, Sailfish::Crypto::Key::LossySerialisationMode),
+                Sailfish::Crypto::Key::serialize(importedKey, Sailfish::Crypto::Key::LossySerializationMode),
                 filterData);
     if (storeResult.code() == Sailfish::Secrets::Result::Failed) {
         retn.setCode(Sailfish::Crypto::Result::Failed);
@@ -198,10 +198,10 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::storedKey_internal(
     QMap<QString, QString> filterData = sfd;
 
     bool ok = true;
-    Sailfish::Crypto::Key fullKey = Sailfish::Crypto::Key::deserialise(secret, &ok);
+    Sailfish::Crypto::Key fullKey = Sailfish::Crypto::Key::deserialize(secret, &ok);
     if (!ok) {
-        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::SerialisationError,
-                                        QLatin1String("Unable to deserialise key from secret blob"));
+        return Sailfish::Crypto::Result(Sailfish::Crypto::Result::SerializationError,
+                                        QLatin1String("Unable to deserialize key from secret blob"));
     }
 
     fullKey.setIdentifier(Sailfish::Crypto::Key::Identifier(
@@ -475,7 +475,7 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::updateCipherSession(
 }
 
 Sailfish::Crypto::Result
-Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::finaliseCipherSession(
+Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::finalizeCipherSession(
         quint64 clientId,
         const QByteArray &data,
         const QVariantMap &customParameters,
@@ -483,7 +483,7 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::finaliseCipherSession(
         QByteArray *generatedData,
         bool *verified)
 {
-    return m_opensslCryptoPlugin.finaliseCipherSession(clientId,
+    return m_opensslCryptoPlugin.finalizeCipherSession(clientId,
                                                        data,
                                                        customParameters,
                                                        cipherSessionToken,

--- a/plugins/sqlcipherplugin/sqlcipherplugin.h
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.h
@@ -237,7 +237,7 @@ public:
             quint32 cipherSessionToken,
             QByteArray *generatedData) Q_DECL_OVERRIDE;
 
-    Sailfish::Crypto::Result finaliseCipherSession(
+    Sailfish::Crypto::Result finalizeCipherSession(
             quint64 clientId,
             const QByteArray &data,
             const QVariantMap &customParameters,

--- a/tests/Crypto/tst_crypto/tst_crypto.cpp
+++ b/tests/Crypto/tst_crypto/tst_crypto.cpp
@@ -12,7 +12,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 #include "Crypto/key.h"
 #include "Crypto/keyderivationparameters.h"
 #include "Crypto/result.h"

--- a/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
+++ b/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
@@ -1689,14 +1689,14 @@ void tst_cryptorequests::cipherEncryptDecrypt()
         QByteArray ciphertextChunk = er.generatedData();
         if (chunk.size() >= 16) {
             QVERIFY(ciphertextChunk.size() >= chunk.size());
-            // otherwise, it will be emitted during FinaliseCipher
+            // otherwise, it will be emitted during FinalizeCipher
         }
         ciphertext.append(ciphertextChunk);
         QVERIFY(!ciphertext.isEmpty());
     }
 
-    er.setCipherMode(CipherRequest::FinaliseCipher);
-    QCOMPARE(er.cipherMode(), CipherRequest::FinaliseCipher);
+    er.setCipherMode(CipherRequest::FinalizeCipher);
+    QCOMPARE(er.cipherMode(), CipherRequest::FinalizeCipher);
     er.setData(QByteArray());
     ssCount = erss.count();
     er.startRequest();
@@ -1787,8 +1787,8 @@ void tst_cryptorequests::cipherEncryptDecrypt()
         }
     }
 
-    dr.setCipherMode(CipherRequest::FinaliseCipher);
-    QCOMPARE(dr.cipherMode(), CipherRequest::FinaliseCipher);
+    dr.setCipherMode(CipherRequest::FinalizeCipher);
+    QCOMPARE(dr.cipherMode(), CipherRequest::FinalizeCipher);
     dr.setData(blockMode == CryptoManager::BlockModeGcm ? authenticationTag : QByteArray());
     ssCount = drss.count();
     dr.startRequest();
@@ -1943,7 +1943,7 @@ void tst_cryptorequests::cipherBenchmark()
             ciphertext.append(ciphertextChunk);
         }
 
-        er.setCipherMode(CipherRequest::FinaliseCipher);
+        er.setCipherMode(CipherRequest::FinalizeCipher);
         er.setData(QByteArray());
         er.startRequest();
         SHORT_WAIT_FOR_FINISHED_WITHOUT_BLOCKING(er);
@@ -1977,7 +1977,7 @@ void tst_cryptorequests::cipherBenchmark()
             decrypted.append(plaintextChunk);
         }
 
-        dr.setCipherMode(CipherRequest::FinaliseCipher);
+        dr.setCipherMode(CipherRequest::FinalizeCipher);
         dr.setData(QByteArray());
         dr.startRequest();
         SHORT_WAIT_FOR_FINISHED_WITHOUT_BLOCKING(dr);
@@ -2037,7 +2037,7 @@ void tst_cryptorequests::cipherBenchmark()
         }
         LONG_WAIT_FOR_FINISHED_WITHOUT_BLOCKING(er); // wait for the updates to finish.
 
-        er.setCipherMode(CipherRequest::FinaliseCipher);
+        er.setCipherMode(CipherRequest::FinalizeCipher);
         er.setData(QByteArray());
         er.startRequest();
         LONG_WAIT_FOR_FINISHED_WITHOUT_BLOCKING(er);
@@ -2072,7 +2072,7 @@ void tst_cryptorequests::cipherBenchmark()
         }
         LONG_WAIT_FOR_FINISHED_WITHOUT_BLOCKING(dr); // drain the queue of responses.
 
-        dr.setCipherMode(CipherRequest::FinaliseCipher);
+        dr.setCipherMode(CipherRequest::FinalizeCipher);
         dr.setData(QByteArray());
         dr.startRequest();
         LONG_WAIT_FOR_FINISHED_WITHOUT_BLOCKING(dr);

--- a/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
+++ b/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
@@ -14,7 +14,7 @@
 
 #include "Crypto/cryptomanager.h"
 #include "Crypto/cryptomanager_p.h"
-#include "Crypto/serialisation_p.h"
+#include "Crypto/serialization_p.h"
 #include "Crypto/key.h"
 #include "Crypto/keypairgenerationparameters.h"
 #include "Crypto/keyderivationparameters.h"
@@ -24,7 +24,7 @@
 #include "Secrets/result.h"
 #include "Secrets/secretmanager.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 // Cannot use waitForFinished() for some replies, as ui flows require user interaction / event handling.
 #define WAIT_FOR_FINISHED_WITHOUT_BLOCKING(dbusreply)       \

--- a/tests/Secrets/tst_secrets/tst_secrets.cpp
+++ b/tests/Secrets/tst_secrets/tst_secrets.cpp
@@ -14,7 +14,7 @@
 #include "Secrets/secretmanager.h"
 #include "Secrets/secret.h"
 #include "Secrets/secretmanager_p.h"
-#include "Secrets/serialisation_p.h"
+#include "Secrets/serialization_p.h"
 
 using namespace Sailfish::Secrets;
 


### PR DESCRIPTION
More changes to prefer US spelling to UK, as per conventions:
finalise -> finalize
serialise -> serialize
synchronise -> synchronize
minimise -> minimize


This also involves file renaming for serialise.* -> serialize.*