### PR TITLE
[sailfish-secrets] Add displayName() to PluginBase API. Contributes to JB#36797

### DIFF
--- a/daemon/CryptoImpl/cryptorequestprocessor.cpp
+++ b/daemon/CryptoImpl/cryptorequestprocessor.cpp
@@ -459,7 +459,7 @@ Daemon::ApiImpl::RequestProcessor::generateStoredKey_afterPreCheck(
             promptParams.setPromptText(qtTrId("sailfish_crypto-generate_stored_key-la-enter_key_passphrase")
                                        .arg(keyTemplate.identifier().name(),
                                             keyTemplate.identifier().collectionName(),
-                                            keyTemplate.identifier().storagePluginName()));
+                                            m_requestQueue->controller()->displayNameForPlugin(keyTemplate.identifier().storagePluginName())));
             promptParams.setInputType(static_cast<Sailfish::Secrets::InteractionParameters::InputType>(uiParams.inputType()));
             promptParams.setEchoMode(static_cast<Sailfish::Secrets::InteractionParameters::EchoMode>(uiParams.echoMode()));
             result = transformSecretsResult(m_secrets->userInput(
@@ -671,7 +671,7 @@ Result Daemon::ApiImpl::RequestProcessor::promptForKeyPassphrase(
     promptParams.setPromptText(qtTrId("sailfish_crypto-import_key-la-enter_import_passphrase")
                                .arg(key.identifier().name(),
                                     key.identifier().collectionName(),
-                                    key.identifier().storagePluginName()));
+                                    m_requestQueue->controller()->displayNameForPlugin(key.identifier().storagePluginName())));
     promptParams.setInputType(static_cast<Sailfish::Secrets::InteractionParameters::InputType>(uiParams.inputType()));
     promptParams.setEchoMode(static_cast<Sailfish::Secrets::InteractionParameters::EchoMode>(uiParams.echoMode()));
 

--- a/daemon/SecretsImpl/pluginwrapper.cpp
+++ b/daemon/SecretsImpl/pluginwrapper.cpp
@@ -29,6 +29,11 @@ bool PluginWrapper::isInitialized() const
     return m_initialized;
 }
 
+QString PluginWrapper::displayName() const
+{
+    return m_plugin->displayName();
+}
+
 QString PluginWrapper::name() const
 {
     return m_plugin->name();

--- a/daemon/SecretsImpl/pluginwrapper_p.h
+++ b/daemon/SecretsImpl/pluginwrapper_p.h
@@ -46,6 +46,7 @@ public:
     virtual Sailfish::Secrets::Result collectionNames(QStringList *names) const = 0;
     virtual Sailfish::Secrets::Result secretNames(const QString &collectionName, QStringList *secretNames) const = 0;
 
+    QString displayName() const Q_DECL_OVERRIDE;
     QString name() const Q_DECL_OVERRIDE;
     int version() const Q_DECL_OVERRIDE;
 

--- a/daemon/SecretsImpl/secrets.cpp
+++ b/daemon/SecretsImpl/secrets.cpp
@@ -440,6 +440,11 @@ Daemon::ApiImpl::SecretsRequestQueue::~SecretsRequestQueue()
     free(m_bkdbLockKeyData);
 }
 
+Sailfish::Secrets::Daemon::Controller *Daemon::ApiImpl::SecretsRequestQueue::controller()
+{
+    return m_controller;
+}
+
 QWeakPointer<QThreadPool> Daemon::ApiImpl::SecretsRequestQueue::secretsThreadPool()
 {
     return m_secretsThreadPool.toWeakRef();

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -400,6 +400,7 @@ public:
     SecretsRequestQueue(Sailfish::Secrets::Daemon::Controller *parent, bool autotestMode);
     ~SecretsRequestQueue();
 
+    Sailfish::Secrets::Daemon::Controller *controller();
     QWeakPointer<QThreadPool> secretsThreadPool();
     bool initialize(const QByteArray &lockCode, InitializationMode mode);
     bool initializePlugins();
@@ -413,6 +414,7 @@ public: // helpers for crypto API: secretscryptohelpers.cpp
     Sailfish::Crypto::Daemon::ApiImpl::CryptoStoragePluginWrapper *cryptoStoragePluginWrapper(const QString &pluginName) const;
     QStringList encryptedStoragePluginNames() const;
     QStringList storagePluginNames() const;
+    QString displayNameForStoragePlugin(const QString &name) const;
     Sailfish::Secrets::Result storedKeyIdentifiers(const QString &storagePluginName, QVector<Secret::Identifier> *idents) const;
 
 private:

--- a/daemon/SecretsImpl/secretscryptohelpers.cpp
+++ b/daemon/SecretsImpl/secretscryptohelpers.cpp
@@ -29,6 +29,12 @@ using namespace Sailfish::Secrets;
 // The methods in this file exist to help fulfil Sailfish Crypto API requests,
 // while allowing the use of a single (secrets) database for atomicity reasons.
 
+QString
+Daemon::ApiImpl::SecretsRequestQueue::displayNameForStoragePlugin(const QString &name) const
+{
+    return m_requestProcessor->displayNameForStoragePlugin(name);
+}
+
 QStringList
 Daemon::ApiImpl::SecretsRequestQueue::storagePluginNames() const
 {
@@ -71,6 +77,17 @@ Daemon::ApiImpl::SecretsRequestQueue::storedKeyIdentifiers(const QString &storag
 {
     // TODO: make this asynchronous, emit a signal when complete.
     return m_requestProcessor->storedKeyIdentifiers(storagePluginName, idents);
+}
+
+QString
+Daemon::ApiImpl::RequestProcessor::displayNameForStoragePlugin(const QString &name) const
+{
+    if (m_storagePlugins.contains(name)) {
+        return m_storagePlugins.value(name)->displayName();
+    } else if (m_encryptedStoragePlugins.contains(name)) {
+        return m_encryptedStoragePlugins.value(name)->displayName();
+    }
+    return QString();
 }
 
 QStringList

--- a/daemon/SecretsImpl/secretsrequestprocessor.cpp
+++ b/daemon/SecretsImpl/secretsrequestprocessor.cpp
@@ -346,7 +346,7 @@ Daemon::ApiImpl::RequestProcessor::createCustomLockCollection(
     //: This will be displayed to the user, prompting them to enter a passphrase which will be used to encrypt a collection. %1 is the application name, %2 is the collection name, %3 is the plugin name.
     //% "App %1 wants to create a new secrets collection %2 in plugin %3. Enter the passphrase which will be used to encrypt the collection."
     promptParams.setPromptText(qtTrId("sailfish_secrets-create_customlock_collection-la-enter_new_collection_passphrase")
-                             .arg(callerApplicationId, collectionName, storagePluginName));
+                             .arg(callerApplicationId, collectionName, m_requestQueue->controller()->displayNameForPlugin(storagePluginName)));
     Result interactionResult = m_authenticationPlugins[authenticationPluginName]->beginUserInputInteraction(
                 callerPid,
                 requestId,
@@ -653,7 +653,7 @@ Daemon::ApiImpl::RequestProcessor::deleteCollectionWithMetadata(
         //: This will be displayed to the user, prompting them to enter a passphrase which will be used to unlock a collection for deletion. %1 is the application name, %2 is the collection name, %3 is the plugin name.
         //% "App %1 wants to delete collection %2 in plugin %3. Enter the passphrase which will be used to unlock the collection for deletion."
         promptParams.setPromptText(qtTrId("sailfish_secrets-delete_collection-la-enter_collection_passphrase")
-                                 .arg(callerApplicationId, collectionName, storagePluginName));
+                                 .arg(callerApplicationId, collectionName, m_requestQueue->controller()->displayNameForPlugin(storagePluginName)));
         Result result = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                     callerPid,
                     requestId,
@@ -938,7 +938,7 @@ Daemon::ApiImpl::RequestProcessor::setCollectionSecretWithMetadata(
                                    .arg(callerApplicationId,
                                         secret.identifier().name(),
                                         secret.identifier().collectionName(),
-                                        secret.identifier().storagePluginName()));
+                                        m_requestQueue->controller()->displayNameForPlugin(secret.identifier().storagePluginName())));
     Result authenticationResult = m_authenticationPlugins[userInputPlugin]->beginUserInputInteraction(
                 callerPid,
                 requestId,
@@ -1033,7 +1033,7 @@ Daemon::ApiImpl::RequestProcessor::setCollectionSecretGetAuthenticationCode(
                                  .arg(callerApplicationId,
                                       secret.identifier().name(),
                                       secret.identifier().collectionName(),
-                                      secret.identifier().storagePluginName()));
+                                      m_requestQueue->controller()->displayNameForPlugin(secret.identifier().storagePluginName())));
         Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                     callerPid,
                     requestId,
@@ -1100,7 +1100,7 @@ Daemon::ApiImpl::RequestProcessor::setCollectionSecretGetAuthenticationCode(
                              .arg(callerApplicationId,
                                   secret.identifier().name(),
                                   secret.identifier().collectionName(),
-                                  secret.identifier().storagePluginName()));
+                                  m_requestQueue->controller()->displayNameForPlugin(secret.identifier().storagePluginName())));
     Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                 callerPid,
                 requestId,
@@ -1423,7 +1423,7 @@ Daemon::ApiImpl::RequestProcessor::setStandaloneDeviceLockSecretWithMetadata(
     modifiedUiParams.setPromptText(qtTrId("sailfish_secrets-set_standalone_secret-la-enter_secret_data")
                                    .arg(newMetadata.ownerApplicationId,
                                         secret.identifier().name(),
-                                        secret.identifier().storagePluginName()));
+                                        m_requestQueue->controller()->displayNameForPlugin(secret.identifier().storagePluginName())));
     Result authenticationResult = m_authenticationPlugins[userInputPlugin]->beginUserInputInteraction(
                 callerPid,
                 requestId,
@@ -1651,7 +1651,7 @@ Daemon::ApiImpl::RequestProcessor::setStandaloneCustomLockSecretWithMetadata(
     modifiedUiParams.setPromptText(qtTrId("sailfish_secrets-set_standalone_secret-la-enter_secret_data")
                                    .arg(newMetadata.ownerApplicationId,
                                         secret.identifier().name(),
-                                        secret.identifier().storagePluginName()));
+                                        m_requestQueue->controller()->displayNameForPlugin(secret.identifier().storagePluginName())));
     Result authenticationResult = m_authenticationPlugins[userInputPlugin]->beginUserInputInteraction(
                 callerPid,
                 requestId,
@@ -1697,7 +1697,7 @@ Daemon::ApiImpl::RequestProcessor::setStandaloneCustomLockSecretGetAuthenticatio
     promptParams.setPromptText(qtTrId("sailfish_secrets-set_standalone_secret-la-enter_secret_passphrase")
                                .arg(secretMetadata.ownerApplicationId,
                                     secret.identifier().name(),
-                                    secret.identifier().storagePluginName()));
+                                    m_requestQueue->controller()->displayNameForPlugin(secret.identifier().storagePluginName())));
     Q_UNUSED(userInteractionMode); // TODO: ensure the auth plugin uses the appropriate mode?
     Result interactionResult = m_authenticationPlugins[secretMetadata.authenticationPluginName]->beginUserInputInteraction(
                 callerPid,
@@ -1973,7 +1973,7 @@ Daemon::ApiImpl::RequestProcessor::getCollectionSecretWithMetadata(
                                          .arg(callerApplicationId,
                                               identifier.name(),
                                               identifier.collectionName(),
-                                              identifier.storagePluginName()));
+                                              m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName())));
                 Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                             callerPid,
                             requestId,
@@ -2047,7 +2047,7 @@ Daemon::ApiImpl::RequestProcessor::getCollectionSecretWithMetadata(
                                          .arg(callerApplicationId,
                                               identifier.name(),
                                               identifier.collectionName(),
-                                              identifier.storagePluginName()));
+                                              m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName())));
                 Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                             callerPid,
                             requestId,
@@ -2334,7 +2334,7 @@ Daemon::ApiImpl::RequestProcessor::getStandaloneSecretWithMetadata(
                              .arg(callerApplicationId,
                                   identifier.name(),
                                   identifier.collectionName(),
-                                  identifier.storagePluginName()));
+                                  m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName())));
     Result interactionResult = m_authenticationPlugins[secretMetadata.authenticationPluginName]->beginUserInputInteraction(
                 callerPid,
                 requestId,
@@ -2655,7 +2655,7 @@ Daemon::ApiImpl::RequestProcessor::findCollectionSecretsWithMetadata(
                 promptParams.setPromptText(qtTrId("sailfish_secrets-find_collection_secrets-la-enter_collection_passphrase")
                                          .arg(callerApplicationId,
                                               collectionName,
-                                              storagePluginName));
+                                              m_requestQueue->controller()->displayNameForPlugin(storagePluginName)));
                 Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                             callerPid,
                             requestId,
@@ -2735,7 +2735,7 @@ Daemon::ApiImpl::RequestProcessor::findCollectionSecretsWithMetadata(
                 promptParams.setPromptText(qtTrId("sailfish_secrets-find_collection_secrets-la-enter_collection_passphrase")
                                          .arg(callerApplicationId,
                                               collectionName,
-                                              storagePluginName));
+                                              m_requestQueue->controller()->displayNameForPlugin(storagePluginName)));
                 Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                             callerPid,
                             requestId,
@@ -3074,7 +3074,7 @@ Daemon::ApiImpl::RequestProcessor::deleteCollectionSecretWithMetadata(
                                      .arg(callerApplicationId,
                                           identifier.name(),
                                           identifier.collectionName(),
-                                          identifier.storagePluginName()));
+                                          m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName())));
             Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                         callerPid,
                         requestId,
@@ -3140,7 +3140,7 @@ Daemon::ApiImpl::RequestProcessor::deleteCollectionSecretWithMetadata(
                                          .arg(callerApplicationId,
                                               identifier.name(),
                                               identifier.collectionName(),
-                                              identifier.storagePluginName()));
+                                              m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName())));
                 Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                             callerPid,
                             requestId,
@@ -3471,7 +3471,7 @@ Daemon::ApiImpl::RequestProcessor::modifyLockCode(
     //: This will be displayed to the user, prompting them to enter the old passphrase to unlock the extension plugin in order to change its lock code. %1 is the application name, %2 is the plugin name.
     //% "App %1 wants to change the lock code for plugin %2. Enter the old passphrase to unlock the plugin."
     const QString modifyPluginLockOldPrompt = qtTrId("sailfish_secrets-modify_lock_code-la-enter_old_plugin_passphrase")
-                                                .arg(callerApplicationId, lockCodeTarget);
+                                                .arg(callerApplicationId, m_requestQueue->controller()->displayNameForPlugin(lockCodeTarget));
     //: This will be displayed to the user, prompting them to enter the old passphrase to unlock the secrets service in order to change the master lock code. %1 is the application name.
     //% "App %1 wants to change the secrets service master lock code. Enter the old master passphrase."
     const QString modifyMasterLockOldPrompt = qtTrId("sailfish_secrets-modify_lock_code-la-enter_old_master_passphrase")
@@ -3541,7 +3541,7 @@ Daemon::ApiImpl::RequestProcessor::modifyLockCodeWithLockCode(
     //: This will be displayed to the user, prompting them to enter the new passphrase for the plugin. %1 is the application name, %2 is the plugin name.
     //% "App %1 wants to change the lock code for plugin %2. Enter the new passphrase for the plugin."
     const QString modifyPluginLockNewPrompt = qtTrId("sailfish_secrets-modify_lock_code-la-enter_new_plugin_passphrase")
-                                                .arg(callerApplicationId, lockCodeTarget);
+                                                .arg(callerApplicationId, m_requestQueue->controller()->displayNameForPlugin(lockCodeTarget));
     //: This will be displayed to the user, prompting them to enter the new master lock code for the secrets service. %1 is the application name.
     //% "App %1 wants to change the secrets service master lock code. Enter the new master passphrase."
     const QString modifyMasterLockNewPrompt = qtTrId("sailfish_secrets-modify_lock_code-la-enter_new_master_passphrase")
@@ -3797,7 +3797,7 @@ Daemon::ApiImpl::RequestProcessor::provideLockCode(
     //: This will be displayed to the user, prompting them to enter the passphrase to unlock the extension plugin. %1 is the application name, %2 is the plugin name.
     //% "App %1 wants to use plugin %2. Enter the passphrase to unlock the plugin."
     const QString providePluginLockPrompt = qtTrId("sailfish_secrets-provide_lock_code-la-enter_plugin_passphrase")
-                                              .arg(callerApplicationId, lockCodeTarget);
+                                              .arg(callerApplicationId, m_requestQueue->controller()->displayNameForPlugin(lockCodeTarget));
     //: This will be displayed to the user, prompting them to enter the passphrase to unlock the secrets service. %1 is the application name.
     //% "App %1 wants to use the secrets service. Enter the master passphrase to unlock the secrets service."
     const QString provideMasterLockPrompt = qtTrId("sailfish_secrets-provide_lock_code-la-enter_master_passphrase")
@@ -4170,7 +4170,7 @@ Daemon::ApiImpl::RequestProcessor::setCollectionKeyPreCheckWithMetadata(
                                    .arg(callerApplicationId,
                                         identifier.name(),
                                         identifier.collectionName(),
-                                        identifier.storagePluginName()));
+                                        m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName())));
         Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                     callerPid,
                     requestId,
@@ -4235,7 +4235,7 @@ Daemon::ApiImpl::RequestProcessor::setCollectionKeyPreCheckWithMetadata(
                                .arg(callerApplicationId,
                                     identifier.name(),
                                     identifier.collectionName(),
-                                    identifier.storagePluginName()));
+                                    m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName())));
     Result interactionResult = m_authenticationPlugins[collectionMetadata.authenticationPluginName]->beginUserInputInteraction(
                 callerPid,
                 requestId,

--- a/daemon/SecretsImpl/secretsrequestprocessor_p.h
+++ b/daemon/SecretsImpl/secretsrequestprocessor_p.h
@@ -254,6 +254,7 @@ public: // helper methods for crypto API bridge (secretscryptohelpers)
     Sailfish::Crypto::Daemon::ApiImpl::CryptoStoragePluginWrapper *cryptoStoragePluginWrapper(const QString &pluginName) const;
     QStringList encryptedStoragePluginNames() const;
     QStringList storagePluginNames() const;
+    QString displayNameForStoragePlugin(const QString &name) const;
     QVector<Sailfish::Secrets::PluginInfo> storagePluginInfo() const;
     Sailfish::Secrets::Result storedKeyIdentifiers(const QString &storagePluginName, QVector<Secret::Identifier> *idents) const;
     Sailfish::Secrets::Result userInput(

--- a/daemon/controller.cpp
+++ b/daemon/controller.cpp
@@ -129,6 +129,15 @@ QWeakPointer<QThreadPool> Sailfish::Secrets::Daemon::Controller::threadPoolForPl
     }
 }
 
+QString Sailfish::Secrets::Daemon::Controller::displayNameForPlugin(const QString &pluginName) const
+{
+    if (m_crypto->plugins().contains(pluginName)) {
+        return m_crypto->plugins().value(pluginName)->displayName();
+    } else {
+        return m_secrets->displayNameForStoragePlugin(pluginName);
+    }
+}
+
 void Sailfish::Secrets::Daemon::Controller::handleClientConnection(const QDBusConnection &connection)
 {
     qCDebug(lcSailfishSecretsDaemon) << "New client p2p connection received!" << connection.name();

--- a/daemon/controller_p.h
+++ b/daemon/controller_p.h
@@ -52,6 +52,7 @@ public:
     Sailfish::Secrets::Daemon::ApiImpl::SecretsRequestQueue *secrets() const;
     Sailfish::Crypto::Daemon::ApiImpl::CryptoRequestQueue *crypto() const;
     QWeakPointer<QThreadPool> threadPoolForPlugin(const QString &pluginName) const;
+    QString displayNameForPlugin(const QString &pluginName) const;
 
 public Q_SLOTS:
     void handleClientConnection(const QDBusConnection &connection);

--- a/lib/SecretsPluginApi/extensionplugins.cpp
+++ b/lib/SecretsPluginApi/extensionplugins.cpp
@@ -60,13 +60,28 @@ using namespace Sailfish::Secrets;
  */
 
 /*!
+ * \fn PluginBase::displayName() const
+ * \brief Return the translated display name of the plugin
+ *
+ * This name will be shown to the user of the device in system prompts when
+ * an attempt is made to access a secret or key stored within the plugin.
+ * It should be a human-readable string, which is informative for the user,
+ * and may need to be translated into different languages if the display
+ * name is not a proper noun.
+ *
+ * For example, the example encrypted storage plugin based on SQLCipher
+ * has the display name "SQLCipher".
+ */
+
+/*!
  * \fn PluginBase::name() const
  * \brief Return the name of the plugin
  *
  * This name must be globally unique, so a fully-qualified-domain-name
- * prefix is recommended.  For example, the example encrypted storage
- * plugin based on SQLCipher has the name:
- * "org.sailfishos.secrets.encryptedstorage.sqlcipher"
+ * prefix is recommended.
+ *
+ * For example, the example encrypted storage plugin based on SQLCipher
+ * has the name: "org.sailfishos.secrets.encryptedstorage.sqlcipher".
  */
 
 /*!

--- a/lib/SecretsPluginApi/extensionplugins.h
+++ b/lib/SecretsPluginApi/extensionplugins.h
@@ -35,6 +35,7 @@ public:
     PluginBase();
     virtual ~PluginBase();
 
+    virtual QString displayName() const = 0;
     virtual QString name() const = 0;
     virtual int version() const = 0;
     virtual bool supportsLocking() const;

--- a/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
+++ b/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
@@ -69,6 +69,11 @@ public:
     ExampleUsbTokenPlugin(QObject *parent = Q_NULLPTR);
     ~ExampleUsbTokenPlugin();
 
+    QString displayName() const Q_DECL_OVERRIDE {
+        //: The (human readable) display name of the Example USB Token plugin
+        //% "Example USB Token"
+        return qtTrId("example_usb_token-display_name");
+    }
     QString name() const Q_DECL_OVERRIDE {
 #ifdef SAILFISHSECRETS_TESTPLUGIN
         return QLatin1String("org.sailfishos.secrets.plugin.cryptostorage.exampleusbtoken.test");

--- a/plugins/inappauthplugin/plugin.h
+++ b/plugins/inappauthplugin/plugin.h
@@ -42,6 +42,11 @@ public:
     InAppPlugin(QObject *parent = Q_NULLPTR);
     ~InAppPlugin();
 
+    QString displayName() const Q_DECL_OVERRIDE {
+        //: The (human readable) display name of the in-app authentication plugin
+        //% "In-App Authenticator"
+        return qtTrId("in_app_auth-display_name");
+    }
     QString name() const Q_DECL_OVERRIDE {
 #ifdef SAILFISHSECRETS_TESTPLUGIN
         return QLatin1String("org.sailfishos.secrets.plugin.authentication.inapp.test");

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.h
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.h
@@ -46,6 +46,9 @@ public:
     OpenSslCryptoPlugin(QObject *parent = Q_NULLPTR);
     ~OpenSslCryptoPlugin();
 
+    QString displayName() const Q_DECL_OVERRIDE {
+        return QStringLiteral("OpenSSL Crypto");
+    }
     QString name() const Q_DECL_OVERRIDE {
 #ifdef SAILFISHCRYPTO_TESTPLUGIN
         return QLatin1String("org.sailfishos.crypto.plugin.crypto.openssl.test");

--- a/plugins/opensslplugin/plugin.h
+++ b/plugins/opensslplugin/plugin.h
@@ -31,6 +31,10 @@ class Q_DECL_EXPORT OpenSslPlugin : public QObject, public virtual Sailfish::Sec
 public:
     OpenSslPlugin(QObject *parent = Q_NULLPTR);
     ~OpenSslPlugin();
+
+    QString displayName() const Q_DECL_OVERRIDE {
+        return QStringLiteral("OpenSSL Secrets");
+    }
     QString name() const Q_DECL_OVERRIDE {
 #ifdef SAILFISHSECRETS_TESTPLUGIN
         return QLatin1String("org.sailfishos.secrets.plugin.encryption.openssl.test");

--- a/plugins/passwordagentauthplugin/passwordagentplugin.h
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.h
@@ -41,6 +41,11 @@ public:
     explicit PasswordAgentPlugin(QObject *parent = Q_NULLPTR);
     ~PasswordAgentPlugin();
 
+    QString displayName() const Q_DECL_OVERRIDE {
+        //: The (human readable) display name of the default system password-agent plugin
+        //% "Sailfish OS Password Agent"
+        return qtTrId("password_agent-display_name");
+    }
     QString name() const Q_DECL_OVERRIDE {
 #ifdef SAILFISHSECRETS_TESTPLUGIN
         return QLatin1String("org.sailfishos.secrets.plugin.authentication.passwordagent.test");

--- a/plugins/sqlcipherplugin/sqlcipherplugin.h
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.h
@@ -70,6 +70,9 @@ public:
     SqlCipherPlugin(QObject *parent = Q_NULLPTR);
     ~SqlCipherPlugin();
 
+    QString displayName() const Q_DECL_OVERRIDE {
+        return QStringLiteral("SQLCipher");
+    }
     QString name() const Q_DECL_OVERRIDE {
 #ifdef SAILFISHSECRETS_TESTPLUGIN
         return QLatin1String("org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test");

--- a/plugins/sqliteplugin/plugin.h
+++ b/plugins/sqliteplugin/plugin.h
@@ -40,6 +40,9 @@ public:
     SqlitePlugin(QObject *parent = Q_NULLPTR);
     ~SqlitePlugin();
 
+    QString displayName() const Q_DECL_OVERRIDE {
+        return QStringLiteral("SQLite");
+    }
     QString name() const Q_DECL_OVERRIDE {
 #ifdef SAILFISHSECRETS_TESTPLUGIN
         return QLatin1String("org.sailfishos.secrets.plugin.storage.sqlite.test");


### PR DESCRIPTION
Note that the display name should be informative and human-readable,
however we do not enforce uniqueness (in order to avoid plugin
ordering issues resulting in lost-data issues).

Plugin implementors should take care to ensure that the display name
reported by their plugin is useful and not confusing.

Contributes to JB#36797