### PR TITLE
[sailfish-crypto] Add collectionName parameter to StoredKeyIdentifiersRequest. Contributes to JB#40058

### DIFF
--- a/daemon/CryptoImpl/crypto.cpp
+++ b/daemon/CryptoImpl/crypto.cpp
@@ -243,13 +243,15 @@ void Daemon::ApiImpl::CryptoDBusObject::deleteStoredKey(
 
 void Daemon::ApiImpl::CryptoDBusObject::storedKeyIdentifiers(
         const QString &storagePluginName,
+        const QString &collectionName,
         const QDBusMessage &message,
         Result &result,
         QVector<Key::Identifier> &identifiers)
 {
     Q_UNUSED(identifiers);  // outparam, set in handlePendingRequest / handleFinishedRequest
     QList<QVariant> inParams;
-    inParams << storagePluginName;
+    inParams << storagePluginName
+             << collectionName;
     m_requestQueue->handleRequest(Daemon::ApiImpl::StoredKeyIdentifiersRequest,
                                   inParams,
                                   connection(),
@@ -961,11 +963,15 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
             QString storagePluginName = request->inParams.size()
                     ? request->inParams.takeFirst().value<QString>()
                     : QString();
+            QString collectionName = request->inParams.size()
+                    ? request->inParams.takeFirst().value<QString>()
+                    : QString();
             QVector<Key::Identifier> identifiers;
             Result result = m_requestProcessor->storedKeyIdentifiers(
                         request->remotePid,
                         request->requestId,
                         storagePluginName,
+                        collectionName,
                         &identifiers);
             // send the reply to the calling peer.
             if (result.code() == Result::Pending) {

--- a/daemon/CryptoImpl/crypto_p.h
+++ b/daemon/CryptoImpl/crypto_p.h
@@ -150,6 +150,7 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "      </method>\n"
     "      <method name=\"storedKeyIdentifiers\">\n"
     "          <arg name=\"storagePluginName\" type=\"s\" direction=\"in\" />\n"
+    "          <arg name=\"collectionName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"identifiers\" type=\"a(sss)\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
@@ -399,6 +400,7 @@ public Q_SLOTS:
 
     void storedKeyIdentifiers(
             const QString &storagePluginName,
+            const QString &collectionName,
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result,
             QVector<Sailfish::Crypto::Key::Identifier> &identifiers);

--- a/daemon/CryptoImpl/cryptopluginwrapper.cpp
+++ b/daemon/CryptoImpl/cryptopluginwrapper.cpp
@@ -57,6 +57,14 @@ CryptoStoragePluginWrapper::keyNames(
     return Sailfish::Secrets::Result(Sailfish::Secrets::Result::Succeeded);
 }
 
+Sailfish::Crypto::Result
+CryptoStoragePluginWrapper::storedKeyIdentifiers(
+        const QString &collectionName,
+        QVector<Sailfish::Crypto::Key::Identifier> *identifiers)
+{
+    return m_cryptoPlugin->storedKeyIdentifiers(collectionName, identifiers);
+}
+
 Result
 CryptoStoragePluginWrapper::prepareToStoreKey(
         const Sailfish::Secrets::Daemon::ApiImpl::SecretMetadata &metadata,

--- a/daemon/CryptoImpl/cryptopluginwrapper_p.h
+++ b/daemon/CryptoImpl/cryptopluginwrapper_p.h
@@ -36,6 +36,10 @@ public:
 
     Sailfish::Secrets::Result keyNames(const QString &collectionName, QStringList *keyNames) Q_DECL_OVERRIDE;
 
+    Sailfish::Crypto::Result storedKeyIdentifiers(
+            const QString &collectionName,
+            QVector<Sailfish::Crypto::Key::Identifier> *identifiers);
+
     Sailfish::Crypto::Result generateAndStoreKey(
             const Sailfish::Secrets::Daemon::ApiImpl::SecretMetadata &metadata,
             const Sailfish::Crypto::Key &keyTemplate,

--- a/daemon/CryptoImpl/cryptopluginwrapper_p.h
+++ b/daemon/CryptoImpl/cryptopluginwrapper_p.h
@@ -63,7 +63,8 @@ protected:
 private:
     Sailfish::Crypto::Result prepareToStoreKey(
             const Sailfish::Secrets::Daemon::ApiImpl::SecretMetadata &metadata,
-            const QByteArray &collectionUnlockKey);
+            const QByteArray &collectionUnlockKey,
+            bool *wasLocked);
 };
 
 } // ApiImpl

--- a/daemon/CryptoImpl/cryptorequestprocessor_p.h
+++ b/daemon/CryptoImpl/cryptorequestprocessor_p.h
@@ -161,6 +161,7 @@ public:
             pid_t callerPid,
             quint64 requestId,
             const QString &storagePluginName,
+            const QString &collectionName,
             QVector<Sailfish::Crypto::Key::Identifier> *identifiers);
 
     Sailfish::Crypto::Result calculateDigest(
@@ -307,6 +308,11 @@ public Q_SLOTS:
             quint64 requestId,
             const Sailfish::Secrets::Result &result);
 
+    void secretsStoredKeyIdentifiersCompleted(
+            quint64 requestId,
+            const Sailfish::Secrets::Result &result,
+            const QVector<Sailfish::Secrets::Secret::Identifier> &idents);
+
     void secretsUserInputCompleted(
             quint64 requestId,
             const Sailfish::Secrets::Result &result,
@@ -436,6 +442,12 @@ private:
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
             const Sailfish::Crypto::Key::Identifier &identifier);
+
+    void storedKeyIdentifiers2(
+            pid_t callerPid,
+            quint64 requestId,
+            const Sailfish::Crypto::Result &result,
+            const QVector<Sailfish::Crypto::Key::Identifier> &identifiers);
 
     void sign2(
             quint64 requestId,

--- a/daemon/SecretsImpl/pluginfunctionwrappers_p.h
+++ b/daemon/SecretsImpl/pluginfunctionwrappers_p.h
@@ -133,6 +133,18 @@ struct LockCodes {
     QByteArray newCode;
 };
 
+struct CollectionInfo {
+    CollectionInfo(const QString &name, const QByteArray &key, bool relock)
+        : collectionName(name), collectionKey(key), relockRequired(relock) {}
+    CollectionInfo(const CollectionInfo &other)
+        : collectionName(other.collectionName)
+        , collectionKey(other.collectionKey)
+        , relockRequired(other.relockRequired) {}
+    QString collectionName;
+    QByteArray collectionKey;
+    bool relockRequired;
+};
+
 FoundResult lockSpecificPlugin(
         const QMap<QString, Sailfish::Secrets::EncryptionPlugin*> &encryptionPlugins,
         const QMap<QString, StoragePluginWrapper*> &storagePlugins,
@@ -172,6 +184,12 @@ IdentifiersResult storedKeyIdentifiers(
         StoragePluginWrapper *storagePlugin,
         EncryptedStoragePluginWrapper *encryptedStoragePlugin,
         Sailfish::Crypto::Daemon::ApiImpl::CryptoStoragePluginWrapper *cryptoStoragePlugin);
+
+IdentifiersResult storedKeyIdentifiersFromCollection(
+        StoragePluginWrapper *storagePlugin,
+        EncryptedStoragePluginWrapper *encryptedStoragePlugin,
+        Sailfish::Crypto::Daemon::ApiImpl::CryptoStoragePluginWrapper *cryptoStoragePlugin,
+        const CollectionInfo &collectionInfo);
 
 namespace EncryptionPluginFunctionWrapper {
     struct DataResult {

--- a/daemon/SecretsImpl/pluginfunctionwrappers_p.h
+++ b/daemon/SecretsImpl/pluginfunctionwrappers_p.h
@@ -403,27 +403,22 @@ namespace EncryptedStoragePluginFunctionWrapper {
 
     SecretResult unlockCollectionAndReadSecret(
             EncryptedStoragePluginWrapper *plugin,
+            const CollectionMetadata &collectionMetadata,
             const Sailfish::Secrets::Secret::Identifier &identifier,
             const QByteArray &encryptionKey);
 
     Sailfish::Secrets::Result unlockCollectionAndRemoveSecret(
             EncryptedStoragePluginWrapper *plugin,
+            const CollectionMetadata &collectionMetadata,
             const Sailfish::Secrets::Secret::Identifier &identifier,
             const QByteArray &encryptionKey);
 
     IdentifiersResult unlockAndFindSecrets(
             EncryptedStoragePluginWrapper *plugin,
-            const QString &collectionName,
+            const CollectionMetadata &collectionMetadata,
             const Sailfish::Secrets::Secret::FilterData &filter,
             Sailfish::Secrets::StoragePlugin::FilterOperator filterOperator,
             const QByteArray &encryptionKey);
-
-    Sailfish::Secrets::Result unlockAndRemoveSecret(
-            EncryptedStoragePluginWrapper *plugin,
-            const QString &collectionName,
-            const QString &secretName,
-            bool secretUsesDeviceLockKey,
-            const QByteArray &deviceLockKey);
 
     Sailfish::Secrets::Result unlockDeviceLockedCollectionsAndReencrypt(
             EncryptedStoragePluginWrapper *plugin,
@@ -440,7 +435,8 @@ namespace EncryptedStoragePluginFunctionWrapper {
             EncryptedStoragePluginWrapper *plugin,
             const QString &collectionName,
             const QString &secretName,
-            const QByteArray &collectionKey);
+            const QByteArray &collectionKey,
+            bool requiresRelock);
 }
 
 } // ApiImpl

--- a/daemon/SecretsImpl/pluginwrapper.cpp
+++ b/daemon/SecretsImpl/pluginwrapper.cpp
@@ -730,6 +730,13 @@ Result EncryptedStoragePluginWrapper::createCollection(
     }
 
     m_metadataDb.commitTransaction();
+
+    // if the collection should be relocked, relock it.
+    if ((metadata.usesDeviceLockKey && metadata.unlockSemantic != SecretManager::DeviceLockKeepUnlocked)
+            || (!metadata.usesDeviceLockKey && metadata.unlockSemantic != SecretManager::CustomLockKeepUnlocked)) {
+        m_encryptedStoragePlugin->setEncryptionKey(metadata.collectionName, QByteArray());
+    }
+
     return Result(Result::Succeeded);
 }
 

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -415,7 +415,6 @@ public: // helpers for crypto API: secretscryptohelpers.cpp
     QStringList encryptedStoragePluginNames() const;
     QStringList storagePluginNames() const;
     QString displayNameForStoragePlugin(const QString &name) const;
-    Sailfish::Secrets::Result storedKeyIdentifiers(const QString &storagePluginName, QVector<Secret::Identifier> *idents) const;
 
 private:
     QSharedPointer<QThreadPool> m_secretsThreadPool;
@@ -461,6 +460,8 @@ public: // Crypto API helper methods.
     Sailfish::Secrets::Result storeKeyPreCheck(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier);
     Sailfish::Secrets::Result storeKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier, const QByteArray &serializedKey,
                                        const QMap<QString, QString> &filterData, const QByteArray &collectionDecryptionKey);
+    Sailfish::Secrets::Result storedKeyIdentifiers(pid_t callerPid, quint64 cryptoRequestId, const QString &collectionName, const QString &storagePluginName,
+                                                   QVector<Sailfish::Crypto::Key::Identifier> *identifiers);
     Sailfish::Secrets::Result deleteStoredKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier);
     Sailfish::Secrets::Result userInput(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Secrets::InteractionParameters &uiParams);
     Sailfish::Secrets::Result modifyCryptoPluginLockCode(pid_t callerPid, quint64 cryptoRequestId, const QString &cryptoPluginName, const Sailfish::Secrets::InteractionParameters &uiParams);
@@ -472,6 +473,7 @@ Q_SIGNALS:
     void storeKeyPreCheckCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &collectionDecryptionKey);
     void storeKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);
     void deleteStoredKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);
+    void storedKeyIdentifiersCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QVector<Sailfish::Secrets::Secret::Identifier> &idents);
     void userInputCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &userInput);
     void cryptoPluginLockCodeRequestCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);
 private:
@@ -479,6 +481,7 @@ private:
         InvalidCryptoApiHelperRequest = 0,
         StoragePluginNamesCryptoApiHelperRequest,
         StoredKeyCryptoApiHelperRequest,
+        StoredKeyIdentifiersCryptoApiHelperRequest,
         DeleteStoredKeyCryptoApiHelperRequest,
         StoreKeyPreCheckCryptoApiHelperRequest,
         StoreKeyCryptoApiHelperRequest,
@@ -516,7 +519,8 @@ enum RequestType {
     SetStandaloneCustomLockUserInputSecretRequest,
     // Crypto API helper request types:
     SetCollectionKeyPreCheckRequest,
-    SetCollectionKeyRequest
+    SetCollectionKeyRequest,
+    StoredKeyIdentifiersRequest
 };
 
 } // ApiImpl

--- a/daemon/SecretsImpl/secretsrequestprocessor_p.h
+++ b/daemon/SecretsImpl/secretsrequestprocessor_p.h
@@ -256,7 +256,14 @@ public: // helper methods for crypto API bridge (secretscryptohelpers)
     QStringList storagePluginNames() const;
     QString displayNameForStoragePlugin(const QString &name) const;
     QVector<Sailfish::Secrets::PluginInfo> storagePluginInfo() const;
-    Sailfish::Secrets::Result storedKeyIdentifiers(const QString &storagePluginName, QVector<Secret::Identifier> *idents) const;
+    Sailfish::Secrets::Result storedKeyIdentifiers(
+            pid_t callerPid,
+            quint64 requestId,
+            const QString &collectionName,
+            const QString &storagePluginName,
+            Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
+            const QString &interactionServiceAddress,
+            QVector<Secret::Identifier> *idents);
     Sailfish::Secrets::Result userInput(
             pid_t callerPid,
             quint64 requestId,
@@ -573,6 +580,36 @@ private:
             const Sailfish::Secrets::Secret::Identifier &identifier,
             const CollectionMetadata &collectionMetadata,
             const QByteArray &collectionDecryptionKey);
+
+    Sailfish::Secrets::Result storedKeyIdentifiersWithMetadata(
+            pid_t callerPid,
+            quint64 requestId,
+            const QString &collectionName,
+            const QString &storagePluginName,
+            Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
+            const QString &interactionServiceAddress,
+            const CollectionMetadata &collectionMetadata);
+
+    Sailfish::Secrets::Result storedKeyIdentifiersWithAuthenticationCode(
+            pid_t callerPid,
+            quint64 requestId,
+            const QString &collectionName,
+            const QString &storagePluginName,
+            Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
+            const QString &interactionServiceAddress,
+            const CollectionMetadata &collectionMetadata,
+            const QByteArray &authenticationCode);
+
+    void storedKeyIdentifiersWithEncryptionKey(
+            pid_t callerPid,
+            quint64 requestId,
+            const QString &collectionName,
+            const QString &storagePluginName,
+            Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
+            const QString &interactionServiceAddress,
+            const CollectionMetadata &collectionMetadata,
+            const QByteArray &collectionKey,
+            bool collectionWasLocked);
 
 private:
     struct PendingRequest {

--- a/daemon/SecretsImpl/secretsrequestprocessor_p.h
+++ b/daemon/SecretsImpl/secretsrequestprocessor_p.h
@@ -507,9 +507,9 @@ private:
             pid_t callerPid,
             quint64 requestId,
             const Sailfish::Secrets::Secret::Identifier &identifier,
-            const QString &collectionEncryptionPluginName,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
+            const CollectionMetadata &collectionMetadata,
             const QByteArray &authenticationCode);
 
     void deleteCollectionSecretWithEncryptionKey(
@@ -518,7 +518,7 @@ private:
             const Secret::Identifier &identifier,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
-            const QString &collectionEncryptionPluginName,
+            const CollectionMetadata &collectionMetadata,
             const QByteArray &encryptionKey);
 
     Sailfish::Secrets::Result deleteStandaloneSecretWithMetadata(

--- a/lib/Crypto/cryptomanager.cpp
+++ b/lib/Crypto/cryptomanager.cpp
@@ -292,7 +292,8 @@ CryptoManagerPrivate::deleteStoredKey(
 
 QDBusPendingReply<Result, QVector<Key::Identifier> >
 CryptoManagerPrivate::storedKeyIdentifiers(
-        const QString &storagePluginName)
+        const QString &storagePluginName,
+        const QString &collectionName)
 {
     if (!m_interface) {
         return QDBusPendingReply<Result, QVector<Key::Identifier> >(
@@ -303,7 +304,8 @@ CryptoManagerPrivate::storedKeyIdentifiers(
     QDBusPendingReply<Result, QVector<Key::Identifier> > reply
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("storedKeyIdentifiers"),
-                QVariantList() << QVariant::fromValue<QString>(storagePluginName));
+                QVariantList() << QVariant::fromValue<QString>(storagePluginName)
+                               << QVariant::fromValue<QString>(collectionName));
     return reply;
 }
 

--- a/lib/Crypto/cryptomanager_p.h
+++ b/lib/Crypto/cryptomanager_p.h
@@ -107,7 +107,8 @@ public:
             const Sailfish::Crypto::Key::Identifier &identifier);
 
     QDBusPendingReply<Sailfish::Crypto::Result, QVector<Sailfish::Crypto::Key::Identifier> > storedKeyIdentifiers(
-            const QString &storagePluginName);
+            const QString &storagePluginName,
+            const QString &collectionName);
 
     QDBusPendingReply<Sailfish::Crypto::Result, QByteArray> calculateDigest(
             const QByteArray &data,

--- a/lib/Crypto/storedkeyidentifiersrequest.h
+++ b/lib/Crypto/storedkeyidentifiersrequest.h
@@ -27,6 +27,7 @@ class SAILFISH_CRYPTO_API StoredKeyIdentifiersRequest : public Sailfish::Crypto:
 {
     Q_OBJECT
     Q_PROPERTY(QString storagePluginName READ storagePluginName WRITE setStoragePluginName NOTIFY storagePluginNameChanged)
+    Q_PROPERTY(QString collectionName READ collectionName WRITE setCollectionName NOTIFY collectionNameChanged)
     Q_PROPERTY(QVector<Sailfish::Crypto::Key::Identifier> identifiers READ identifiers NOTIFY identifiersChanged)
 
 public:
@@ -35,6 +36,9 @@ public:
 
     QString storagePluginName() const;
     void setStoragePluginName(const QString &pluginName);
+
+    QString collectionName() const;
+    void setCollectionName(const QString &name);
 
     QVector<Sailfish::Crypto::Key::Identifier> identifiers() const;
 
@@ -52,6 +56,7 @@ public:
 
 Q_SIGNALS:
     void storagePluginNameChanged();
+    void collectionNameChanged();
     void identifiersChanged();
 
 private:

--- a/lib/Crypto/storedkeyidentifiersrequest_p.h
+++ b/lib/Crypto/storedkeyidentifiersrequest_p.h
@@ -31,6 +31,7 @@ public:
 
     QPointer<Sailfish::Crypto::CryptoManager> m_manager;
     QString m_storagePluginName;
+    QString m_collectionName;
     QVariantMap m_customParameters;
     QVector<Sailfish::Crypto::Key::Identifier> m_identifiers;
 

--- a/plugins/inappauthplugin/plugin.cpp
+++ b/plugins/inappauthplugin/plugin.cpp
@@ -119,6 +119,15 @@ Daemon::Plugins::InAppPlugin::beginUserInputInteraction(
                                   Q_ARG(Sailfish::Secrets::Result, Sailfish::Secrets::Result(Sailfish::Secrets::Result::Succeeded)),
                                   Q_ARG(QByteArray, QByteArray("pluginlock")));
         return Result(Result::Pending);
+    } else if (interactionParameters.operation() != InteractionParameters::RequestUserData) {
+        QMetaObject::invokeMethod(this, "userInputInteractionCompleted", Qt::QueuedConnection,
+                                  Q_ARG(uint, callerPid),
+                                  Q_ARG(qint64, requestId),
+                                  Q_ARG(Sailfish::Secrets::InteractionParameters, interactionParameters),
+                                  Q_ARG(QString, interactionServiceAddress),
+                                  Q_ARG(Sailfish::Secrets::Result, Sailfish::Secrets::Result(Sailfish::Secrets::Result::Succeeded)),
+                                  Q_ARG(QByteArray, QByteArray("testpassphrase")));
+        return Result(Result::Pending);
     }
 #endif
 

--- a/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
+++ b/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
@@ -86,6 +86,7 @@ using namespace Sailfish::Crypto;
 #define DEFAULT_TEST_STORAGE_PLUGIN Sailfish::Secrets::SecretManager::DefaultStoragePluginName + QLatin1String(".test")
 #define DEFAULT_TEST_ENCRYPTION_PLUGIN Sailfish::Secrets::SecretManager::DefaultEncryptionPluginName + QLatin1String(".test")
 #define IN_APP_TEST_AUTHENTICATION_PLUGIN Sailfish::Secrets::SecretManager::InAppAuthenticationPluginName + QLatin1String(".test")
+#define PASSWORD_AGENT_TEST_AUTH_PLUGIN Sailfish::Secrets::SecretManager::DefaultAuthenticationPluginName + QLatin1String(".test")
 
 
 namespace {
@@ -160,6 +161,8 @@ private slots:
     void calculateDigest_data();
     void storedKeyRequests_data();
     void storedKeyRequests();
+    void storedKeyIdentifiersRequests_data();
+    void storedKeyIdentifiersRequests();
     void storedDerivedKeyRequests_data();
     void storedDerivedKeyRequests();
     void storedGeneratedKeyRequests();
@@ -1060,6 +1063,151 @@ void tst_cryptorequests::storedKeyRequests()
     // clean up by deleting the collection.
     dcr.startRequest();
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(dcr);
+    QCOMPARE(dcr.result().code(), Sailfish::Secrets::Result::Succeeded);
+}
+
+void tst_cryptorequests::storedKeyIdentifiersRequests_data()
+{
+    QTest::addColumn<QString>("collectionName");
+    QTest::addColumn<QString>("cryptoPluginName");
+    QTest::addColumn<QString>("keyName");
+    QTest::addColumn<CryptoManager::Algorithm>("algorithm");
+    QTest::addColumn<int>("keySize");
+    QTest::addColumn<Sailfish::Secrets::SecretManager::CustomLockUnlockSemantic>("unlockSemantic");
+
+    QTest::newRow("sqlcipher customlock keepunlocked")
+            << "tstcryptorequestsskir"
+            << DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME
+            << "testkeyname"
+            << CryptoManager::AlgorithmAes
+            << 128
+            << Sailfish::Secrets::SecretManager::CustomLockKeepUnlocked;
+
+    QTest::newRow("sqlcipher customlock accessrelock")
+            << "tstcryptorequestsskir"
+            << DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME
+            << "testkeyname"
+            << CryptoManager::AlgorithmAes
+            << 128
+            << Sailfish::Secrets::SecretManager::CustomLockAccessRelock;
+}
+
+void tst_cryptorequests::storedKeyIdentifiersRequests()
+{
+    QFETCH(QString, cryptoPluginName);
+    QFETCH(QString, collectionName);
+    QFETCH(QString, keyName);
+    QFETCH(CryptoManager::Algorithm, algorithm);
+    QFETCH(int, keySize);
+    QFETCH(Sailfish::Secrets::SecretManager::CustomLockUnlockSemantic, unlockSemantic);
+
+    if (algorithm != CryptoManager::AlgorithmAes) {
+        QSKIP("Only AES is supported by the current test.");
+    }
+
+    // test generating a symmetric cipher key and storing securely in the same plugin which produces the key.
+    Sailfish::Crypto::Key keyTemplate;
+    keyTemplate.setSize(keySize);
+    keyTemplate.setAlgorithm(algorithm);
+    keyTemplate.setOrigin(Sailfish::Crypto::Key::OriginDevice);
+    keyTemplate.setOperations(Sailfish::Crypto::CryptoManager::OperationEncrypt | Sailfish::Crypto::CryptoManager::OperationDecrypt);
+    keyTemplate.setComponentConstraints(Sailfish::Crypto::Key::MetaData | Sailfish::Crypto::Key::PublicKeyData | Sailfish::Crypto::Key::PrivateKeyData);
+    keyTemplate.setFilterData(QLatin1String("test"), QLatin1String("true"));
+    keyTemplate.setCustomParameters(QVector<QByteArray>() << QByteArray("testparameter"));
+
+    // first, create the collection via the Secrets API.
+    Sailfish::Secrets::CreateCollectionRequest ccr;
+    ccr.setManager(&sm);
+    ccr.setCollectionLockType(Sailfish::Secrets::CreateCollectionRequest::CustomLock);
+    ccr.setCollectionName(collectionName);
+    ccr.setStoragePluginName(cryptoPluginName);
+    ccr.setEncryptionPluginName(cryptoPluginName);
+    ccr.setAuthenticationPluginName(PASSWORD_AGENT_TEST_AUTH_PLUGIN);
+    ccr.setCustomLockUnlockSemantic(unlockSemantic);
+    ccr.setAccessControlMode(Sailfish::Secrets::SecretManager::OwnerOnlyMode);
+    ccr.setUserInteractionMode(Sailfish::Secrets::SecretManager::ApplicationInteraction);
+    ccr.startRequest();
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(ccr);
+    QCOMPARE(ccr.status(), Sailfish::Secrets::Request::Finished);
+    QCOMPARE(ccr.result().errorMessage(), QString());
+    QCOMPARE(ccr.result().code(), Sailfish::Secrets::Result::Succeeded);
+
+    // request that the secret key be generated and stored into that collection.
+    keyTemplate.setIdentifier(Sailfish::Crypto::Key::Identifier(keyName,
+                                                                collectionName,
+                                                                cryptoPluginName));
+    // note that the secret key data will never enter the client process address space.
+    GenerateStoredKeyRequest gskr;
+    gskr.setManager(&cm);
+    QSignalSpy gskrss(&gskr, &GenerateStoredKeyRequest::statusChanged);
+    QSignalSpy gskrks(&gskr, &GenerateStoredKeyRequest::generatedKeyReferenceChanged);
+    gskr.setKeyTemplate(keyTemplate);
+    QCOMPARE(gskr.keyTemplate(), keyTemplate);
+    gskr.setCryptoPluginName(cryptoPluginName);
+    QCOMPARE(gskr.cryptoPluginName(), cryptoPluginName);
+    QCOMPARE(gskr.status(), Request::Inactive);
+    gskr.startRequest();
+    QCOMPARE(gskrss.count(), 1);
+    QCOMPARE(gskr.status(), Request::Active);
+    QCOMPARE(gskr.result().code(), Result::Pending);
+    QCOMPARE(gskrks.count(), 0);
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(gskr);
+    QCOMPARE(gskrss.count(), 2);
+    QCOMPARE(gskr.status(), Request::Finished);
+    QCOMPARE(ccr.result().errorMessage(), QString());
+    QCOMPARE(gskr.result().code(), Result::Succeeded);
+    QCOMPARE(gskrks.count(), 1);
+    Sailfish::Crypto::Key keyReference = gskr.generatedKeyReference();
+    QVERIFY(keyReference.secretKey().isEmpty());
+    QVERIFY(keyReference.privateKey().isEmpty());
+    QCOMPARE(keyReference.filterData(), keyTemplate.filterData());
+    QVERIFY(!keyReference.identifier().name().isEmpty());
+    QVERIFY(!keyReference.identifier().collectionName().isEmpty());
+    QVERIFY(!keyReference.identifier().storagePluginName().isEmpty());
+
+    // if the unlock semantic is CustomLockRelock then requesting all
+    // stored key identifiers may not return the newly added key,
+    // since that collection should be locked.
+    StoredKeyIdentifiersRequest skir;
+    skir.setManager(&cm);
+    skir.setStoragePluginName(cryptoPluginName);
+    skir.setCollectionName(QString()); // clear.
+    skir.startRequest();
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(skir);
+    QCOMPARE(skir.result().code(), Result::Succeeded);
+    if (unlockSemantic == Sailfish::Secrets::SecretManager::CustomLockKeepUnlocked) {
+        bool keyFound = false;
+        for (const Key::Identifier &ident : skir.identifiers()) {
+            if (ident == keyReference.identifier()) {
+                keyFound = true;
+            }
+        }
+        QCOMPARE(keyFound, true);
+    }
+
+    // in either case, requesting stored key identifiers from the
+    // specific collection should work (after an unlock flow completes).
+    skir.setCollectionName(collectionName);
+    skir.startRequest();
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(skir);
+    QCOMPARE(skir.result().code(), Result::Succeeded);
+    bool keyFound = false;
+    for (const Key::Identifier &ident : skir.identifiers()) {
+        if (ident == keyReference.identifier()) {
+            keyFound = true;
+        }
+    }
+    QCOMPARE(keyFound, true);
+
+    // clean up by deleting the collection in which the secret is stored.
+    Sailfish::Secrets::DeleteCollectionRequest dcr;
+    dcr.setManager(&sm);
+    dcr.setCollectionName(collectionName);
+    dcr.setStoragePluginName(cryptoPluginName);
+    dcr.setUserInteractionMode(Sailfish::Secrets::SecretManager::PreventInteraction);
+    dcr.startRequest();
+    WAIT_FOR_FINISHED_WITHOUT_BLOCKING(dcr);
+    QCOMPARE(dcr.status(), Sailfish::Secrets::Request::Finished);
     QCOMPARE(dcr.result().code(), Sailfish::Secrets::Result::Succeeded);
 }
 

--- a/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
+++ b/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
@@ -1204,7 +1204,7 @@ void tst_cryptorequests::storedKeyIdentifiersRequests()
     dcr.setManager(&sm);
     dcr.setCollectionName(collectionName);
     dcr.setStoragePluginName(cryptoPluginName);
-    dcr.setUserInteractionMode(Sailfish::Secrets::SecretManager::PreventInteraction);
+    dcr.setUserInteractionMode(Sailfish::Secrets::SecretManager::SystemInteraction);
     dcr.startRequest();
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(dcr);
     QCOMPARE(dcr.status(), Sailfish::Secrets::Request::Finished);
@@ -1259,7 +1259,7 @@ void tst_cryptorequests::storedDerivedKeyRequests()
     ccr.setCollectionName(QLatin1String("tstcryptosecretsgcsked"));
     ccr.setStoragePluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
     ccr.setEncryptionPluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
-    ccr.setAuthenticationPluginName(IN_APP_TEST_AUTHENTICATION_PLUGIN);
+    ccr.setAuthenticationPluginName(PASSWORD_AGENT_TEST_AUTH_PLUGIN);
     ccr.setDeviceLockUnlockSemantic(Sailfish::Secrets::SecretManager::DeviceLockKeepUnlocked);
     ccr.setAccessControlMode(Sailfish::Secrets::SecretManager::OwnerOnlyMode);
     ccr.setUserInteractionMode(Sailfish::Secrets::SecretManager::ApplicationInteraction);


### PR DESCRIPTION
If a collectionName is specified and that collection is locked,
this request will now trigger an unlock flow to retrieve the
key identifiers in the collection.