### PR TITLE
[sailfish-crypto] Improve ImportKeyRequest API. Contributes to JB#40058

### DIFF
--- a/daemon/CryptoImpl/crypto.cpp
+++ b/daemon/CryptoImpl/crypto.cpp
@@ -166,7 +166,7 @@ void Daemon::ApiImpl::CryptoDBusObject::generateStoredKey(
 }
 
 void Daemon::ApiImpl::CryptoDBusObject::importKey(
-        const Key &key,
+        const QByteArray &data,
         const Sailfish::Crypto::InteractionParameters &uiParams,
         const QVariantMap &customParameters,
         const QString &cryptosystemProviderName,
@@ -176,7 +176,7 @@ void Daemon::ApiImpl::CryptoDBusObject::importKey(
 {
     Q_UNUSED(importedKey);  // outparam, set in handlePendingRequest / handleFinishedRequest
     QList<QVariant> inParams;
-    inParams << QVariant::fromValue<Key>(key);
+    inParams << QVariant::fromValue<QByteArray>(data);
     inParams << QVariant::fromValue<InteractionParameters>(uiParams);
     inParams << QVariant::fromValue<QVariantMap>(customParameters);
     inParams << QVariant::fromValue<QString>(cryptosystemProviderName);
@@ -188,7 +188,8 @@ void Daemon::ApiImpl::CryptoDBusObject::importKey(
 }
 
 void Daemon::ApiImpl::CryptoDBusObject::importStoredKey(
-        const Key &key,
+        const QByteArray &data,
+        const Key &keyTemplate,
         const Sailfish::Crypto::InteractionParameters &uiParams,
         const QVariantMap &customParameters,
         const QString &cryptosystemProviderName,
@@ -198,7 +199,8 @@ void Daemon::ApiImpl::CryptoDBusObject::importStoredKey(
 {
     Q_UNUSED(importedKey);  // outparam, set in handlePendingRequest / handleFinishedRequest
     QList<QVariant> inParams;
-    inParams << QVariant::fromValue<Key>(key);
+    inParams << QVariant::fromValue<QByteArray>(data);
+    inParams << QVariant::fromValue<Key>(keyTemplate);
     inParams << QVariant::fromValue<InteractionParameters>(uiParams);
     inParams << QVariant::fromValue<QVariantMap>(customParameters);
     inParams << QVariant::fromValue<QString>(cryptosystemProviderName);
@@ -847,9 +849,9 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
         case ImportKeyRequest: {
             qCDebug(lcSailfishCryptoDaemon) << "Handling GenerateKeyRequest from client:" << request->remotePid << ", request number:" << request->requestId;
             Key importedKey;
-            Key key = request->inParams.size()
-                    ? request->inParams.takeFirst().value<Key>()
-                    : Key();
+            QByteArray data = request->inParams.size()
+                    ? request->inParams.takeFirst().value<QByteArray>()
+                    : QByteArray();
             InteractionParameters uiParams = request->inParams.size()
                     ? request->inParams.takeFirst().value<InteractionParameters>()
                     : InteractionParameters();
@@ -862,7 +864,7 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
             Result result = m_requestProcessor->importKey(
                         request->remotePid,
                         request->requestId,
-                        key,
+                        data,
                         uiParams,
                         customParameters,
                         cryptosystemProviderName,
@@ -882,7 +884,10 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
         case ImportStoredKeyRequest: {
             qCDebug(lcSailfishCryptoDaemon) << "Handling GenerateStoredKeyRequest from client:" << request->remotePid << ", request number:" << request->requestId;
             Key importedKey;
-            Key key = request->inParams.size()
+            QByteArray data = request->inParams.size()
+                    ? request->inParams.takeFirst().value<QByteArray>()
+                    : QByteArray();
+            Key keyTemplate = request->inParams.size()
                     ? request->inParams.takeFirst().value<Key>()
                     : Key();
             InteractionParameters uiParams = request->inParams.size()
@@ -897,7 +902,8 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
             Result result = m_requestProcessor->importStoredKey(
                         request->remotePid,
                         request->requestId,
-                        key,
+                        data,
+                        keyTemplate,
                         uiParams,
                         customParameters,
                         cryptosystemProviderName,

--- a/daemon/CryptoImpl/crypto_p.h
+++ b/daemon/CryptoImpl/crypto_p.h
@@ -109,26 +109,26 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out1\" value=\"Sailfish::Crypto::Key\" />\n"
     "      </method>\n"
     "      <method name=\"importKey\">\n"
-    "          <arg name=\"key\" type=\"(ay)\" direction=\"in\" />\n"
+    "          <arg name=\"data\" type=\"ay\" direction=\"in\" />\n"
     "          <arg name=\"uiParams\" type=\"(ssss(i)sss(i)(i))\" direction=\"in\" />\n"
     "          <arg name=\"customParameters\" type=\"a{sv}\" direction=\"in\" />\n"
     "          <arg name=\"cryptosystemProviderName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"importedKey\" type=\"(ay)\" direction=\"out\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Crypto::Key\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In1\" value=\"Sailfish::Crypto::InteractionParameters\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out1\" value=\"Sailfish::Crypto::Key\" />\n"
     "      </method>\n"
     "      <method name=\"importStoredKey\">\n"
-    "          <arg name=\"key\" type=\"(ay)\" direction=\"in\" />\n"
+    "          <arg name=\"data\" type=\"ay\" direction=\"in\" />\n"
+    "          <arg name=\"keyTemplate\" type=\"(ay)\" direction=\"in\" />\n"
     "          <arg name=\"uiParams\" type=\"(ssss(i)sss(i)(i))\" direction=\"in\" />\n"
     "          <arg name=\"customParameters\" type=\"a{sv}\" direction=\"in\" />\n"
     "          <arg name=\"cryptosystemProviderName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"importedKeyReference\" type=\"(ay)\" direction=\"out\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Crypto::Key\" />\n"
-    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In1\" value=\"Sailfish::Crypto::InteractionParameters\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In1\" value=\"Sailfish::Crypto::Key\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::InteractionParameters\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out1\" value=\"Sailfish::Crypto::Key\" />\n"
     "      </method>\n"
@@ -369,7 +369,7 @@ public Q_SLOTS:
             Sailfish::Crypto::Key &key);
 
     void importKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
             const Sailfish::Crypto::InteractionParameters &uiParams,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,
@@ -378,7 +378,8 @@ public Q_SLOTS:
             Sailfish::Crypto::Key &importedKey);
 
     void importStoredKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
+            const Sailfish::Crypto::Key &keyTemplate,
             const Sailfish::Crypto::InteractionParameters &uiParams,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,

--- a/daemon/CryptoImpl/cryptopluginfunctionwrappers.cpp
+++ b/daemon/CryptoImpl/cryptopluginfunctionwrappers.cpp
@@ -90,7 +90,7 @@ DataResult CryptoPluginFunctionWrapper::generateInitializationVector(
 
 KeyResult CryptoPluginFunctionWrapper::importKey(
         const PluginAndCustomParams &pluginAndCustomParams,
-        const Sailfish::Crypto::Key &keyData,
+        const QByteArray &keyData,
         const QByteArray &passphrase)
 {
     Key key;
@@ -103,6 +103,7 @@ KeyResult CryptoPluginFunctionWrapper::importKey(
 
 KeyResult CryptoPluginFunctionWrapper::importAndStoreKey(
         const PluginWrapperAndCustomParams &pluginAndCustomParams,
+        const QByteArray &keyData,
         const Sailfish::Crypto::Key &keyTemplate,
         const QByteArray &passphrase,
         const QByteArray &collectionDecryptionKey)
@@ -130,6 +131,7 @@ KeyResult CryptoPluginFunctionWrapper::importAndStoreKey(
     Key keyReference(keyTemplate);
     Result result = pluginAndCustomParams.plugin->importAndStoreKey(
                 metadata,
+                keyData,
                 keyTemplate,
                 passphrase,
                 pluginAndCustomParams.customParameters,

--- a/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
+++ b/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
@@ -221,12 +221,13 @@ DataResult generateInitializationVector(
 
 KeyResult importKey(
         const PluginAndCustomParams &pluginAndCustomParams,
-        const Sailfish::Crypto::Key &keyData,
+        const QByteArray &keyData,
         const QByteArray &passphrase);
 
 KeyResult importAndStoreKey(
         const PluginWrapperAndCustomParams &pluginAndCustomParams,
-        const Sailfish::Crypto::Key &keyData,
+        const QByteArray &keyData,
+        const Sailfish::Crypto::Key &keyTemplate,
         const QByteArray &passphrase,
         const QByteArray &collectionDecryptionKey);
 

--- a/daemon/CryptoImpl/cryptopluginwrapper.cpp
+++ b/daemon/CryptoImpl/cryptopluginwrapper.cpp
@@ -190,6 +190,7 @@ CryptoStoragePluginWrapper::generateAndStoreKey(
 Result
 CryptoStoragePluginWrapper::importAndStoreKey(
         const Sailfish::Secrets::Daemon::ApiImpl::SecretMetadata &metadata,
+        const QByteArray &data,
         const Key &keyTemplate,
         const QByteArray &importPassphrase,
         const QVariantMap &customParameters,
@@ -200,6 +201,7 @@ CryptoStoragePluginWrapper::importAndStoreKey(
     Result result = prepareToStoreKey(metadata, collectionUnlockKey, &wasLocked);
     if (result.code() == Result::Succeeded) {
         result = m_cryptoPlugin->importAndStoreKey(
+                    data,
                     keyTemplate,
                     importPassphrase,
                     customParameters,

--- a/daemon/CryptoImpl/cryptopluginwrapper_p.h
+++ b/daemon/CryptoImpl/cryptopluginwrapper_p.h
@@ -51,6 +51,7 @@ public:
 
     Sailfish::Crypto::Result importAndStoreKey(
             const Sailfish::Secrets::Daemon::ApiImpl::SecretMetadata &metadata,
+            const QByteArray &data,
             const Sailfish::Crypto::Key &keyTemplate,
             const QByteArray &importPassphrase,
             const QVariantMap &customParameters,

--- a/daemon/CryptoImpl/cryptorequestprocessor_p.h
+++ b/daemon/CryptoImpl/cryptorequestprocessor_p.h
@@ -129,7 +129,7 @@ public:
     Sailfish::Crypto::Result importKey(
             pid_t callerPid,
             quint64 requestId,
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
             const Sailfish::Crypto::InteractionParameters &uiParams,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,
@@ -139,7 +139,8 @@ public:
     Sailfish::Crypto::Result importStoredKey(
             pid_t callerPid,
             quint64 requestId,
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
+            const Sailfish::Crypto::Key &keyTemplate,
             const Sailfish::Crypto::InteractionParameters &uiParams,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,
@@ -403,7 +404,7 @@ private:
     void importKey_withPassphrase(
             pid_t callerPid,
             quint64 requestId,
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
             const Sailfish::Crypto::InteractionParameters &uiParams,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,
@@ -413,6 +414,7 @@ private:
     void importStoredKey_afterPreCheck(
             pid_t callerPid,
             quint64 requestId,
+            const QByteArray &data,
             const Sailfish::Crypto::Key &keyTemplate,
             const Sailfish::Crypto::InteractionParameters &uiParams,
             const QVariantMap &customParameters,
@@ -423,6 +425,7 @@ private:
     void importStoredKey_withPassphrase(
             pid_t callerPid,
             quint64 requestId,
+            const QByteArray &data,
             const Sailfish::Crypto::Key &keyTemplate,
             const Sailfish::Crypto::InteractionParameters &uiParams,
             const QVariantMap &customParameters,

--- a/lib/Crypto/cryptomanager.cpp
+++ b/lib/Crypto/cryptomanager.cpp
@@ -210,8 +210,8 @@ CryptoManagerPrivate::generateStoredKey(
 
 QDBusPendingReply<Result, Key>
 CryptoManagerPrivate::importKey(
-        const Key &key,
-        const Sailfish::Crypto::InteractionParameters &uiParams,
+        const QByteArray &data,
+        const InteractionParameters &uiParams,
         const QVariantMap &customParameters,
         const QString &cryptosystemProviderName)
 {
@@ -224,7 +224,7 @@ CryptoManagerPrivate::importKey(
     QDBusPendingReply<Result, Key> reply
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("importKey"),
-                QVariantList() << QVariant::fromValue<Key>(key)
+                QVariantList() << QVariant::fromValue<QByteArray>(data)
                                << QVariant::fromValue<InteractionParameters>(uiParams)
                                << QVariant::fromValue<QVariantMap>(customParameters)
                                << QVariant::fromValue<QString>(cryptosystemProviderName));
@@ -233,8 +233,9 @@ CryptoManagerPrivate::importKey(
 
 QDBusPendingReply<Result, Key>
 CryptoManagerPrivate::importStoredKey(
-        const Key &key,
-        const Sailfish::Crypto::InteractionParameters &uiParams,
+        const QByteArray &data,
+        const Key &keyTemplate,
+        const InteractionParameters &uiParams,
         const QVariantMap &customParameters,
         const QString &cryptosystemProviderName)
 {
@@ -247,7 +248,8 @@ CryptoManagerPrivate::importStoredKey(
     QDBusPendingReply<Result, Key> reply
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("importStoredKey"),
-                QVariantList() << QVariant::fromValue<Key>(key)
+                QVariantList() << QVariant::fromValue<QByteArray>(data)
+                               << QVariant::fromValue<Key>(keyTemplate)
                                << QVariant::fromValue<InteractionParameters>(uiParams)
                                << QVariant::fromValue<QVariantMap>(customParameters)
                                << QVariant::fromValue<QString>(cryptosystemProviderName));

--- a/lib/Crypto/cryptomanager_p.h
+++ b/lib/Crypto/cryptomanager_p.h
@@ -88,13 +88,14 @@ public:
             const QString &cryptosystemProviderName);
 
     QDBusPendingReply<Sailfish::Crypto::Result, Sailfish::Crypto::Key> importKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
             const Sailfish::Crypto::InteractionParameters &uiParams,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName);
 
     QDBusPendingReply<Sailfish::Crypto::Result, Sailfish::Crypto::Key> importStoredKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
+            const Sailfish::Crypto::Key &keyTemplate,
             const Sailfish::Crypto::InteractionParameters &uiParams,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName);

--- a/lib/Crypto/importkeyrequest.cpp
+++ b/lib/Crypto/importkeyrequest.cpp
@@ -101,27 +101,27 @@ void ImportKeyRequest::setInteractionParameters(
 }
 
 /*!
- * \brief Returns the key which should be imported.
+ * \brief Returns the data which should be imported as a key.
  */
-Key ImportKeyRequest::key() const
+QByteArray ImportKeyRequest::data() const
 {
     Q_D(const ImportKeyRequest);
-    return d->m_key;
+    return d->m_data;
 }
 
 /*!
- * \brief Sets the \a key which should be imported.
+ * \brief Sets the \a data which should be imported.
  */
-void ImportKeyRequest::setKey(const Key &key)
+void ImportKeyRequest::setData(const QByteArray &data)
 {
     Q_D(ImportKeyRequest);
-    if (d->m_status != Request::Active && d->m_key != key) {
-        d->m_key = key;
+    if (d->m_status != Request::Active && d->m_data != data) {
+        d->m_data = data;
         if (d->m_status == Request::Finished) {
             d->m_status = Request::Inactive;
             emit statusChanged();
         }
-        emit keyChanged();
+        emit dataChanged();
     }
 }
 
@@ -194,7 +194,7 @@ void ImportKeyRequest::startRequest()
         }
 
         QDBusPendingReply<Result, Key> reply =
-                d->m_manager->d_ptr->importKey(d->m_key,
+                d->m_manager->d_ptr->importKey(d->m_data,
                                                d->m_uiParams,
                                                d->m_customParameters,
                                                d->m_cryptoPluginName);

--- a/lib/Crypto/importkeyrequest.h
+++ b/lib/Crypto/importkeyrequest.h
@@ -29,7 +29,7 @@ class SAILFISH_CRYPTO_API ImportKeyRequest : public Sailfish::Crypto::Request
     Q_OBJECT
     Q_PROPERTY(QString cryptoPluginName READ cryptoPluginName WRITE setCryptoPluginName NOTIFY cryptoPluginNameChanged)
     Q_PROPERTY(Sailfish::Crypto::InteractionParameters interactionParameters READ interactionParameters WRITE setInteractionParameters NOTIFY interactionParametersChanged)
-    Q_PROPERTY(Sailfish::Crypto::Key key READ key WRITE setKey NOTIFY keyChanged)
+    Q_PROPERTY(QByteArray data READ data WRITE setData NOTIFY dataChanged)
     Q_PROPERTY(Sailfish::Crypto::Key importedKey READ importedKey NOTIFY importedKeyChanged)
 
 public:
@@ -42,8 +42,8 @@ public:
     Sailfish::Crypto::InteractionParameters interactionParameters() const;
     void setInteractionParameters(const Sailfish::Crypto::InteractionParameters &uiParams);
 
-    Sailfish::Crypto::Key key() const;
-    void setKey(const Sailfish::Crypto::Key &key);
+    QByteArray data() const;
+    void setData(const QByteArray &data);
 
     Sailfish::Crypto::Key importedKey() const;
 
@@ -62,7 +62,7 @@ public:
 Q_SIGNALS:
     void cryptoPluginNameChanged();
     void interactionParametersChanged();
-    void keyChanged();
+    void dataChanged();
     void importedKeyChanged();
 
 private:

--- a/lib/Crypto/importkeyrequest_p.h
+++ b/lib/Crypto/importkeyrequest_p.h
@@ -33,7 +33,7 @@ public:
     QString m_cryptoPluginName;
     QVariantMap m_customParameters;
     Sailfish::Crypto::InteractionParameters m_uiParams;
-    Sailfish::Crypto::Key m_key;
+    QByteArray m_data;
     Sailfish::Crypto::Key m_importedKey;
 
     QScopedPointer<QDBusPendingCallWatcher> m_watcher;

--- a/lib/Crypto/importstoredkeyrequest.h
+++ b/lib/Crypto/importstoredkeyrequest.h
@@ -29,7 +29,8 @@ class SAILFISH_CRYPTO_API ImportStoredKeyRequest : public Sailfish::Crypto::Requ
     Q_OBJECT
     Q_PROPERTY(QString cryptoPluginName READ cryptoPluginName WRITE setCryptoPluginName NOTIFY cryptoPluginNameChanged)
     Q_PROPERTY(Sailfish::Crypto::InteractionParameters interactionParameters READ interactionParameters WRITE setInteractionParameters NOTIFY interactionParametersChanged)
-    Q_PROPERTY(Sailfish::Crypto::Key key READ key WRITE setKey NOTIFY keyChanged)
+    Q_PROPERTY(QByteArray data READ data WRITE setData NOTIFY dataChanged)
+    Q_PROPERTY(Sailfish::Crypto::Key keyTemplate READ keyTemplate WRITE setKeyTemplate NOTIFY keyTemplateChanged)
     Q_PROPERTY(Sailfish::Crypto::Key importedKeyReference READ importedKeyReference NOTIFY importedKeyReferenceChanged)
 
 public:
@@ -42,8 +43,11 @@ public:
     Sailfish::Crypto::InteractionParameters interactionParameters() const;
     void setInteractionParameters(const Sailfish::Crypto::InteractionParameters &uiParams);
 
-    Sailfish::Crypto::Key key() const;
-    void setKey(const Sailfish::Crypto::Key &key);
+    QByteArray data() const;
+    void setData(const QByteArray &data);
+
+    Sailfish::Crypto::Key keyTemplate() const;
+    void setKeyTemplate(const Sailfish::Crypto::Key &keyTemplate);
 
     Sailfish::Crypto::Key importedKeyReference() const;
 
@@ -62,7 +66,8 @@ public:
 Q_SIGNALS:
     void cryptoPluginNameChanged();
     void interactionParametersChanged();
-    void keyChanged();
+    void dataChanged();
+    void keyTemplateChanged();
     void importedKeyReferenceChanged();
 
 private:

--- a/lib/Crypto/importstoredkeyrequest_p.h
+++ b/lib/Crypto/importstoredkeyrequest_p.h
@@ -35,7 +35,8 @@ public:
     QString m_cryptoPluginName;
     QVariantMap m_customParameters;
     Sailfish::Crypto::InteractionParameters m_uiParams;
-    Sailfish::Crypto::Key m_key;
+    QByteArray m_data;
+    Sailfish::Crypto::Key m_keyTemplate;
     Sailfish::Crypto::Key m_importedKeyReference;
 
     QScopedPointer<QDBusPendingCallWatcher> m_watcher;

--- a/lib/Crypto/interactionparameters.h
+++ b/lib/Crypto/interactionparameters.h
@@ -92,6 +92,7 @@ public:
         DeriveMac           = 1 << 23,
         DeriveKey           = 1 << 24,
         StoreKey            = 1 << 25,
+        ImportKey           = 1 << 26,
 
         // reserved
         LastOperation       = 1 << 30

--- a/lib/Crypto/key.cpp
+++ b/lib/Crypto/key.cpp
@@ -125,6 +125,26 @@ Key::Identifier& Key::Identifier::operator=(const Key::Identifier &other)
 }
 
 /*!
+ * \brief Returns true if the key identifier consists of valid, non-empty components
+ *
+ * Note that this doesn't mean that the identifier does in fact identify
+ * a valid key stored by the system secrets service; rather, it means
+ * that if a key with the name() specified in this identifier is stored
+ * in a collection with the collectionName() specified in this identifier
+ * by the storage (or crypto storage) plugin identified by the storagePluginName()
+ * specified in this identifier, then this identifier would identify it.
+ *
+ * That is, if either name() or collectionName() or storagePluginName() is
+ * empty, the identifier is not considered valid.
+ */
+bool Key::Identifier::isValid() const
+{
+    return !d_ptr->m_name.isEmpty()
+            && !d_ptr->m_collectionName.isEmpty()
+            && !d_ptr->m_storagePluginName.isEmpty();
+}
+
+/*!
  * \brief Returns the key name from the identifier
  */
 QString Key::Identifier::name() const

--- a/lib/Crypto/key.h
+++ b/lib/Crypto/key.h
@@ -70,6 +70,8 @@ public:
 
         Identifier &operator=(const Sailfish::Crypto::Key::Identifier &other);
 
+        bool isValid() const;
+
         QString name() const;
         void setName(const QString &name);
         QString collectionName() const;

--- a/lib/CryptoPluginApi/extensionplugins.h
+++ b/lib/CryptoPluginApi/extensionplugins.h
@@ -84,13 +84,14 @@ public:
             Sailfish::Crypto::Key *keyMetadata) = 0;
 
     virtual Sailfish::Crypto::Result importKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
             const QByteArray &passphrase,
             const QVariantMap &customParameters,
             Sailfish::Crypto::Key *importedKey) = 0;
 
     virtual Sailfish::Crypto::Result importAndStoreKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
+            const Sailfish::Crypto::Key &keyTemplate,
             const QByteArray &passphrase,
             const QVariantMap &customParameters,
             Sailfish::Crypto::Key *keyMetadata) = 0;

--- a/lib/Secrets/interactionparameters.h
+++ b/lib/Secrets/interactionparameters.h
@@ -92,6 +92,7 @@ public:
         DeriveMac           = 1 << 23,
         DeriveKey           = 1 << 24,
         StoreKey            = 1 << 25,
+        ImportKey           = 1 << 26,
 
         // reserved
         LastOperation       = 1 << 30

--- a/plugins/exampleusbtokenplugin/cryptoplugin.cpp
+++ b/plugins/exampleusbtokenplugin/cryptoplugin.cpp
@@ -85,7 +85,8 @@ ExampleUsbTokenPlugin::generateAndStoreKey(
 
 Result
 ExampleUsbTokenPlugin::importAndStoreKey(
-        const Key & /* key */,
+        const QByteArray & /* data */,
+        const Key & /* keyTemplate */,
         const QByteArray & /* passphrase */,
         const QVariantMap & /* customParameters */,
         Key * /* keyMetadata */)
@@ -195,7 +196,7 @@ ExampleUsbTokenPlugin::generateKey(
 
 Result
 ExampleUsbTokenPlugin::importKey(
-        const Key & /* key */,
+        const QByteArray & /* keyData */,
         const QByteArray & /* passphrase */,
         const QVariantMap & /* customParameters */,
         Key * /* importedKey */)

--- a/plugins/exampleusbtokenplugin/exampleusbtokenplugin.cpp
+++ b/plugins/exampleusbtokenplugin/exampleusbtokenplugin.cpp
@@ -85,10 +85,9 @@ bool ExampleUsbTokenPlugin::unlock(const QByteArray &lockCode)
        "6obcnqDfdVsOcLZIjLpXeoW3GQ7dakwe3gPwVvCEEDqNzTPosxKNCUKlzVasRECQ\n"
        "-----END RSA PRIVATE KEY-----\n");
 
-    Sailfish::Crypto::Key keyTemplate, importedKey;
-    keyTemplate.setPrivateKey(pemData);
+    Sailfish::Crypto::Key importedKey;
     Sailfish::Crypto::Result result = m_usbInterface.importKey(
-                keyTemplate, lockCode, QVariantMap(), &importedKey);
+                pemData, lockCode, QVariantMap(), &importedKey);
     if (result.code() == Crypto::Result::Succeeded) {
         m_usbTokenKey = importedKey;
     }

--- a/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
+++ b/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
@@ -157,13 +157,14 @@ public:
             Sailfish::Crypto::Key *keyMetadata) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result importKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
             const QByteArray &passphrase,
             const QVariantMap &customParameters,
             Sailfish::Crypto::Key *importedKey) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result importAndStoreKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
+            const Sailfish::Crypto::Key &keyTemplate,
             const QByteArray &passphrase,
             const QVariantMap &customParameters,
             Sailfish::Crypto::Key *keyMetadata) Q_DECL_OVERRIDE;

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.h
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.h
@@ -99,13 +99,14 @@ public:
             Sailfish::Crypto::Key *keyMetadata) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result importKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
             const QByteArray &passphrase,
             const QVariantMap &customParameters,
             Sailfish::Crypto::Key *importedKey) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result importAndStoreKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
+            const Sailfish::Crypto::Key &keyTemplate,
             const QByteArray &passphrase,
             const QVariantMap &customParameters,
             Sailfish::Crypto::Key *keyMetadata) Q_DECL_OVERRIDE;

--- a/plugins/sqlcipherplugin/sqlcipherplugin.h
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.h
@@ -149,13 +149,14 @@ public:
             Sailfish::Crypto::Key *keyMetadata) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result importKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
             const QByteArray &passphrase,
             const QVariantMap &customParameters,
             Sailfish::Crypto::Key *importedKey) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result importAndStoreKey(
-            const Sailfish::Crypto::Key &key,
+            const QByteArray &data,
+            const Sailfish::Crypto::Key &keyTemplate,
             const QByteArray &passphrase,
             const QVariantMap &customParameters,
             Sailfish::Crypto::Key *keyMetadata) Q_DECL_OVERRIDE;

--- a/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
+++ b/tests/Crypto/tst_cryptorequests/tst_cryptorequests.cpp
@@ -2931,41 +2931,35 @@ static const auto test_key_dsa_1024_out = QByteArrayLiteral(
             "-----END PRIVATE KEY-----\n");
 
 static Key createPublicKey(
-        const Key::Identifier &identifier, const QByteArray &data, Key::Component constraints = Key::PublicKeyData)
+        const Key::Identifier &identifier)
 {
     Key key;
     key.setIdentifier(identifier);
-    key.setPublicKey(data);
-    key.setComponentConstraints(constraints);
+    key.setComponentConstraints(Key::MetaData | Key::PublicKeyData);
+    key.setOperations(Sailfish::Crypto::CryptoManager::OperationEncrypt
+                     |Sailfish::Crypto::CryptoManager::OperationVerify);
 
     return key;
 }
 
 static Key createPrivateKey(
-        const Key::Identifier &identifier, const QByteArray &data, Key::Component constraints = Key::PrivateKeyData)
+        const Key::Identifier &identifier)
 {
     Key key;
     key.setIdentifier(identifier);
-    key.setPrivateKey(data);
-    key.setComponentConstraints(constraints);
-
-    return key;
-}
-
-static Key createSecretKey(
-        const Key::Identifier &identifier, const QByteArray &data, Key::Component constraints = Key::SecretKeyData)
-{
-    Key key;
-    key.setIdentifier(identifier);
-    key.setSecretKey(data);
-    key.setComponentConstraints(constraints);
+    key.setComponentConstraints(Key::MetaData | Key::PublicKeyData | Key::PrivateKeyData);
+    key.setOperations(Sailfish::Crypto::CryptoManager::OperationEncrypt
+                     |Sailfish::Crypto::CryptoManager::OperationDecrypt
+                     |Sailfish::Crypto::CryptoManager::OperationSign
+                     |Sailfish::Crypto::CryptoManager::OperationVerify);
 
     return key;
 }
 
 void tst_cryptorequests::importKey_data()
 {
-    QTest::addColumn<Sailfish::Crypto::Key>("key");
+    QTest::addColumn<QByteArray>("data");
+    QTest::addColumn<Sailfish::Crypto::Key>("keyTemplate");
     QTest::addColumn<Sailfish::Crypto::InteractionParameters>("interactionParameters");
     QTest::addColumn<Sailfish::Crypto::Result::ResultCode>("resultCode");
     QTest::addColumn<Sailfish::Crypto::Result::ErrorCode>("errorCode");
@@ -2994,7 +2988,8 @@ void tst_cryptorequests::importKey_data()
                                   DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
 
     QTest::newRow("Private RSA 2048 - no passphrase")
-            << createPrivateKey(keyIdentifier, test_key_rsa_2048_in)
+            << test_key_rsa_2048_in
+            << createPrivateKey(keyIdentifier)
             << noUserInteraction
             << Result::Succeeded
             << Result::NoError
@@ -3004,7 +2999,8 @@ void tst_cryptorequests::importKey_data()
             << Key::OriginImported
             << CryptoManager::AlgorithmRsa;
     QTest::newRow("Private RSA 2048 - passphrase")
-            << createPrivateKey(keyIdentifier, test_key_rsa_2048_sailfish_in)
+            << test_key_rsa_2048_sailfish_in
+            << createPrivateKey(keyIdentifier)
             << promptForSailfishPassphrase
             << Result::Succeeded
             << Result::NoError
@@ -3014,7 +3010,8 @@ void tst_cryptorequests::importKey_data()
             << Key::OriginImported
             << CryptoManager::AlgorithmRsa;
     QTest::newRow("Public RSA 2048")
-            << createPublicKey(keyIdentifier, test_key_rsa_2048_pub)
+            << test_key_rsa_2048_pub
+            << createPublicKey(keyIdentifier)
             << noUserInteraction
             << Result::Succeeded
             << Result::NoError
@@ -3025,7 +3022,8 @@ void tst_cryptorequests::importKey_data()
             << CryptoManager::AlgorithmRsa;
 
     QTest::newRow("Private RSA 1024 - no passphrase")
-            << createPrivateKey(keyIdentifier, test_key_rsa_1024_in)
+            << test_key_rsa_1024_in
+            << createPrivateKey(keyIdentifier)
             << noUserInteraction
             << Result::Succeeded
             << Result::NoError
@@ -3035,7 +3033,8 @@ void tst_cryptorequests::importKey_data()
             << Key::OriginImported
             << CryptoManager::AlgorithmRsa;
     QTest::newRow("Private RSA 1024 - passphrase")
-            << createPrivateKey(keyIdentifier, test_key_rsa_1024_sailfish_in)
+            << test_key_rsa_1024_sailfish_in
+            << createPrivateKey(keyIdentifier)
             << promptForSailfishPassphrase
             << Result::Succeeded
             << Result::NoError
@@ -3045,7 +3044,8 @@ void tst_cryptorequests::importKey_data()
             << Key::OriginImported
             << CryptoManager::AlgorithmRsa;
     QTest::newRow("Public RSA 1024")
-            << createPublicKey(keyIdentifier, test_key_rsa_1024_pub)
+            << test_key_rsa_1024_pub
+            << createPublicKey(keyIdentifier)
             << noUserInteraction
             << Result::Succeeded
             << Result::NoError
@@ -3056,7 +3056,8 @@ void tst_cryptorequests::importKey_data()
             << CryptoManager::AlgorithmRsa;
 
     QTest::newRow("Private DSA 1024 - no passphrase")
-            << createPrivateKey(keyIdentifier, test_key_dsa_1024_in)
+            << test_key_dsa_1024_in
+            << createPrivateKey(keyIdentifier)
             << noUserInteraction
             << Result::Succeeded
             << Result::NoError
@@ -3066,7 +3067,8 @@ void tst_cryptorequests::importKey_data()
             << Key::OriginImported
             << CryptoManager::AlgorithmDsa;
     QTest::newRow("Private DSA 1024 - passphrase")
-            << createPrivateKey(keyIdentifier, test_key_dsa_1024_sailfish_in)
+            << test_key_dsa_1024_sailfish_in
+            << createPrivateKey(keyIdentifier)
             << promptForSailfishPassphrase
             << Result::Succeeded
             << Result::NoError
@@ -3076,7 +3078,8 @@ void tst_cryptorequests::importKey_data()
             << Key::OriginImported
             << CryptoManager::AlgorithmDsa;
     QTest::newRow("Public DSA 1024")
-            << createPublicKey(keyIdentifier, test_key_dsa_1024_pub)
+            << test_key_dsa_1024_pub
+            << createPublicKey(keyIdentifier)
             << noUserInteraction
             << Result::Succeeded
             << Result::NoError
@@ -3086,19 +3089,9 @@ void tst_cryptorequests::importKey_data()
             << Key::OriginImported
             << CryptoManager::AlgorithmDsa;
 
-    QTest::newRow("Private RSA 2048 - secret")
-            << createSecretKey(keyIdentifier, test_key_rsa_2048_in)
-            << noUserInteraction
-            << Result::Succeeded
-            << Result::NoError
-            << test_key_rsa_2048_out
-            << test_key_rsa_2048_pub
-            << 2048
-            << Key::OriginImported
-            << CryptoManager::AlgorithmRsa;
-
     QTest::newRow("Private RSA 2048 - passphrase, no user interaction")
-            << createPrivateKey(keyIdentifier, test_key_rsa_2048_sailfish_in)
+            << test_key_rsa_2048_sailfish_in
+            << createPrivateKey(keyIdentifier)
             << noUserInteraction
             << Result::Failed
             << Result::CryptoPluginIncorrectPassphrase
@@ -3108,7 +3101,8 @@ void tst_cryptorequests::importKey_data()
             << Key::OriginUnknown
             << CryptoManager::AlgorithmUnknown;
     QTest::newRow("Private RSA 2048 - passphrase, canceled")
-            << createPrivateKey(keyIdentifier, test_key_rsa_2048_sailfish_in)
+            << test_key_rsa_2048_sailfish_in
+            << createPrivateKey(keyIdentifier)
             << promptToCancel
             << Result::Failed
             << Result::CryptoPluginKeyImportError
@@ -3117,21 +3111,12 @@ void tst_cryptorequests::importKey_data()
             << 0
             << Key::OriginUnknown
             << CryptoManager::AlgorithmUnknown;
-    QTest::newRow("Private RSA 2048 - public constraint")
-            << createPrivateKey(keyIdentifier, test_key_rsa_2048_in, Key::PublicKeyData)
-            << noUserInteraction
-            << Result::Succeeded
-            << Result::NoError
-            << QByteArray()
-            << test_key_rsa_2048_pub
-            << 2048
-            << Key::OriginImported
-            << CryptoManager::AlgorithmRsa;
 }
 
 void tst_cryptorequests::importKey()
 {
-    QFETCH(Sailfish::Crypto::Key, key);
+    QFETCH(QByteArray, data);
+    QFETCH(Sailfish::Crypto::Key, keyTemplate);
     QFETCH(Sailfish::Crypto::InteractionParameters, interactionParameters);
     QFETCH(Sailfish::Crypto::Result::ResultCode, resultCode);
     QFETCH(Sailfish::Crypto::Result::ErrorCode, errorCode);
@@ -3141,14 +3126,16 @@ void tst_cryptorequests::importKey()
     QFETCH(Sailfish::Crypto::Key::Origin, origin);
     QFETCH(Sailfish::Crypto::CryptoManager::Algorithm, algorithm);
 
+    Q_UNUSED(keyTemplate); // importKey just uses the data.
+
     Sailfish::Crypto::ImportKeyRequest request;
     request.setManager(&cm);
 
     request.setCryptoPluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
     QCOMPARE(request.cryptoPluginName(), DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
 
-    request.setKey(key);
-    QCOMPARE(request.key(), key);
+    request.setData(data);
+    QCOMPARE(request.data(), data);
 
     if (interactionParameters.isValid()) {
         QSKIP("Invalid interaction service address for in-app authentication");
@@ -3169,6 +3156,46 @@ void tst_cryptorequests::importKey()
     QCOMPARE(importedKey.size(), size);
     QCOMPARE(importedKey.origin(), origin);
     QCOMPARE(importedKey.algorithm(), algorithm);
+
+    // ensure that we can perform crypto operations with the imported key.
+    if (resultCode == Result::Succeeded && privateKey.size()) {
+        // attempt to sign some data with the key.
+        const QByteArray dataToSign("The quick brown fox jumps over the lazy dog");
+        Sailfish::Crypto::SignRequest sr;
+        sr.setManager(&cm);
+        sr.setData(dataToSign);
+        sr.setDigestFunction(Sailfish::Crypto::CryptoManager::DigestSha256);
+        sr.setPadding(Sailfish::Crypto::CryptoManager::SignaturePaddingNone);
+        sr.setKey(importedKey);
+        sr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
+        sr.startRequest();
+        WAIT_FOR_FINISHED_WITHOUT_BLOCKING(sr);
+        QCOMPARE(sr.result().errorMessage(), QString());
+        QCOMPARE(sr.result().code(), Sailfish::Crypto::Result::Succeeded);
+        QCOMPARE(sr.signature().isEmpty(), false);
+
+        // attempt to verify the signed data.
+        Sailfish::Crypto::VerifyRequest vr;
+        vr.setManager(&cm);
+        vr.setData(dataToSign);
+        vr.setSignature(sr.signature());
+        vr.setDigestFunction(Sailfish::Crypto::CryptoManager::DigestSha256);
+        vr.setPadding(Sailfish::Crypto::CryptoManager::SignaturePaddingNone);
+        vr.setKey(importedKey);
+        vr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
+        vr.startRequest();
+        WAIT_FOR_FINISHED_WITHOUT_BLOCKING(vr);
+        QCOMPARE(vr.result().errorMessage(), QString());
+        QCOMPARE(vr.result().code(), Sailfish::Crypto::Result::Succeeded);
+        QCOMPARE(vr.verified(), true);
+
+        // attempt to verify some other random data, and ensure that it fails.
+        const QByteArray randomDataToVerify("abcdef1234567890987654321fedcba");
+        vr.setData(randomDataToVerify);
+        vr.startRequest();
+        WAIT_FOR_FINISHED_WITHOUT_BLOCKING(vr);
+        QCOMPARE(vr.verified(), false);
+    }
 }
 
 void tst_cryptorequests::importKeyAndStore_data()
@@ -3176,7 +3203,8 @@ void tst_cryptorequests::importKeyAndStore_data()
     importKey_data();
 
     QTest::newRow("Private RSA 2048 - no identifier")
-            << createPrivateKey(Key::Identifier(), test_key_rsa_2048_in)
+            << test_key_rsa_2048_in
+            << createPrivateKey(Key::Identifier())
             << InteractionParameters()
             << Result::Failed
             << Result::InvalidKeyIdentifier
@@ -3189,7 +3217,8 @@ void tst_cryptorequests::importKeyAndStore_data()
 
 void tst_cryptorequests::importKeyAndStore()
 {
-    QFETCH(Sailfish::Crypto::Key, key);
+    QFETCH(QByteArray, data);
+    QFETCH(Sailfish::Crypto::Key, keyTemplate);
     QFETCH(Sailfish::Crypto::InteractionParameters, interactionParameters);
     QFETCH(Sailfish::Crypto::Result::ResultCode, resultCode);
     QFETCH(Sailfish::Crypto::Result::ErrorCode, errorCode);
@@ -3203,12 +3232,12 @@ void tst_cryptorequests::importKeyAndStore()
         QSKIP("Invalid interaction service address for in-app authentication");
     }
 
-    if (!key.collectionName().isEmpty()) {
+    if (!keyTemplate.collectionName().isEmpty()) {
         // first, create the collection via the Secrets API.
         Sailfish::Secrets::CreateCollectionRequest ccr;
         ccr.setManager(&sm);
         ccr.setCollectionLockType(Sailfish::Secrets::CreateCollectionRequest::DeviceLock);
-        ccr.setCollectionName(key.collectionName());
+        ccr.setCollectionName(keyTemplate.collectionName());
         ccr.setStoragePluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
         ccr.setEncryptionPluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
         ccr.setAuthenticationPluginName(IN_APP_TEST_AUTHENTICATION_PLUGIN);
@@ -3220,7 +3249,7 @@ void tst_cryptorequests::importKeyAndStore()
         if (ccr.result().code() == Sailfish::Secrets::Result::Failed) {
             qDebug() << ccr.result().errorMessage();
         } else {
-            populatedCollections.insert(key.collectionName(), key.storagePluginName());
+            populatedCollections.insert(keyTemplate.collectionName(), keyTemplate.storagePluginName());
         }
     }
 
@@ -3230,8 +3259,10 @@ void tst_cryptorequests::importKeyAndStore()
     request.setCryptoPluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
     QCOMPARE(request.cryptoPluginName(), DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
 
-    request.setKey(key);
-    QCOMPARE(request.key(), key);
+    request.setData(data);
+    QCOMPARE(request.data(), data);
+    request.setKeyTemplate(keyTemplate);
+    QCOMPARE(request.keyTemplate(), keyTemplate);
 
     request.startRequest();
 
@@ -3250,10 +3281,51 @@ void tst_cryptorequests::importKeyAndStore()
         // but, when we successfully store an imported key, we always
         // return a key reference which contains no private key data.
         QCOMPARE(importedKey.privateKey(), QByteArray());
+        QCOMPARE(importedKey.identifier(), keyTemplate.identifier());
     }
     QCOMPARE(importedKey.size(), size);
     QCOMPARE(importedKey.origin(), origin);
     QCOMPARE(importedKey.algorithm(), algorithm);
+
+    // ensure that we can perform crypto operations with the stored key.
+    if (resultCode == Result::Succeeded && privateKey.size()) {
+        // attempt to sign some data with the key.
+        const QByteArray dataToSign("The quick brown fox jumps over the lazy dog");
+        Sailfish::Crypto::SignRequest sr;
+        sr.setManager(&cm);
+        sr.setData(dataToSign);
+        sr.setDigestFunction(Sailfish::Crypto::CryptoManager::DigestSha256);
+        sr.setPadding(Sailfish::Crypto::CryptoManager::SignaturePaddingNone);
+        sr.setKey(importedKey);
+        sr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
+        sr.startRequest();
+        WAIT_FOR_FINISHED_WITHOUT_BLOCKING(sr);
+        QCOMPARE(sr.result().errorMessage(), QString());
+        QCOMPARE(sr.result().code(), Sailfish::Crypto::Result::Succeeded);
+        QCOMPARE(sr.signature().isEmpty(), false);
+
+        // attempt to verify the signed data.
+        Sailfish::Crypto::VerifyRequest vr;
+        vr.setManager(&cm);
+        vr.setData(dataToSign);
+        vr.setSignature(sr.signature());
+        vr.setDigestFunction(Sailfish::Crypto::CryptoManager::DigestSha256);
+        vr.setPadding(Sailfish::Crypto::CryptoManager::SignaturePaddingNone);
+        vr.setKey(importedKey);
+        vr.setCryptoPluginName(DEFAULT_TEST_CRYPTO_STORAGE_PLUGIN_NAME);
+        vr.startRequest();
+        WAIT_FOR_FINISHED_WITHOUT_BLOCKING(vr);
+        QCOMPARE(vr.result().errorMessage(), QString());
+        QCOMPARE(vr.result().code(), Sailfish::Crypto::Result::Succeeded);
+        QCOMPARE(vr.verified(), true);
+
+        // attempt to verify some other random data, and ensure that it fails.
+        const QByteArray randomDataToVerify("abcdef1234567890987654321fedcba");
+        vr.setData(randomDataToVerify);
+        vr.startRequest();
+        WAIT_FOR_FINISHED_WITHOUT_BLOCKING(vr);
+        QCOMPARE(vr.verified(), false);
+    }
 }
 
 void tst_cryptorequests::exampleUsbTokenPlugin()


### PR DESCRIPTION
Instead of taking a key parameter, it now takes raw byte array, which
will be converted into an appropriate, usable Key by the plugin.