### PR TITLE
[sailfish-crypto] Use VerificationResult instead of bool for verified…

### DIFF
--- a/daemon/CryptoImpl/crypto_p.h
+++ b/daemon/CryptoImpl/crypto_p.h
@@ -191,11 +191,12 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "          <arg name=\"customParameters\" type=\"a{sv}\" direction=\"in\" />\n"
     "          <arg name=\"cryptosystemProviderName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
-    "          <arg name=\"verified\" type=\"b\" direction=\"out\" />\n"
+    "          <arg name=\"verificationStatus\" type=\"(i)\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::Key\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Crypto::CryptoManager::SignaturePadding\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In4\" value=\"Sailfish::Crypto::CryptoManager::Digest\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out1\" value=\"Sailfish::Crypto::CryptoManager::VerificationStatus\" />\n"
     "      </method>\n"
     "      <method name=\"encrypt\">\n"
     "          <arg name=\"data\" type=\"ay\" direction=\"in\" />\n"
@@ -226,11 +227,12 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "          <arg name=\"cryptosystemProviderName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"decrypted\" type=\"ay\" direction=\"out\" />\n"
-    "          <arg name=\"verified\" type=\"b\" direction=\"out\" />\n"
+    "          <arg name=\"verificationStatus\" type=\"(i)\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In2\" value=\"Sailfish::Crypto::Key\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In3\" value=\"Sailfish::Crypto::CryptoManager::BlockMode\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In4\" value=\"Sailfish::Crypto::CryptoManager::EncryptionPadding\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out1\" value=\"Sailfish::Crypto::CryptoManager::VerificationStatus\" />\n"
     "      </method>\n"
     "      <method name=\"initializeCipherSession\">\n"
     "          <arg name=\"initializationVector\" type=\"ay\" direction=\"in\" />\n"
@@ -276,8 +278,9 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "          <arg name=\"cipherSessionToken\" type=\"u\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"generatedData\" type=\"ay\" direction=\"out\" />\n"
-    "          <arg name=\"verified\" type=\"b\" direction=\"out\" />\n"
+    "          <arg name=\"verificationStatus\" type=\"(i)\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out1\" value=\"Sailfish::Crypto::CryptoManager::VerificationStatus\" />\n"
     "      </method>\n"
     "      <method name=\"modifyLockCode\">\n"
     "          <arg name=\"lockCodeTargetType\" type=\"(i)\" direction=\"in\" />\n"
@@ -437,7 +440,7 @@ public Q_SLOTS:
             const QString &cryptosystemProviderName,
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result,
-            bool &verified);
+            Sailfish::Crypto::CryptoManager::VerificationStatus &verificationStatus);
 
     void encrypt(
             const QByteArray &data,
@@ -466,7 +469,7 @@ public Q_SLOTS:
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result,
             QByteArray &decrypted,
-            bool &verified);
+            Sailfish::Crypto::CryptoManager::VerificationStatus &verificationStatus);
 
     void initializeCipherSession(
             const QByteArray &initializationVector,
@@ -507,7 +510,7 @@ public Q_SLOTS:
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result,
             QByteArray &generatedData,
-            bool &verified);
+            Sailfish::Crypto::CryptoManager::VerificationStatus &verificationStatus);
 
     void modifyLockCode(
             Sailfish::Crypto::LockCodeRequest::LockCodeTargetType lockCodeTargetType,

--- a/daemon/CryptoImpl/cryptopluginfunctionwrappers.cpp
+++ b/daemon/CryptoImpl/cryptopluginfunctionwrappers.cpp
@@ -213,14 +213,14 @@ ValidatedResult CryptoPluginFunctionWrapper::verify(
         const Key &key,
         const SignatureOptions &options)
 {
-    bool verified = false;
+    Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus = Sailfish::Crypto::CryptoManager::VerificationStatusUnknown;
     Result result = pluginAndCustomParams.plugin->verify(
                 signature, data, key,
                 options.signaturePadding,
                 options.digestFunction,
                 pluginAndCustomParams.customParameters,
-                &verified);
-    return ValidatedResult(result, verified);
+                &verificationStatus);
+    return ValidatedResult(result, verificationStatus);
 }
 
 TagDataResult CryptoPluginFunctionWrapper::encrypt(
@@ -252,7 +252,7 @@ VerifiedDataResult CryptoPluginFunctionWrapper::decrypt(
         const AuthDataAndTag &authDataAndTag)
 {
     QByteArray plaintext;
-    bool verified = false;
+    Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus = Sailfish::Crypto::CryptoManager::VerificationStatusUnknown;
     Result result = pluginAndCustomParams.plugin->decrypt(
                 dataAndIv.data,
                 dataAndIv.initVector,
@@ -262,8 +262,8 @@ VerifiedDataResult CryptoPluginFunctionWrapper::decrypt(
                 authDataAndTag.authData,
                 authDataAndTag.tag,
                 pluginAndCustomParams.customParameters,
-                &plaintext, &verified);
-    return VerifiedDataResult(result, plaintext, verified);
+                &plaintext, &verificationStatus);
+    return VerifiedDataResult(result, plaintext, verificationStatus);
 }
 
 CipherSessionTokenResult CryptoPluginFunctionWrapper::initializeCipherSession(
@@ -321,14 +321,14 @@ VerifiedDataResult CryptoPluginFunctionWrapper::finalizeCipherSession(
         const QByteArray &data,
         quint32 cipherSessionToken)
 {
-    bool verified = false;
+    Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus = Sailfish::Crypto::CryptoManager::VerificationStatusUnknown;
     QByteArray generatedData;
     Result result = pluginAndCustomParams.plugin->finalizeCipherSession(
                 clientId, data,
                 pluginAndCustomParams.customParameters,
                 cipherSessionToken,
-                &generatedData, &verified);
-    return VerifiedDataResult(result, generatedData, verified);
+                &generatedData, &verificationStatus);
+    return VerifiedDataResult(result, generatedData, verificationStatus);
 }
 
 KeyResult CryptoPluginFunctionWrapper::generateAndStoreKey(

--- a/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
+++ b/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
@@ -48,23 +48,23 @@ struct DataResult {
 
 struct VerifiedDataResult {
     VerifiedDataResult(const Sailfish::Crypto::Result &r = Sailfish::Crypto::Result(),
-                       const QByteArray &d = QByteArray(), bool v = false)
-        : result(r), data(d), verified(v) {}
+                       const QByteArray &d = QByteArray(), Sailfish::Crypto::CryptoManager::VerificationStatus v = Sailfish::Crypto::CryptoManager::VerificationStatusUnknown)
+        : result(r), data(d), verificationStatus(v) {}
     VerifiedDataResult(const VerifiedDataResult &other)
-        : result(other.result), data(other.data), verified(other.verified) {}
+        : result(other.result), data(other.data), verificationStatus(other.verificationStatus) {}
     Sailfish::Crypto::Result result;
     QByteArray data;
-    bool verified;
+    Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus;
 };
 
 struct ValidatedResult {
     ValidatedResult(const Sailfish::Crypto::Result &r = Sailfish::Crypto::Result(),
-                    bool v = false)
-        : result(r), validated(v) {}
+                    Sailfish::Crypto::CryptoManager::VerificationStatus v = Sailfish::Crypto::CryptoManager::VerificationStatusUnknown)
+        : result(r), verificationStatus(v) {}
     ValidatedResult(const ValidatedResult &other)
-        : result(other.result), validated(other.validated) {}
+        : result(other.result), verificationStatus(other.verificationStatus) {}
     Sailfish::Crypto::Result result;
-    bool validated;
+    Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus;
 };
 
 struct KeyResult {

--- a/daemon/CryptoImpl/cryptorequestprocessor.cpp
+++ b/daemon/CryptoImpl/cryptorequestprocessor.cpp
@@ -1379,10 +1379,10 @@ Daemon::ApiImpl::RequestProcessor::verify(
         CryptoManager::DigestFunction digestFunction,
         const QVariantMap &customParameters,
         const QString &cryptosystemProviderName,
-        bool *verified)
+        Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
 {
     // TODO: Access Control
-    Q_UNUSED(verified); // asynchronous out-param.
+    Q_UNUSED(verificationStatus); // asynchronous out-param.
 
     CryptoPlugin* cryptoPlugin = m_cryptoPlugins.value(cryptosystemProviderName);
     if (cryptoPlugin == Q_NULLPTR) {
@@ -1458,7 +1458,7 @@ Daemon::ApiImpl::RequestProcessor::verify(
         ValidatedResult vr = watcher->future().result();
         QVariantList outParams;
         outParams << QVariant::fromValue<Result>(vr.result);
-        outParams << QVariant::fromValue<bool>(vr.validated);
+        outParams << QVariant::fromValue<CryptoManager::VerificationStatus>(vr.verificationStatus);
         m_requestQueue->requestFinished(requestId, outParams);
     });
 
@@ -1480,7 +1480,7 @@ Daemon::ApiImpl::RequestProcessor::verify2(
     if (result.code() != Result::Succeeded) {
         QList<QVariant> outParams;
         outParams << QVariant::fromValue<Result>(result);
-        outParams << QVariant::fromValue<bool>(false);
+        outParams << QVariant::fromValue<CryptoManager::VerificationStatus>(CryptoManager::VerificationFailed);
         m_requestQueue->requestFinished(requestId, outParams);
         return;
     }
@@ -1501,7 +1501,7 @@ Daemon::ApiImpl::RequestProcessor::verify2(
         ValidatedResult vr = watcher->future().result();
         QVariantList outParams;
         outParams << QVariant::fromValue<Result>(vr.result);
-        outParams << QVariant::fromValue<bool>(vr.validated);
+        outParams << QVariant::fromValue<CryptoManager::VerificationStatus>(vr.verificationStatus);
         m_requestQueue->requestFinished(requestId, outParams);
     });
 }
@@ -1680,11 +1680,11 @@ Daemon::ApiImpl::RequestProcessor::decrypt(
         const QVariantMap &customParameters,
         const QString &cryptosystemProviderName,
         QByteArray *decrypted,
-        bool *verified)
+        Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
 {
     // TODO: Access Control
     Q_UNUSED(decrypted); // asynchronous out-param.
-    Q_UNUSED(verified); // asynchronous out-param.
+    Q_UNUSED(verificationStatus); // asynchronous out-param.
 
     CryptoPlugin* cryptoPlugin = m_cryptoPlugins.value(cryptosystemProviderName);
     if (cryptoPlugin == Q_NULLPTR) {
@@ -1765,7 +1765,7 @@ Daemon::ApiImpl::RequestProcessor::decrypt(
         QVariantList outParams;
         outParams << QVariant::fromValue<Result>(dr.result);
         outParams << QVariant::fromValue<QByteArray>(dr.data);
-        outParams << QVariant::fromValue<bool>(dr.verified);
+        outParams << QVariant::fromValue<CryptoManager::VerificationStatus>(dr.verificationStatus);
         m_requestQueue->requestFinished(requestId, outParams);
     });
 
@@ -1790,7 +1790,7 @@ Daemon::ApiImpl::RequestProcessor::decrypt2(
         QList<QVariant> outParams;
         outParams << QVariant::fromValue<Result>(result);
         outParams << QVariant::fromValue<QByteArray>(QByteArray());
-        outParams << QVariant::fromValue<bool>(false);
+        outParams << QVariant::fromValue<CryptoManager::VerificationStatus>(CryptoManager::VerificationFailed);
         m_requestQueue->requestFinished(requestId, outParams);
     }
 
@@ -1811,7 +1811,7 @@ Daemon::ApiImpl::RequestProcessor::decrypt2(
         QVariantList outParams;
         outParams << QVariant::fromValue<Result>(dr.result);
         outParams << QVariant::fromValue<QByteArray>(dr.data);
-        outParams << QVariant::fromValue<bool>(dr.verified);
+        outParams << QVariant::fromValue<CryptoManager::VerificationStatus>(dr.verificationStatus);
         m_requestQueue->requestFinished(requestId, outParams);
     });
 }
@@ -2059,11 +2059,11 @@ Daemon::ApiImpl::RequestProcessor::finalizeCipherSession(
         const QString &cryptosystemProviderName,
         quint32 cipherSessionToken,
         QByteArray *generatedData,
-        bool *verified)
+        Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
 {
     Q_UNUSED(requestId); // TODO: Access Control
     Q_UNUSED(generatedData); // asynchronous out-param.
-    Q_UNUSED(verified);      // asynchronous out-param.
+    Q_UNUSED(verificationStatus);      // asynchronous out-param.
 
     CryptoPlugin* cryptoPlugin = m_cryptoPlugins.value(cryptosystemProviderName);
     if (cryptoPlugin == Q_NULLPTR) {
@@ -2087,7 +2087,7 @@ Daemon::ApiImpl::RequestProcessor::finalizeCipherSession(
         QVariantList outParams;
         outParams << QVariant::fromValue<Result>(vdr.result);
         outParams << QVariant::fromValue<QByteArray>(vdr.data);
-        outParams << QVariant::fromValue<bool>(vdr.verified);
+        outParams << QVariant::fromValue<CryptoManager::VerificationStatus>(vdr.verificationStatus);
         m_requestQueue->requestFinished(requestId, outParams);
     });
 

--- a/daemon/CryptoImpl/cryptorequestprocessor_p.h
+++ b/daemon/CryptoImpl/cryptorequestprocessor_p.h
@@ -196,7 +196,7 @@ public:
             Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,
-            bool *verified);
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus);
 
     Sailfish::Crypto::Result encrypt(
             pid_t callerPid,
@@ -225,7 +225,7 @@ public:
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,
             QByteArray *decrypted,
-            bool *verified);
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus);
 
     Sailfish::Crypto::Result initializeCipherSession(
             pid_t callerPid,
@@ -266,7 +266,7 @@ public:
             const QString &cryptosystemProviderName,
             quint32 cipherSessionToken,
             QByteArray *generatedData,
-            bool *verified);
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus);
 
     Sailfish::Crypto::Result modifyLockCode(
             pid_t callerPid,

--- a/lib/Crypto/cipherrequest.h
+++ b/lib/Crypto/cipherrequest.h
@@ -37,7 +37,7 @@ class SAILFISH_CRYPTO_API CipherRequest : public Sailfish::Crypto::Request
     Q_PROPERTY(Sailfish::Crypto::CryptoManager::DigestFunction digestFunction READ digestFunction WRITE setDigestFunction NOTIFY digestFunctionChanged)
     Q_PROPERTY(QString cryptoPluginName READ cryptoPluginName WRITE setCryptoPluginName NOTIFY cryptoPluginNameChanged)
     Q_PROPERTY(QByteArray generatedData READ generatedData NOTIFY generatedDataChanged)
-    Q_PROPERTY(bool verified READ verified NOTIFY verifiedChanged)
+    Q_PROPERTY(Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus READ verificationStatus NOTIFY verificationStatusChanged)
 
 public:
     enum CipherMode {
@@ -82,7 +82,7 @@ public:
     void setCryptoPluginName(const QString &pluginName);
 
     QByteArray generatedData() const;
-    bool verified() const;
+    Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus() const;
 
     Sailfish::Crypto::Request::Status status() const Q_DECL_OVERRIDE;
     Sailfish::Crypto::Result result() const Q_DECL_OVERRIDE;
@@ -108,7 +108,7 @@ Q_SIGNALS:
     void digestFunctionChanged();
     void cryptoPluginNameChanged();
     void generatedDataChanged();
-    void verifiedChanged();
+    void verificationStatusChanged();
 
 private:
     QScopedPointer<CipherRequestPrivate> const d_ptr;

--- a/lib/Crypto/cipherrequest_p.h
+++ b/lib/Crypto/cipherrequest_p.h
@@ -44,7 +44,7 @@ public:
     QString m_cryptoPluginName;
     quint32 m_cipherSessionToken;
     QByteArray m_generatedData;
-    bool m_verified;
+    Sailfish::Crypto::CryptoManager::VerificationStatus m_verificationStatus;
 
     QQueue<QDBusPendingCallWatcher*> m_watcherQueue;
     QHash<QDBusPendingCallWatcher*, bool> m_completedHash;

--- a/lib/Crypto/cryptodaemonconnection.cpp
+++ b/lib/Crypto/cryptodaemonconnection.cpp
@@ -164,11 +164,13 @@ void Sailfish::Crypto::CryptoDaemonConnection::registerDBusTypes()
     qRegisterMetaType<Sailfish::Crypto::CryptoManager::SignaturePadding>("Sailfish::Crypto::CryptoManager::SignaturePadding");
     qRegisterMetaType<Sailfish::Crypto::CryptoManager::DigestFunction>("Sailfish::Crypto::CryptoManager::Digest");
     qRegisterMetaType<Sailfish::Crypto::CryptoManager::Operation>("Sailfish::Crypto::CryptoManager::Operation");
+    qRegisterMetaType<Sailfish::Crypto::CryptoManager::VerificationStatusType>("Sailfish::Crypto::CryptoManager::VerificationStatusType");
     qRegisterMetaType<QVector<Sailfish::Crypto::CryptoManager::BlockMode> >("QVector<Sailfish::Crypto::CryptoManager::BlockMode>");
     qRegisterMetaType<QVector<Sailfish::Crypto::CryptoManager::EncryptionPadding> >("QVector<Sailfish::Crypto::CryptoManager::EncryptionPadding>");
     qRegisterMetaType<QVector<Sailfish::Crypto::CryptoManager::SignaturePadding> >("QVector<Sailfish::Crypto::CryptoManager::SignaturePadding>");
     qRegisterMetaType<QVector<Sailfish::Crypto::CryptoManager::DigestFunction> >("QVector<Sailfish::Crypto::CryptoManager::DigestFunction>");
     qRegisterMetaType<Sailfish::Crypto::CryptoManager::Operations>("Sailfish::Crypto::CryptoManager::Operations");
+    qRegisterMetaType<Sailfish::Crypto::CryptoManager::VerificationStatus>("Sailfish::Crypto::CryptoManager::VerificationStatus");
     qRegisterMetaType<Sailfish::Crypto::Key::Identifier>("Sailfish::Crypto::Key::Identifier");
     qRegisterMetaType<QVector<Sailfish::Crypto::Key::Identifier> >("QVector<Sailfish::Crypto::Key::Identifier>");
     qRegisterMetaType<Sailfish::Crypto::Key::FilterData>("Sailfish::Crypto::Key::FilterData");
@@ -192,11 +194,13 @@ void Sailfish::Crypto::CryptoDaemonConnection::registerDBusTypes()
     qDBusRegisterMetaType<Sailfish::Crypto::CryptoManager::SignaturePadding>();
     qDBusRegisterMetaType<Sailfish::Crypto::CryptoManager::DigestFunction>();
     qDBusRegisterMetaType<Sailfish::Crypto::CryptoManager::Operation>();
+    qDBusRegisterMetaType<Sailfish::Crypto::CryptoManager::VerificationStatusType>();
     qDBusRegisterMetaType<QVector<Sailfish::Crypto::CryptoManager::BlockMode> >();
     qDBusRegisterMetaType<QVector<Sailfish::Crypto::CryptoManager::EncryptionPadding> >();
     qDBusRegisterMetaType<QVector<Sailfish::Crypto::CryptoManager::SignaturePadding> >();
     qDBusRegisterMetaType<QVector<Sailfish::Crypto::CryptoManager::DigestFunction> >();
     qDBusRegisterMetaType<Sailfish::Crypto::CryptoManager::Operations>();
+    qDBusRegisterMetaType<Sailfish::Crypto::CryptoManager::VerificationStatus>();
     qDBusRegisterMetaType<Sailfish::Crypto::Key::Identifier>();
     qDBusRegisterMetaType<QVector<Sailfish::Crypto::Key::Identifier> >();
     qDBusRegisterMetaType<Sailfish::Crypto::Key>();

--- a/lib/Crypto/cryptomanager.cpp
+++ b/lib/Crypto/cryptomanager.cpp
@@ -363,8 +363,7 @@ CryptoManagerPrivate::sign(
     return reply;
 }
 
-QDBusPendingReply<Result, bool>
-CryptoManagerPrivate::verify(
+QDBusPendingReply<Result, CryptoManager::VerificationStatus> CryptoManagerPrivate::verify(
         const QByteArray &signature,
         const QByteArray &data,
         const Key &key,
@@ -374,12 +373,12 @@ CryptoManagerPrivate::verify(
         const QString &cryptosystemProviderName)
 {
     if (!m_interface) {
-        return QDBusPendingReply<Result, bool>(
+        return QDBusPendingReply<Result, Sailfish::Crypto::CryptoManager::VerificationStatus>(
                     QDBusMessage::createError(QDBusError::Other,
                                               QStringLiteral("Not connected to daemon")));
     }
 
-    QDBusPendingReply<Result, bool> reply
+    QDBusPendingReply<Result, Sailfish::Crypto::CryptoManager::VerificationStatus> reply
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("verify"),
                 QVariantList() << QVariant::fromValue<QByteArray>(signature)
@@ -423,7 +422,7 @@ CryptoManagerPrivate::encrypt(
     return reply;
 }
 
-QDBusPendingReply<Result, QByteArray, bool> CryptoManagerPrivate::decrypt(
+QDBusPendingReply<Result, QByteArray, Sailfish::Crypto::CryptoManager::VerificationStatus> CryptoManagerPrivate::decrypt(
         const QByteArray &data,
         const QByteArray &iv,
         const Key &key, // or keyreference, i.e. Key(keyName)
@@ -435,12 +434,12 @@ QDBusPendingReply<Result, QByteArray, bool> CryptoManagerPrivate::decrypt(
         const QString &cryptosystemProviderName)
 {
     if (!m_interface) {
-        return QDBusPendingReply<Result, QByteArray, bool>(
+        return QDBusPendingReply<Result, QByteArray, Sailfish::Crypto::CryptoManager::VerificationStatus>(
                     QDBusMessage::createError(QDBusError::Other,
                                               QStringLiteral("Not connected to daemon")));
     }
 
-    QDBusPendingReply<Result, QByteArray, bool> reply
+    QDBusPendingReply<Result, QByteArray, Sailfish::Crypto::CryptoManager::VerificationStatus> reply
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("decrypt"),
                 QVariantList() << QVariant::fromValue<QByteArray>(data)
@@ -534,7 +533,7 @@ CryptoManagerPrivate::updateCipherSession(
     return reply;
 }
 
-QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, bool>
+QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, Sailfish::Crypto::CryptoManager::VerificationStatus>
 CryptoManagerPrivate::finalizeCipherSession(
         const QByteArray &data,
         const QVariantMap &customParameters,
@@ -542,12 +541,12 @@ CryptoManagerPrivate::finalizeCipherSession(
         quint32 cipherSessionToken)
 {
     if (!m_interface) {
-        return QDBusPendingReply<Result, QByteArray, bool>(
+        return QDBusPendingReply<Result, QByteArray, Sailfish::Crypto::CryptoManager::VerificationStatus>(
                     QDBusMessage::createError(QDBusError::Other,
                                               QStringLiteral("Not connected to daemon")));
     }
 
-    QDBusPendingReply<Result, QByteArray, bool> reply
+    QDBusPendingReply<Result, QByteArray, Sailfish::Crypto::CryptoManager::VerificationStatus> reply
             = m_interface->asyncCallWithArgumentList(
                 "finalizeCipherSession",
                 QVariantList() << QVariant::fromValue<QByteArray>(data)

--- a/lib/Crypto/cryptomanager.h
+++ b/lib/Crypto/cryptomanager.h
@@ -313,6 +313,20 @@ public:
     Q_DECLARE_FLAGS(Operations, Operation)
     Q_FLAG(Operations)
 
+    enum VerificationStatusType {
+        VerificationStatusUnknown = 0,
+        VerificationSucceeded = 1,
+        VerificationFailed = 2,
+        VerificationSignatureInvalid = 4,
+        VerificationSignatureExpired = 8,
+        VerificationKeyExpired = 16,
+        VerificationKeyRevoked = 32,
+        VerificationKeyInvalid = 64
+    };
+    Q_ENUM(VerificationStatusType)
+    Q_DECLARE_FLAGS(VerificationStatus, VerificationStatusType)
+    Q_FLAG(VerificationStatus)
+
     CryptoManager(QObject *parent = Q_NULLPTR);
     virtual ~CryptoManager();
 
@@ -352,6 +366,9 @@ Q_DECLARE_METATYPE(Sailfish::Crypto::CryptoManager::SignaturePadding);
 Q_DECLARE_METATYPE(Sailfish::Crypto::CryptoManager::DigestFunction);
 Q_DECLARE_METATYPE(Sailfish::Crypto::CryptoManager::Operation);
 Q_DECLARE_METATYPE(Sailfish::Crypto::CryptoManager::Operations);
+Q_DECLARE_METATYPE(Sailfish::Crypto::CryptoManager::VerificationStatusType);
+Q_DECLARE_METATYPE(Sailfish::Crypto::CryptoManager::VerificationStatus);
 Q_DECLARE_OPERATORS_FOR_FLAGS(Sailfish::Crypto::CryptoManager::Operations);
+Q_DECLARE_OPERATORS_FOR_FLAGS(Sailfish::Crypto::CryptoManager::VerificationStatus);
 
 #endif // LIBSAILFISHCRYPTO_CRYPTOMANAGER_H

--- a/lib/Crypto/cryptomanager_p.h
+++ b/lib/Crypto/cryptomanager_p.h
@@ -126,7 +126,7 @@ public:
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName);
 
-    QDBusPendingReply<Sailfish::Crypto::Result, bool> verify(
+    QDBusPendingReply<Sailfish::Crypto::Result, Sailfish::Crypto::CryptoManager::VerificationStatus> verify(
             const QByteArray &signature,
             const QByteArray &data,
             const Sailfish::Crypto::Key &key, // or keyreference, i.e. Key(keyName)
@@ -145,7 +145,7 @@ public:
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName);
 
-    QDBusPendingReply<Result, QByteArray, bool> decrypt(
+    QDBusPendingReply<Result, QByteArray, Sailfish::Crypto::CryptoManager::VerificationStatus> decrypt(
             const QByteArray &data,
             const QByteArray &iv,
             const Key &key, // or keyreference, i.e. Key(keyName)
@@ -179,7 +179,7 @@ public:
             const QString &cryptosystemProviderName,
             quint32 cipherSessionToken);
 
-    QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, bool> finalizeCipherSession(
+    QDBusPendingReply<Result, QByteArray, CryptoManager::VerificationStatus> finalizeCipherSession(
             const QByteArray &data,
             const QVariantMap &customParameters,
             const QString &cryptosystemProviderName,

--- a/lib/Crypto/decryptrequest.h
+++ b/lib/Crypto/decryptrequest.h
@@ -36,7 +36,7 @@ class SAILFISH_CRYPTO_API DecryptRequest : public Sailfish::Crypto::Request
     Q_PROPERTY(QByteArray authenticationTag READ authenticationTag WRITE setAuthenticationTag NOTIFY authenticationTagChanged)
     Q_PROPERTY(QString cryptoPluginName READ cryptoPluginName WRITE setCryptoPluginName NOTIFY cryptoPluginNameChanged)
     Q_PROPERTY(QByteArray plaintext READ plaintext NOTIFY plaintextChanged)
-    Q_PROPERTY(bool verified READ verified NOTIFY verifiedChanged)
+    Q_PROPERTY(Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus READ verificationStatus NOTIFY verificationStatusChanged)
 
 public:
     DecryptRequest(QObject *parent = Q_NULLPTR);
@@ -67,7 +67,7 @@ public:
     void setCryptoPluginName(const QString &pluginName);
 
     QByteArray plaintext() const;
-    bool verified() const;
+    Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus() const;
 
     Sailfish::Crypto::Request::Status status() const Q_DECL_OVERRIDE;
     Sailfish::Crypto::Result result() const Q_DECL_OVERRIDE;
@@ -91,7 +91,7 @@ Q_SIGNALS:
     void authenticationTagChanged();
     void cryptoPluginNameChanged();
     void plaintextChanged();
-    void verifiedChanged();
+    void verificationStatusChanged();
 
 private:
     QScopedPointer<DecryptRequestPrivate> const d_ptr;

--- a/lib/Crypto/decryptrequest_p.h
+++ b/lib/Crypto/decryptrequest_p.h
@@ -40,7 +40,7 @@ public:
     QByteArray m_authenticationTag;
     QString m_cryptoPluginName;
     QByteArray m_plaintext;
-    bool m_verified;
+    Sailfish::Crypto::CryptoManager::VerificationStatus m_verificationStatus;
 
     QScopedPointer<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;

--- a/lib/Crypto/serialization.cpp
+++ b/lib/Crypto/serialization.cpp
@@ -277,6 +277,36 @@ QDataStream& operator<<(QDataStream& out, const CryptoManager::Operations &v)
     return out;
 }
 
+QDataStream& operator>>(QDataStream& in, CryptoManager::VerificationStatusType &v)
+{
+    quint32 temp = 0;
+    in >> temp;
+    v = static_cast<CryptoManager::VerificationStatusType>(temp);
+    return in;
+}
+
+QDataStream& operator<<(QDataStream& out, const CryptoManager::VerificationStatusType &v)
+{
+    quint32 temp = static_cast<quint32>(v);
+    out << temp;
+    return out;
+}
+
+QDataStream& operator>>(QDataStream& in, CryptoManager::VerificationStatus &v)
+{
+    quint32 temp = 0;
+    in >> temp;
+    v = static_cast<CryptoManager::VerificationStatus>(temp);
+    return in;
+}
+
+QDataStream& operator<<(QDataStream& out, const CryptoManager::VerificationStatus &v)
+{
+    quint32 temp = static_cast<quint32>(v);
+    out << temp;
+    return out;
+}
+
 QDBusArgument &operator<<(QDBusArgument &argument, const Key &key)
 {
     argument.beginStructure();
@@ -512,6 +542,42 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, CryptoManager::Op
     argument >> iv;
     argument.endStructure();
     operations = static_cast<CryptoManager::Operations>(iv);
+    return argument;
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument, const CryptoManager::VerificationStatus verificationStatus)
+{
+    argument.beginStructure();
+    argument << static_cast<int>(verificationStatus);
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, CryptoManager::VerificationStatus &verificationStatus)
+{
+    int data = 0;
+    argument.beginStructure();
+    argument >> data;
+    argument.endStructure();
+    verificationStatus = static_cast<CryptoManager::VerificationStatus>(data);
+    return argument;
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument, const CryptoManager::VerificationStatusType verificationStatusType)
+{
+    argument.beginStructure();
+    argument << static_cast<int>(verificationStatusType);
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, CryptoManager::VerificationStatusType &verificationStatusType)
+{
+    int data = 0;
+    argument.beginStructure();
+    argument >> data;
+    argument.endStructure();
+    verificationStatusType = static_cast<CryptoManager::VerificationStatusType>(data);
     return argument;
 }
 

--- a/lib/Crypto/serialization_p.h
+++ b/lib/Crypto/serialization_p.h
@@ -59,9 +59,12 @@ QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::Crypt
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::CryptoManager::KeyDerivationFunction &kdf) SAILFISH_CRYPTO_API;
 QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::CryptoManager::Operation operation) SAILFISH_CRYPTO_API;
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::CryptoManager::Operation &operation) SAILFISH_CRYPTO_API;
-
 QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::CryptoManager::Operations operations) SAILFISH_CRYPTO_API;
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::CryptoManager::Operations &operations) SAILFISH_CRYPTO_API;
+QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::CryptoManager::VerificationStatusType verificationStatusType) SAILFISH_CRYPTO_API;
+const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::CryptoManager::VerificationStatusType &verificationStatusType) SAILFISH_CRYPTO_API;
+QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus) SAILFISH_CRYPTO_API;
+const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::CryptoManager::VerificationStatus &verificationStatus) SAILFISH_CRYPTO_API;
 
 QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Crypto::Key::Component component) SAILFISH_CRYPTO_API;
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Crypto::Key::Component &component) SAILFISH_CRYPTO_API;

--- a/lib/Crypto/verifyrequest.h
+++ b/lib/Crypto/verifyrequest.h
@@ -33,7 +33,7 @@ class SAILFISH_CRYPTO_API VerifyRequest : public Sailfish::Crypto::Request
     Q_PROPERTY(Sailfish::Crypto::CryptoManager::SignaturePadding padding READ padding WRITE setPadding NOTIFY paddingChanged)
     Q_PROPERTY(Sailfish::Crypto::CryptoManager::DigestFunction digestFunction READ digestFunction WRITE setDigestFunction NOTIFY digestFunctionChanged)
     Q_PROPERTY(QString cryptoPluginName READ cryptoPluginName WRITE setCryptoPluginName NOTIFY cryptoPluginNameChanged)
-    Q_PROPERTY(bool verified READ verified NOTIFY verifiedChanged)
+    Q_PROPERTY(Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus READ verificationStatus NOTIFY verificationStatusChanged)
 
 public:
     VerifyRequest(QObject *parent = Q_NULLPTR);
@@ -57,7 +57,7 @@ public:
     QString cryptoPluginName() const;
     void setCryptoPluginName(const QString &pluginName);
 
-    bool verified() const;
+    Sailfish::Crypto::CryptoManager::VerificationStatus verificationStatus() const;
 
     Sailfish::Crypto::Request::Status status() const Q_DECL_OVERRIDE;
     Sailfish::Crypto::Result result() const Q_DECL_OVERRIDE;
@@ -78,7 +78,7 @@ Q_SIGNALS:
     void paddingChanged();
     void digestFunctionChanged();
     void cryptoPluginNameChanged();
-    void verifiedChanged();
+    void verificationStatusChanged();
 
 private:
     QScopedPointer<VerifyRequestPrivate> const d_ptr;

--- a/lib/Crypto/verifyrequest_p.h
+++ b/lib/Crypto/verifyrequest_p.h
@@ -37,7 +37,7 @@ public:
     Sailfish::Crypto::CryptoManager::SignaturePadding m_padding;
     Sailfish::Crypto::CryptoManager::DigestFunction m_digestFunction;
     QString m_cryptoPluginName;
-    bool m_verified;
+    Sailfish::Crypto::CryptoManager::VerificationStatus m_verificationStatus;
 
     QScopedPointer<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;

--- a/lib/CryptoPluginApi/extensionplugins.cpp
+++ b/lib/CryptoPluginApi/extensionplugins.cpp
@@ -497,11 +497,11 @@ CryptoPlugin::~CryptoPlugin()
  */
 
 /*!
- * \fn CryptoPlugin::verify(const QByteArray &signature, const QByteArray &data, const Sailfish::Crypto::Key &key, Sailfish::Crypto::CryptoManager::SignaturePadding padding, Sailfish::Crypto::CryptoManager::DigestFunction digestFunction, const QVariantMap &customParameters, bool *verified)
+ * \fn CryptoPlugin::verify(const QByteArray &signature, const QByteArray &data, const Sailfish::Crypto::Key &key, Sailfish::Crypto::CryptoManager::SignaturePadding padding, Sailfish::Crypto::CryptoManager::DigestFunction digestFunction, const QVariantMap &customParameters, int *verificationStatus)
  * \brief Attempts to verify that the given \a signature was generated from the
  *        input \a data after being padded according to the \a padding, using
  *        the specified \a digestFunction and signing key \a key, and writes
- *        verification state to the out-parameter \a verified.
+ *        verification state to the out-parameter \a verificationStatus.
  *
  * If the plugin itself is locked, this function should return a
  * Sailfish::Crypto::Result with the result code set to
@@ -532,16 +532,16 @@ CryptoPlugin::~CryptoPlugin()
  *
  * If the plugin was able to successfully determine that the given \a signature
  * was generated from the input \a data with the specified \a key then it
- * should write the value \c true to the \a verified out-parameter and return a
- * Sailfish::Crypto::Result with the result code set to
- * Sailfish::Crypto::Result::Succeeded.
+ * should write Sailfish::Crypto::CryptoManager::VerificationSucceeded to the
+ * \a verificationStatus out-parameter and return a Sailfish::Crypto::Result with the
+ * result code set to Sailfish::Crypto::Result::Succeeded.
  *
  * If the plugin was able to determine that the given \a signature was not
  * generated from the input \a data with the specified \a key then it
- * should write the value \c false to the \a verified out-parameter and return
- * a Sailfish::Crypto::Result with the result code set to
- * Sailfish::Crypto::Result::Succeeded (as it was successfully able to
- * determine that the signature was not correct).
+ * should write the appropriate Sailfish::Crypto::CryptoManager::VerificationStatus
+ * value to the \a verificationStatus out-parameter and return a Sailfish::Crypto::Result
+ * with the result code set to Sailfish::Crypto::Result::Succeeded (as it was
+ * successfully able to determine that the signature was not correct).
  */
 
 /*!
@@ -574,7 +574,7 @@ CryptoPlugin::~CryptoPlugin()
  */
 
 /*!
- * \fn CryptoPlugin::decrypt(const QByteArray &data, const QByteArray &iv, const Sailfish::Crypto::Key &key, Sailfish::Crypto::CryptoManager::BlockMode blockMode, Sailfish::Crypto::CryptoManager::EncryptionPadding padding, const QByteArray &authenticationData, const QByteArray &authenticationTag, const QVariantMap &customParameters, QByteArray *decrypted, bool *verified)
+ * \fn CryptoPlugin::decrypt(const QByteArray &data, const QByteArray &iv, const Sailfish::Crypto::Key &key, Sailfish::Crypto::CryptoManager::BlockMode blockMode, Sailfish::Crypto::CryptoManager::EncryptionPadding padding, const QByteArray &authenticationData, const QByteArray &authenticationTag, const QVariantMap &customParameters, QByteArray *decrypted, Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
  * \brief Decrypt the input \a data given an initialization vector \a iv using
  *        the specified \a key and (if applicable) \a blockMode and \a padding,
  *        and write the decrypted data to the out-parameter \a decrypted.
@@ -594,10 +594,10 @@ CryptoPlugin::~CryptoPlugin()
  * successfully decrypting the input \a data the plugin should also calculate
  * the authentication tag and compare it to the given \a authenticationTag to
  * see if it matches, and should write the comparison result to the
- * \a verified out-parameter.  Note that if the decryption succeeded but the
+ * \a verificationStatus out-parameter.  Note that if the decryption succeeded but the
  * authentication tag comparison failed, the result of the operation should
  * still be Sailfish::Crypto::Result::Succeeded, but clients are required to
- * explicitly check the value of the \a verified out-parameter to determine
+ * explicitly check the value of the \a verificationStatus out-parameter to determine
  * whether the input data had been tampered with by an attacker.
  *
  * The \a key may be either a full key (that is, containing private or secret
@@ -684,14 +684,14 @@ CryptoPlugin::~CryptoPlugin()
  */
 
 /*!
- * \fn CryptoPlugin::finalizeCipherSession(quint64 clientId, const QByteArray &data, const QVariantMap &customParameters, quint32 cipherSessionToken, QByteArray *generatedData, bool *verified)
+ * \fn CryptoPlugin::finalizeCipherSession(quint64 clientId, const QByteArray &data, const QVariantMap &customParameters, quint32 cipherSessionToken, QByteArray *generatedData, Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
  * \brief Finalizes the cipher session identified by the specified
  *        \a cipherSessionToken for the client identified by the given
  *        \a clientId, with the specified finalization \a data,
  *        and writes any generated data (e.g. ciphertext, plaintext
  *        or signature data) to the out-parameter \a generatedData,
  *        and the result of any verification to the out-parameter
- *        \a verified.
+ *        \a verificationStatus.
  *
  * If the plugin itself is locked, this function should return a
  * Sailfish::Crypto::Result with the result code set to
@@ -709,7 +709,7 @@ CryptoPlugin::~CryptoPlugin()
  * If the cipher session operation is decryption with a symmetric algorithm
  * and the block mode is GCM, or if the cipher session operation is
  * verification of a signature, then the result of the verification should
- * be written to the \a verified out-parameter, otherwise that out-parameter
+ * be written to the \a verificationStatus out-parameter, otherwise that out-parameter
  * can be ignored.
  *
  * Note that if the cipher session operation is decryption with a symmetric
@@ -719,6 +719,6 @@ CryptoPlugin::~CryptoPlugin()
  * Sailfish::Crypto::Result::Succeeded (as it was successfully able to
  * decrypt the input data, and determine that the input data had been
  * tampered with).  In that case, the client must check the value of the
- * \a verified out-parameter to ascertain whether or not the decrypted
+ * \a verificationStatus out-parameter to ascertain whether or not the decrypted
  * data can be trusted.
  */

--- a/lib/CryptoPluginApi/extensionplugins.h
+++ b/lib/CryptoPluginApi/extensionplugins.h
@@ -133,7 +133,7 @@ public:
             Sailfish::Crypto::CryptoManager::SignaturePadding padding,
             Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
             const QVariantMap &customParameters,
-            bool *verified) = 0;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) = 0;
 
     virtual Sailfish::Crypto::Result encrypt(
             const QByteArray &data,
@@ -156,7 +156,7 @@ public:
             const QByteArray &authenticationTag,
             const QVariantMap &customParameters,
             QByteArray *decrypted,
-            bool *verified) = 0;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) = 0;
 
     virtual Sailfish::Crypto::Result initializeCipherSession(
             quint64 clientId,
@@ -189,7 +189,7 @@ public:
             const QVariantMap &customParameters,
             quint32 cipherSessionToken,
             QByteArray *generatedData,
-            bool *verified) = 0;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) = 0;
 };
 
 } // namespace Crypto

--- a/lib/SecretsPluginApi/extensionplugins.cpp
+++ b/lib/SecretsPluginApi/extensionplugins.cpp
@@ -1291,7 +1291,7 @@ EncryptedStoragePlugin::~EncryptedStoragePlugin()
  * \fn AuthenticationPlugin::authenticationTypes() const
  * \brief Return the types of authentication which are supported by this plugin
  *
- * These are the ways in which the user's identity may be verified.
+ * These are the ways in which the user's identity may be verificationStatus.
  */
 
 /*!
@@ -1330,7 +1330,7 @@ AuthenticationPlugin::~AuthenticationPlugin()
  *
  * When complete, the plugin should emit the authenticationCompleted()
  * signal, with the result parameter having the appropriate result code
- * set depending on whether the user successfully verified their identity
+ * set depending on whether the user successfully verificationStatus their identity
  * or not.
  *
  * If the plugin itself is locked, this function should return a

--- a/plugins/exampleusbtokenplugin/cryptoplugin.cpp
+++ b/plugins/exampleusbtokenplugin/cryptoplugin.cpp
@@ -253,7 +253,7 @@ ExampleUsbTokenPlugin::verify(
         CryptoManager::SignaturePadding padding,
         CryptoManager::DigestFunction digestFunction,
         const QVariantMap &customParameters,
-        bool *verified)
+        Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
 {
     Key fullKey;
     Sailfish::Crypto::Result keyResult = getFullKey(key, &fullKey);
@@ -268,7 +268,7 @@ ExampleUsbTokenPlugin::verify(
                 padding,
                 digestFunction,
                 customParameters,
-                verified);
+                verificationStatus);
 }
 
 Result
@@ -312,7 +312,7 @@ ExampleUsbTokenPlugin::decrypt(
         const QByteArray &authenticationTag,
         const QVariantMap &customParameters,
         QByteArray *decrypted,
-        bool *verified)
+        Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
 {
     Key fullKey;
     Sailfish::Crypto::Result keyResult = getFullKey(key, &fullKey);
@@ -330,7 +330,7 @@ ExampleUsbTokenPlugin::decrypt(
                 authenticationTag,
                 customParameters,
                 decrypted,
-                verified);
+                verificationStatus);
 }
 
 Result
@@ -402,7 +402,7 @@ ExampleUsbTokenPlugin::finalizeCipherSession(
         const QVariantMap &customParameters,
         quint32 cipherSessionToken,
         QByteArray *generatedData,
-        bool *verified)
+        Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
 {
     return m_usbInterface.finalizeCipherSession(
                 clientId,
@@ -410,5 +410,5 @@ ExampleUsbTokenPlugin::finalizeCipherSession(
                 customParameters,
                 cipherSessionToken,
                 generatedData,
-                verified);
+                verificationStatus);
 }

--- a/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
+++ b/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
@@ -202,7 +202,7 @@ public:
             Sailfish::Crypto::CryptoManager::SignaturePadding padding,
             Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
             const QVariantMap &customParameters,
-            bool *verified) Q_DECL_OVERRIDE;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result encrypt(
             const QByteArray &data,
@@ -225,7 +225,7 @@ public:
             const QByteArray &authenticationTag,
             const QVariantMap &customParameters,
             QByteArray *decrypted,
-            bool *verified);
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus);
 
     Sailfish::Crypto::Result initializeCipherSession(
             quint64 clientId,
@@ -258,7 +258,7 @@ public:
             const QVariantMap &customParameters,
             quint32 cipherSessionToken,
             QByteArray *generatedData,
-            bool *verified) Q_DECL_OVERRIDE;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) Q_DECL_OVERRIDE;
 
 private:
     Sailfish::Crypto::Key readDefaultKeyFromUsbToken() const;

--- a/plugins/opensslcryptoplugin/evp/evp.cpp
+++ b/plugins/opensslcryptoplugin/evp/evp.cpp
@@ -157,6 +157,9 @@ int OpenSslEvp::pkcs5_pbkdf2_hmac(const char *pass, int passlen,
                                           int plaintext_length,
                                           unsigned char **encrypted)
 
+    Implemented according to:
+    https://wiki.openssl.org/index.php/EVP_Symmetric_Encryption_and_Decryption
+
     Encrypts the \a plaintext of the specified \a plaintext_length with the
     given symmetric encryption \a key, using the specified cipher. The result
     is stored in \a encrypted. The caller owns the content of the
@@ -322,6 +325,27 @@ int OpenSslEvp::aes_decrypt_ciphertext(const EVP_CIPHER *evp_cipher,
     return plaintext_length;
 }
 
+/*
+    int aes_auth_encrypt_plaintext(const EVP_CIPHER *evp_cipher,
+                                   const unsigned char *init_vector,
+                                   int init_vector_length,
+                                   const unsigned char *key,
+                                   int key_length,
+                                   const unsigned char *auth,
+                                   int auth_length,
+                                   const unsigned char *plaintext,
+                                   int plaintext_length,
+                                   unsigned char **encrypted,
+                                   unsigned char **tag,
+                                   int tag_length)
+
+    Implemented according to:
+    https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption
+
+    Equivalent to aes_encrypt_plaintext() but with authentication added. Authentication
+    is done with the specified \a auth and \a auth_length authentication data, and
+    the specified \a tag and \a tag_length for the authentication tag.
+ */
 int OpenSslEvp::aes_auth_encrypt_plaintext(const EVP_CIPHER *evp_cipher,
                                            const unsigned char *init_vector,
                                            int init_vector_length,
@@ -473,6 +497,28 @@ int OpenSslEvp::aes_auth_encrypt_plaintext(const EVP_CIPHER *evp_cipher,
     return ciphertext_length;
 }
 
+/*
+    int aes_auth_decrypt_ciphertext(const EVP_CIPHER *evp_cipher,
+                                    const unsigned char *init_vector,
+                                    int init_vector_length,
+                                    const unsigned char *key,
+                                    int key_length,
+                                    const unsigned char *auth,
+                                    int auth_length,
+                                    unsigned char *tag,
+                                    int tag_length,
+                                    const unsigned char *ciphertext,
+                                    int ciphertext_length,
+                                    unsigned char **decrypted,
+                                    int *verified)
+
+    Implemented according to:
+    https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption
+
+    Equivalent to aes_decrypt_plaintext() but with authentication added. Authentication
+    is done with the specified \a auth and \a auth_length authentication data, and
+    the specified \a tag and \a tag_length for the authentication tag.
+ */
 int OpenSslEvp::aes_auth_decrypt_ciphertext(const EVP_CIPHER *evp_cipher,
                                             const unsigned char *init_vector,
                                             int init_vector_length,

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.h
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.h
@@ -142,7 +142,7 @@ public:
             Sailfish::Crypto::CryptoManager::SignaturePadding padding,
             Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
             const QVariantMap &customParameters,
-            bool *verified) Q_DECL_OVERRIDE;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result encrypt(
             const QByteArray &data,
@@ -165,7 +165,7 @@ public:
             const QByteArray &authenticationTag,
             const QVariantMap &customParameters,
             QByteArray *decrypted,
-            bool *verified) Q_DECL_OVERRIDE;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result initializeCipherSession(
             quint64 clientId,
@@ -198,7 +198,7 @@ public:
             const QVariantMap &customParameters,
             quint32 cipherSessionToken,
             QByteArray *generatedData,
-            bool *verified) Q_DECL_OVERRIDE;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) Q_DECL_OVERRIDE;
 
 private:
     QByteArray aes_encrypt_plaintext(Sailfish::Crypto::CryptoManager::BlockMode blockMode, const QByteArray &plaintext, const QByteArray &key, const QByteArray &init_vector);
@@ -244,7 +244,7 @@ private:
             const QByteArray &authenticationData,
             const QByteArray &authenticationTag,
             QByteArray *decrypted,
-            bool *verified);
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus);
 
     Sailfish::Crypto::Result decryptAsymmetric(
             const QByteArray &data,

--- a/plugins/sqlcipherplugin/cryptoplugin.cpp
+++ b/plugins/sqlcipherplugin/cryptoplugin.cpp
@@ -363,7 +363,7 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::verify(
         Sailfish::Crypto::CryptoManager::SignaturePadding padding,
         Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
         const QVariantMap &customParameters,
-        bool *verified)
+        Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
 {
     Sailfish::Crypto::Key fullKey;
     Sailfish::Crypto::Result keyResult = getFullKey(key, &fullKey);
@@ -371,7 +371,7 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::verify(
         return keyResult;
     }
 
-    return m_opensslCryptoPlugin.verify(signature, data, fullKey, padding, digestFunction, customParameters, verified);
+    return m_opensslCryptoPlugin.verify(signature, data, fullKey, padding, digestFunction, customParameters, verificationStatus);
 }
 
 Sailfish::Crypto::Result
@@ -406,7 +406,7 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::decrypt(
         const QByteArray &authenticationTag,
         const QVariantMap &customParameters,
         QByteArray *decrypted,
-        bool *verified)
+        Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
 {
     Sailfish::Crypto::Key fullKey;
     Sailfish::Crypto::Result keyResult = getFullKey(key, &fullKey);
@@ -414,7 +414,7 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::decrypt(
         return keyResult;
     }
 
-    return m_opensslCryptoPlugin.decrypt(data, iv, fullKey, blockMode, padding, authenticationData, authenticationTag, customParameters, decrypted, verified);
+    return m_opensslCryptoPlugin.decrypt(data, iv, fullKey, blockMode, padding, authenticationData, authenticationTag, customParameters, decrypted, verificationStatus);
 }
 
 Sailfish::Crypto::Result
@@ -483,12 +483,12 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::finalizeCipherSession(
         const QVariantMap &customParameters,
         quint32 cipherSessionToken,
         QByteArray *generatedData,
-        bool *verified)
+        Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus)
 {
     return m_opensslCryptoPlugin.finalizeCipherSession(clientId,
                                                        data,
                                                        customParameters,
                                                        cipherSessionToken,
                                                        generatedData,
-                                                       verified);
+                                                       verificationStatus);
 }

--- a/plugins/sqlcipherplugin/sqlcipherplugin.h
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.h
@@ -192,7 +192,7 @@ public:
             Sailfish::Crypto::CryptoManager::SignaturePadding padding,
             Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
             const QVariantMap &customParameters,
-            bool *verified) Q_DECL_OVERRIDE;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result encrypt(
             const QByteArray &data,
@@ -215,7 +215,7 @@ public:
             const QByteArray &authenticationTag,
             const QVariantMap &customParameters,
             QByteArray *decrypted,
-            bool *verified);
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus);
 
     Sailfish::Crypto::Result initializeCipherSession(
             quint64 clientId,
@@ -248,7 +248,7 @@ public:
             const QVariantMap &customParameters,
             quint32 cipherSessionToken,
             QByteArray *generatedData,
-            bool *verified) Q_DECL_OVERRIDE;
+            Sailfish::Crypto::CryptoManager::VerificationStatus *verificationStatus) Q_DECL_OVERRIDE;
 
 private:
     static QString databaseDirPath(bool isTestPlugin, const QString &databaseSubdir);

--- a/tests/Crypto/tst_crypto/tst_crypto.cpp
+++ b/tests/Crypto/tst_crypto/tst_crypto.cpp
@@ -263,7 +263,7 @@ void tst_crypto::generateKeyEncryptDecrypt()
     QCOMPARE(authenticationTag.isEmpty(), authData.isEmpty());
 
     // test decrypting the ciphertext, and ensure that the roundtrip works.
-    QDBusPendingReply<Result, QByteArray, bool> decryptReply = cm.decrypt(
+    QDBusPendingReply<Result, QByteArray, CryptoManager::VerificationStatus> decryptReply = cm.decrypt(
             encrypted,
             initVector,
             fullKey,
@@ -278,10 +278,10 @@ void tst_crypto::generateKeyEncryptDecrypt()
     QCOMPARE(decryptReply.argumentAt<0>().errorMessage(), QString());
     QCOMPARE(decryptReply.argumentAt<0>().code(), Result::Succeeded);
     QByteArray decrypted = decryptReply.argumentAt<1>();
-    bool verified = decryptReply.argumentAt<2>();
+    CryptoManager::VerificationStatus verificationStatus = decryptReply.argumentAt<2>();
     QVERIFY(!decrypted.isEmpty());
     QCOMPARE(decrypted, plaintext);
-    QCOMPARE(verified, !authenticationTag.isEmpty());
+    QCOMPARE(verificationStatus == CryptoManager::VerificationSucceeded, !authenticationTag.isEmpty());
 }
 
 #include "tst_crypto.moc"

--- a/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
+++ b/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
@@ -235,7 +235,7 @@ void tst_cryptosecrets::secretsStoredKey()
     QVERIFY(encrypted != plaintext);
 
     // test decrypting the ciphertext, and ensure that the roundtrip works.
-    QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, bool> decryptReply = cm.decrypt(
+    QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, Sailfish::Crypto::CryptoManager::VerificationStatus> decryptReply = cm.decrypt(
             encrypted,
             initVector,
             keyReference,
@@ -482,7 +482,7 @@ void tst_cryptosecrets::cryptoStoredKey()
     QVERIFY(encrypted != plaintext);
 
     // test decrypting the ciphertext, and ensure that the roundtrip works.
-    QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, bool> decryptReply = cm.decrypt(
+    QDBusPendingReply<Sailfish::Crypto::Result, QByteArray, Sailfish::Crypto::CryptoManager::VerificationStatus> decryptReply = cm.decrypt(
             encrypted,
             initVector,
             keyReference,

--- a/tests/qml/tst_qml_signing/tst_qml_signing.qml
+++ b/tests/qml/tst_qml_signing/tst_qml_signing.qml
@@ -105,7 +105,7 @@ TestCase {
         verifyRequest.waitForFinished()
         compare(verifyRequest.result.code, 0, "VerifyRequest failed:" + String(verifyRequest.result))
 
-        compare(verifyRequest.verified, true, "The signature MUST be verified successfully")
+        compare(verifyRequest.verified, CryptoManager.VerificationSuccess, "The signature MUST be verified successfully")
     }
 
     SecretManager {

--- a/tools/secrets-tool/commandhelper.cpp
+++ b/tools/secrets-tool/commandhelper.cpp
@@ -664,7 +664,7 @@ void CommandHelper::cryptoRequestStatusChanged()
         stdoutFile.write(r->signature());
     } else if (m_command == QStringLiteral("--verify")) {
         Sailfish::Crypto::VerifyRequest *r = qobject_cast<Sailfish::Crypto::VerifyRequest*>(m_cryptoRequest.data());
-        if (r->verified()) {
+        if (r->verificationStatus() == Sailfish::Crypto::CryptoManager::VerificationSucceeded) {
             qInfo() << "Verification SUCCEEDED!";
         } else {
             qInfo() << "Verification FAILED!";


### PR DESCRIPTION
… values. Contributes to JB#40058

Add CryptoManager::VerificationResult for more detailed verification
result codes and use this in the library and plugins instead of bool
values.