### PR TITLE
[sailfish-crypto] Add customParameters arg to StoredKey/StoredKeyIdentifiers. Contributes to JB#40058

### DIFF
--- a/daemon/CryptoImpl/crypto_p.h
+++ b/daemon/CryptoImpl/crypto_p.h
@@ -135,6 +135,7 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "      <method name=\"storedKey\">\n"
     "          <arg name=\"identifier\" type=\"(sss)\" direction=\"in\" />\n"
     "          <arg name=\"keyComponents\" type=\"(i)\" direction=\"in\" />\n"
+    "          <arg name=\"customParameters\" type=\"a{sv}\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"key\" type=\"(ay)\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"Sailfish::Crypto::Key::Identifier\" />\n"
@@ -151,6 +152,7 @@ class CryptoDBusObject : public QObject, protected QDBusContext
     "      <method name=\"storedKeyIdentifiers\">\n"
     "          <arg name=\"storagePluginName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"collectionName\" type=\"s\" direction=\"in\" />\n"
+    "          <arg name=\"customParameters\" type=\"a{sv}\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iiis)\" direction=\"out\" />\n"
     "          <arg name=\"identifiers\" type=\"a(sss)\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Crypto::Result\" />\n"
@@ -393,6 +395,7 @@ public Q_SLOTS:
     void storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
             Sailfish::Crypto::Key::Components keyComponents,
+            const QVariantMap &customParameters,
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result,
             Sailfish::Crypto::Key &key);
@@ -405,6 +408,7 @@ public Q_SLOTS:
     void storedKeyIdentifiers(
             const QString &storagePluginName,
             const QString &collectionName,
+            const QVariantMap &customParameters,
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result,
             QVector<Sailfish::Crypto::Key::Identifier> &identifiers);

--- a/daemon/CryptoImpl/cryptopluginfunctionwrappers.cpp
+++ b/daemon/CryptoImpl/cryptopluginfunctionwrappers.cpp
@@ -157,21 +157,23 @@ KeyResult CryptoPluginFunctionWrapper::generateKey(
 KeyResult CryptoPluginFunctionWrapper::storedKey(
         CryptoPlugin *plugin,
         const Key::Identifier &identifier,
-        Key::Components keyComponents)
+        Key::Components keyComponents,
+        const QVariantMap &customParameters)
 {
     Key key;
     key.setIdentifier(identifier);
     Result result = plugin->storedKey(
-                identifier, keyComponents, &key);
+                identifier, keyComponents, customParameters, &key);
     return KeyResult(result, key);
 }
 
 IdentifiersResult CryptoPluginFunctionWrapper::storedKeyIdentifiers(
         CryptoPlugin *plugin,
-        const QString &collectionName)
+        const QString &collectionName,
+        const QVariantMap &customParameters)
 {
     QVector<Key::Identifier> identifiers;
-    Result result = plugin->storedKeyIdentifiers(collectionName, &identifiers);
+    Result result = plugin->storedKeyIdentifiers(collectionName, customParameters, &identifiers);
     return IdentifiersResult(result, identifiers);
 }
 

--- a/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
+++ b/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
@@ -240,11 +240,13 @@ KeyResult generateKey(
 KeyResult storedKey(
         Sailfish::Crypto::CryptoPlugin *plugin,
         const Sailfish::Crypto::Key::Identifier &identifier,
-        Sailfish::Crypto::Key::Components keyComponents);
+        Sailfish::Crypto::Key::Components keyComponents,
+        const QVariantMap &customParameters);
 
 IdentifiersResult storedKeyIdentifiers(
         Sailfish::Crypto::CryptoPlugin *plugin,
-        const QString &collectionName);
+        const QString &collectionName,
+        const QVariantMap &customParameters);
 
 DataResult calculateDigest(
         const PluginAndCustomParams &pluginAndCustomParams,

--- a/daemon/CryptoImpl/cryptopluginwrapper.cpp
+++ b/daemon/CryptoImpl/cryptopluginwrapper.cpp
@@ -29,6 +29,7 @@ CryptoStoragePluginWrapper::~CryptoStoragePluginWrapper()
 Sailfish::Secrets::Result
 CryptoStoragePluginWrapper::keyNames(
         const QString &collectionName,
+        const QVariantMap &customParameters,
         QStringList *keyNames)
 {
     QStringList knownKeys;
@@ -39,7 +40,7 @@ CryptoStoragePluginWrapper::keyNames(
 
     QVector<Key::Identifier> identifiers;
     if (m_cryptoPlugin->canStoreKeys()) {
-        Result result = m_cryptoPlugin->storedKeyIdentifiers(collectionName, &identifiers);
+        Result result = m_cryptoPlugin->storedKeyIdentifiers(collectionName, customParameters, &identifiers);
         if (result != Result::Succeeded) {
             if (result.storageErrorCode() != 0) {
                 return Sailfish::Secrets::Result(static_cast<Sailfish::Secrets::Result::ErrorCode>(result.storageErrorCode()),
@@ -65,9 +66,10 @@ CryptoStoragePluginWrapper::keyNames(
 Sailfish::Crypto::Result
 CryptoStoragePluginWrapper::storedKeyIdentifiers(
         const QString &collectionName,
+        const QVariantMap &customParameters,
         QVector<Sailfish::Crypto::Key::Identifier> *identifiers)
 {
-    return m_cryptoPlugin->storedKeyIdentifiers(collectionName, identifiers);
+    return m_cryptoPlugin->storedKeyIdentifiers(collectionName, customParameters, identifiers);
 }
 
 Result

--- a/daemon/CryptoImpl/cryptopluginwrapper_p.h
+++ b/daemon/CryptoImpl/cryptopluginwrapper_p.h
@@ -34,10 +34,13 @@ public:
                                bool autotestMode);
     ~CryptoStoragePluginWrapper();
 
-    Sailfish::Secrets::Result keyNames(const QString &collectionName, QStringList *keyNames) Q_DECL_OVERRIDE;
+    Sailfish::Secrets::Result keyNames(const QString &collectionName,
+                                       const QVariantMap &customParameters,
+                                       QStringList *keyNames) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result storedKeyIdentifiers(
             const QString &collectionName,
+            const QVariantMap &customParameters,
             QVector<Sailfish::Crypto::Key::Identifier> *identifiers);
 
     Sailfish::Crypto::Result generateAndStoreKey(

--- a/daemon/CryptoImpl/cryptorequestprocessor.cpp
+++ b/daemon/CryptoImpl/cryptorequestprocessor.cpp
@@ -1820,6 +1820,7 @@ Daemon::ApiImpl::RequestProcessor::decrypt2(
         outParams << QVariant::fromValue<QByteArray>(QByteArray());
         outParams << QVariant::fromValue<CryptoManager::VerificationStatus>(CryptoManager::VerificationFailed);
         m_requestQueue->requestFinished(requestId, outParams);
+        return;
     }
 
     QFutureWatcher<VerifiedDataResult> *watcher = new QFutureWatcher<VerifiedDataResult>(this);

--- a/daemon/CryptoImpl/cryptorequestprocessor.cpp
+++ b/daemon/CryptoImpl/cryptorequestprocessor.cpp
@@ -1068,6 +1068,7 @@ Daemon::ApiImpl::RequestProcessor::storedKey(
         quint64 requestId,
         const Key::Identifier &identifier,
         Key::Components keyComponents,
+        const QVariantMap &customParameters,
         Key *key)
 {
     // TODO: access control
@@ -1087,7 +1088,8 @@ Daemon::ApiImpl::RequestProcessor::storedKey(
                     CryptoPluginFunctionWrapper::storedKey,
                     m_cryptoPlugins[identifier.storagePluginName()],
                     identifier,
-                    keyComponents);
+                    keyComponents,
+                    customParameters);
 
         watcher->setFuture(future);
         connect(watcher, &QFutureWatcher<KeyResult>::finished, [=] {
@@ -1184,11 +1186,12 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiers(
         quint64 requestId,
         const QString &storagePluginName,
         const QString &collectionName,
+        const QVariantMap &customParameters,
         QVector<Key::Identifier> *identifiers)
 {
     // TODO: access control
     Result retn = transformSecretsResult(m_secrets->storedKeyIdentifiers(
-                callerPid, requestId, collectionName, storagePluginName, identifiers));
+                callerPid, requestId, collectionName, storagePluginName, customParameters, identifiers));
 
     if (retn.code() == Result::Pending) {
         // asynchronous flow, will call back to storedKeyIdentifiers2().

--- a/daemon/CryptoImpl/cryptorequestprocessor_p.h
+++ b/daemon/CryptoImpl/cryptorequestprocessor_p.h
@@ -151,6 +151,7 @@ public:
             quint64 requestId,
             const Sailfish::Crypto::Key::Identifier &identifier,
             Key::Components keyComponents,
+            const QVariantMap &customParameters,
             Sailfish::Crypto::Key *key);
 
     Sailfish::Crypto::Result deleteStoredKey(
@@ -163,6 +164,7 @@ public:
             quint64 requestId,
             const QString &storagePluginName,
             const QString &collectionName,
+            const QVariantMap &customParameters,
             QVector<Sailfish::Crypto::Key::Identifier> *identifiers);
 
     Sailfish::Crypto::Result calculateDigest(

--- a/daemon/SecretsImpl/pluginfunctionwrappers_p.h
+++ b/daemon/SecretsImpl/pluginfunctionwrappers_p.h
@@ -195,13 +195,15 @@ bool modifyMasterLockPlugins(
 IdentifiersResult storedKeyIdentifiers(
         StoragePluginWrapper *storagePlugin,
         EncryptedStoragePluginWrapper *encryptedStoragePlugin,
-        Sailfish::Crypto::Daemon::ApiImpl::CryptoStoragePluginWrapper *cryptoStoragePlugin);
+        Sailfish::Crypto::Daemon::ApiImpl::CryptoStoragePluginWrapper *cryptoStoragePlugin,
+        const QVariantMap &customParameters);
 
 IdentifiersResult storedKeyIdentifiersFromCollection(
         StoragePluginWrapper *storagePlugin,
         EncryptedStoragePluginWrapper *encryptedStoragePlugin,
         Sailfish::Crypto::Daemon::ApiImpl::CryptoStoragePluginWrapper *cryptoStoragePlugin,
-        const CollectionInfo &collectionInfo);
+        const CollectionInfo &collectionInfo,
+        const QVariantMap &customParameters);
 
 namespace EncryptionPluginFunctionWrapper {
     struct DataResult {

--- a/daemon/SecretsImpl/pluginwrapper.cpp
+++ b/daemon/SecretsImpl/pluginwrapper.cpp
@@ -223,8 +223,10 @@ Result StoragePluginWrapper::secretNames(
 
 Result StoragePluginWrapper::keyNames(
         const QString &collectionName,
+        const QVariantMap &customParameters,
         QStringList *keyNames)
 {
+    Q_UNUSED(customParameters) // only CryptoStorage plugins support custom parameters.
     return m_metadataDb.keyNames(collectionName, keyNames);
 }
 
@@ -573,8 +575,10 @@ Result EncryptedStoragePluginWrapper::secretNames(
 
 Result EncryptedStoragePluginWrapper::keyNames(
         const QString &collectionName,
+        const QVariantMap &customParameters,
         QStringList *keyNames)
 {
+    Q_UNUSED(customParameters) // only CryptoStorage plugins support custom parameters.
     return m_metadataDb.keyNames(collectionName, keyNames);
 }
 

--- a/daemon/SecretsImpl/pluginwrapper_p.h
+++ b/daemon/SecretsImpl/pluginwrapper_p.h
@@ -42,7 +42,7 @@ public:
 
     virtual Sailfish::Secrets::Result collectionMetadata(const QString &collectionName, CollectionMetadata *metadata) = 0;
     virtual Sailfish::Secrets::Result secretMetadata(const QString &collectionName, const QString &secretName, SecretMetadata *metadata) = 0;
-    virtual Sailfish::Secrets::Result keyNames(const QString &collectionName, QStringList *keyNames) = 0;
+    virtual Sailfish::Secrets::Result keyNames(const QString &collectionName, const QVariantMap &customParameters, QStringList *keyNames) = 0;
     virtual Sailfish::Secrets::Result collectionNames(QStringList *names) const = 0;
     virtual Sailfish::Secrets::Result secretNames(const QString &collectionName, QStringList *secretNames) const = 0;
 
@@ -80,7 +80,7 @@ public:
     bool initialize(const QByteArray &masterLockKey = QByteArray()) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result collectionMetadata(const QString &collectionName, CollectionMetadata *metadata) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result secretMetadata(const QString &collectionName, const QString &secretName, SecretMetadata *metadata) Q_DECL_OVERRIDE;
-    Sailfish::Secrets::Result keyNames(const QString &collectionName, QStringList *keyNames) Q_DECL_OVERRIDE;
+    Sailfish::Secrets::Result keyNames(const QString &collectionName, const QVariantMap &customParameters, QStringList *keyNames) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result collectionNames(QStringList *names) const Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result secretNames(const QString &collectionName, QStringList *secretNames) const Q_DECL_OVERRIDE;
 
@@ -112,7 +112,7 @@ public:
     bool initialize(const QByteArray &masterLockKey = QByteArray()) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result collectionMetadata(const QString &collectionName, CollectionMetadata *metadata) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result secretMetadata(const QString &collectionName, const QString &secretName, SecretMetadata *metadata) Q_DECL_OVERRIDE;
-    Sailfish::Secrets::Result keyNames(const QString &collectionName, QStringList *keyNames) Q_DECL_OVERRIDE;
+    Sailfish::Secrets::Result keyNames(const QString &collectionName, const QVariantMap &customParameters, QStringList *keyNames) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result collectionNames(QStringList *names) const Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result secretNames(const QString &collectionName, QStringList *secretNames) const Q_DECL_OVERRIDE;
 

--- a/daemon/SecretsImpl/secrets.cpp
+++ b/daemon/SecretsImpl/secrets.cpp
@@ -1653,6 +1653,9 @@ void Daemon::ApiImpl::SecretsRequestQueue::handlePendingRequest(
             QString storagePluginName = request->inParams.size()
                     ? request->inParams.takeFirst().value<QString>()
                     : QString();
+            QVariantMap customParameters = request->inParams.size()
+                    ? request->inParams.takeFirst().value<QVariantMap>()
+                    : QVariantMap();
             SecretManager::UserInteractionMode userInteractionMode = request->inParams.size()
                     ? request->inParams.takeFirst().value<SecretManager::UserInteractionMode>()
                     : SecretManager::PreventInteraction;
@@ -1668,6 +1671,7 @@ void Daemon::ApiImpl::SecretsRequestQueue::handlePendingRequest(
                                       request->requestId,
                                       collectionName,
                                       storagePluginName,
+                                      customParameters,
                                       userInteractionMode,
                                       interactionServiceAddress,
                                       &identifiers);

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -461,7 +461,7 @@ public: // Crypto API helper methods.
     Sailfish::Secrets::Result storeKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier, const QByteArray &serializedKey,
                                        const QMap<QString, QString> &filterData, const QByteArray &collectionDecryptionKey);
     Sailfish::Secrets::Result storedKeyIdentifiers(pid_t callerPid, quint64 cryptoRequestId, const QString &collectionName, const QString &storagePluginName,
-                                                   QVector<Sailfish::Crypto::Key::Identifier> *identifiers);
+                                                   const QVariantMap &customParameters, QVector<Sailfish::Crypto::Key::Identifier> *identifiers);
     Sailfish::Secrets::Result deleteStoredKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier);
     Sailfish::Secrets::Result userInput(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Secrets::InteractionParameters &uiParams);
     Sailfish::Secrets::Result modifyCryptoPluginLockCode(pid_t callerPid, quint64 cryptoRequestId, const QString &cryptoPluginName, const Sailfish::Secrets::InteractionParameters &uiParams);

--- a/daemon/SecretsImpl/secretscryptohelpers.cpp
+++ b/daemon/SecretsImpl/secretscryptohelpers.cpp
@@ -225,6 +225,7 @@ Daemon::ApiImpl::SecretsRequestQueue::storedKeyIdentifiers(
         quint64 cryptoRequestId,
         const QString &collectionName,
         const QString &storagePluginName,
+        const QVariantMap &customParameters,
         QVector<Sailfish::Crypto::Key::Identifier> *identifiers)
 {
     Q_UNUSED(identifiers) // asynchronous out-param.
@@ -233,6 +234,7 @@ Daemon::ApiImpl::SecretsRequestQueue::storedKeyIdentifiers(
     QList<QVariant> inParams;
     inParams << QVariant::fromValue<QString>(collectionName)
              << QVariant::fromValue<QString>(storagePluginName)
+             << QVariant::fromValue<QVariantMap>(customParameters)
              << QVariant::fromValue<SecretManager::UserInteractionMode>(SecretManager::SystemInteraction)
              << QVariant::fromValue<QString>(QString());
     Result enqueueResult(Result::Succeeded);

--- a/daemon/SecretsImpl/secretsrequestprocessor.cpp
+++ b/daemon/SecretsImpl/secretsrequestprocessor.cpp
@@ -882,6 +882,7 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiers(
         quint64 requestId,
         const QString &collectionName,
         const QString &storagePluginName,
+        const QVariantMap &customParameters,
         SecretManager::UserInteractionMode userInteractionMode,
         const QString &interactionServiceAddress,
         QVector<Secret::Identifier> *identifiers)
@@ -907,7 +908,8 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiers(
                     &Daemon::ApiImpl::storedKeyIdentifiers,
                     m_storagePlugins.value(storagePluginName),
                     m_encryptedStoragePlugins.value(storagePluginName),
-                    m_cryptoStoragePlugins.value(storagePluginName));
+                    m_cryptoStoragePlugins.value(storagePluginName),
+                    customParameters);
         future.waitForFinished();
         *identifiers = future.result().identifiers;
         return future.result().result;
@@ -942,6 +944,7 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiers(
                       requestId,
                       collectionName,
                       storagePluginName,
+                      customParameters,
                       userInteractionMode,
                       interactionServiceAddress,
                       cmr.metadata);
@@ -961,6 +964,7 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiersWithMetadata(
         quint64 requestId,
         const QString &collectionName,
         const QString &storagePluginName,
+        const QVariantMap &customParameters,
         SecretManager::UserInteractionMode userInteractionMode,
         const QString &interactionServiceAddress,
         const CollectionMetadata &collectionMetadata)
@@ -1094,6 +1098,7 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiersWithMetadata(
                                      Daemon::ApiImpl::StoredKeyIdentifiersRequest,
                                      QVariantList() << collectionName
                                                     << storagePluginName
+                                                    << customParameters
                                                     << userInteractionMode
                                                     << interactionServiceAddress
                                                     << QVariant::fromValue<CollectionMetadata>(collectionMetadata)));
@@ -1103,6 +1108,7 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiersWithMetadata(
                     requestId,
                     collectionName,
                     storagePluginName,
+                    customParameters,
                     userInteractionMode,
                     interactionServiceAddress,
                     collectionMetadata,
@@ -1119,6 +1125,7 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiersWithAuthenticationCode(
         quint64 requestId,
         const QString &collectionName,
         const QString &storagePluginName,
+        const QVariantMap &customParameters,
         SecretManager::UserInteractionMode userInteractionMode,
         const QString &interactionServiceAddress,
         const CollectionMetadata &collectionMetadata,
@@ -1155,7 +1162,8 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiersWithAuthenticationCode(
             m_requestQueue->requestFinished(requestId, outParams);
         } else {
             storedKeyIdentifiersWithEncryptionKey(
-                        callerPid, requestId, collectionName, storagePluginName,
+                        callerPid, requestId,
+                        collectionName, storagePluginName, customParameters,
                         userInteractionMode, interactionServiceAddress,
                         collectionMetadata, dkr.key, true);
         }
@@ -1170,6 +1178,7 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiersWithEncryptionKey(
         quint64 requestId,
         const QString &collectionName,
         const QString &storagePluginName,
+        const QVariantMap &customParameters,
         SecretManager::UserInteractionMode userInteractionMode,
         const QString &interactionServiceAddress,
         const CollectionMetadata &collectionMetadata,
@@ -1192,7 +1201,8 @@ Daemon::ApiImpl::RequestProcessor::storedKeyIdentifiersWithEncryptionKey(
                 m_storagePlugins.value(storagePluginName),
                 m_encryptedStoragePlugins.value(storagePluginName),
                 m_cryptoStoragePlugins.value(storagePluginName),
-                CollectionInfo(collectionName, collectionKey, requiresRelock));
+                CollectionInfo(collectionName, collectionKey, requiresRelock),
+                customParameters);
 
     watcher->setFuture(future);
     connect(watcher, &QFutureWatcher<IdentifiersResult>::finished, [=] {
@@ -5526,7 +5536,7 @@ Daemon::ApiImpl::RequestProcessor::userInputInteractionCompleted(
                     break;
                 }
                 case StoredKeyIdentifiersRequest: {
-                    if (pr.parameters.size() != 5) {
+                    if (pr.parameters.size() != 6) {
                         returnResult = Result(Result::UnknownError,
                                               QLatin1String("Internal error: incorrect parameter count!"));
                     } else {
@@ -5535,6 +5545,7 @@ Daemon::ApiImpl::RequestProcessor::userInputInteractionCompleted(
                                     pr.requestId,
                                     pr.parameters.takeFirst().value<QString>(),
                                     pr.parameters.takeFirst().value<QString>(),
+                                    pr.parameters.takeFirst().value<QVariantMap>(),
                                     static_cast<SecretManager::UserInteractionMode>(pr.parameters.takeFirst().value<int>()),
                                     pr.parameters.takeFirst().value<QString>(),
                                     pr.parameters.takeFirst().value<CollectionMetadata>(),
@@ -5610,6 +5621,7 @@ void Daemon::ApiImpl::RequestProcessor::authenticationCompleted(
                                     pr.requestId,
                                     pr.parameters.takeFirst().value<QString>(),
                                     pr.parameters.takeFirst().value<QString>(),
+                                    pr.parameters.takeFirst().value<QVariantMap>(),
                                     static_cast<SecretManager::UserInteractionMode>(pr.parameters.takeFirst().value<int>()),
                                     pr.parameters.takeFirst().value<QString>(),
                                     pr.parameters.takeFirst().value<CollectionMetadata>(),

--- a/daemon/SecretsImpl/secretsrequestprocessor.cpp
+++ b/daemon/SecretsImpl/secretsrequestprocessor.cpp
@@ -1975,7 +1975,7 @@ Daemon::ApiImpl::RequestProcessor::setStandaloneDeviceLockSecretWithMetadata(
     modifiedUiParams.setOperation(InteractionParameters::RequestUserData);
     modifiedUiParams.setPromptText({
         //: This will be displayed to the user, prompting them to enter the standalone secret data which will be stored. %1 is the application name, %2 is the secret name, %3 is the plugin name.
-        //% "%1 wants to store a new secret named %2 into collection %3 in plugin %4."
+        //% "%1 wants to store a new standalone secret named %2 in plugin %3."
         { InteractionParameters::Message, qtTrId("sailfish_secrets-set_standalone_secret-la-message")
                     .arg(newMetadata.ownerApplicationId,
                             secret.identifier().name(),
@@ -2207,7 +2207,7 @@ Daemon::ApiImpl::RequestProcessor::setStandaloneCustomLockSecretWithMetadata(
     modifiedUiParams.setOperation(InteractionParameters::RequestUserData);
     modifiedUiParams.setPromptText({
         //: This will be displayed to the user, prompting them to enter the standalone secret data which will be stored. %1 is the application name, %2 is the secret name, %3 is the plugin name.
-        //% "%1 wants to store a new secret named %2 into collection %3 in plugin %4."
+        //% "%1 wants to store a new standalone secret named %2 in plugin %3."
         { InteractionParameters::Message, qtTrId("sailfish_secrets-set_standalone_secret-la-message")
                     .arg(newMetadata.ownerApplicationId,
                             secret.identifier().name(),
@@ -4291,7 +4291,7 @@ Daemon::ApiImpl::RequestProcessor::modifyLockCode(
             //: This will be displayed to the user, prompting them to enter the old passphrase to unlock the extension plugin in order to change its lock code. %1 is the application name, %2 is the plugin name.
             //% "%1 wants to change the lock code for plugin %2."
             { InteractionParameters::Message, qtTrId("sailfish_secrets-modify_lock_code-la-message_old_plugin")
-                        .arg(callerApplicationId) },
+                        .arg(callerApplicationId, m_requestQueue->controller()->displayNameForPlugin(lockCodeTarget)) },
             //% "Enter the old passphrase to unlock the plugin."
             { InteractionParameters::Instruction, qtTrId("sailfish_secrets-modify_lock_code-la-enter_old_plugin_passphrase") }
         });

--- a/daemon/SecretsImpl/secretsrequestprocessor_p.h
+++ b/daemon/SecretsImpl/secretsrequestprocessor_p.h
@@ -261,6 +261,7 @@ public: // helper methods for crypto API bridge (secretscryptohelpers)
             quint64 requestId,
             const QString &collectionName,
             const QString &storagePluginName,
+            const QVariantMap &customParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
             QVector<Secret::Identifier> *idents);
@@ -596,6 +597,7 @@ private:
             quint64 requestId,
             const QString &collectionName,
             const QString &storagePluginName,
+            const QVariantMap &customParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
             const CollectionMetadata &collectionMetadata);
@@ -605,6 +607,7 @@ private:
             quint64 requestId,
             const QString &collectionName,
             const QString &storagePluginName,
+            const QVariantMap &customParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
             const CollectionMetadata &collectionMetadata,
@@ -615,6 +618,7 @@ private:
             quint64 requestId,
             const QString &collectionName,
             const QString &storagePluginName,
+            const QVariantMap &customParameters,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
             const CollectionMetadata &collectionMetadata,

--- a/lib/Crypto/cryptomanager.cpp
+++ b/lib/Crypto/cryptomanager.cpp
@@ -259,7 +259,8 @@ CryptoManagerPrivate::importStoredKey(
 QDBusPendingReply<Result, Key>
 CryptoManagerPrivate::storedKey(
         const Key::Identifier &identifier,
-        Key::Components keyComponents)
+        Key::Components keyComponents,
+        const QVariantMap &customParameters)
 {
     if (!m_interface) {
         return QDBusPendingReply<Result, Key>(
@@ -271,7 +272,8 @@ CryptoManagerPrivate::storedKey(
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("storedKey"),
                 QVariantList() << QVariant::fromValue<Key::Identifier>(identifier)
-                               << QVariant::fromValue<Key::Components>(keyComponents));
+                               << QVariant::fromValue<Key::Components>(keyComponents)
+                               << QVariant::fromValue<QVariantMap>(customParameters));
     return reply;
 }
 
@@ -295,7 +297,8 @@ CryptoManagerPrivate::deleteStoredKey(
 QDBusPendingReply<Result, QVector<Key::Identifier> >
 CryptoManagerPrivate::storedKeyIdentifiers(
         const QString &storagePluginName,
-        const QString &collectionName)
+        const QString &collectionName,
+        const QVariantMap &customParameters)
 {
     if (!m_interface) {
         return QDBusPendingReply<Result, QVector<Key::Identifier> >(
@@ -307,7 +310,8 @@ CryptoManagerPrivate::storedKeyIdentifiers(
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("storedKeyIdentifiers"),
                 QVariantList() << QVariant::fromValue<QString>(storagePluginName)
-                               << QVariant::fromValue<QString>(collectionName));
+                               << QVariant::fromValue<QString>(collectionName)
+                               << QVariant::fromValue<QVariantMap>(customParameters));
     return reply;
 }
 

--- a/lib/Crypto/cryptomanager_p.h
+++ b/lib/Crypto/cryptomanager_p.h
@@ -102,14 +102,16 @@ public:
 
     QDBusPendingReply<Sailfish::Crypto::Result, Sailfish::Crypto::Key> storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
-            Key::Components keyComponents);
+            Key::Components keyComponents,
+            const QVariantMap &customParameters);
 
     QDBusPendingReply<Sailfish::Crypto::Result> deleteStoredKey(
             const Sailfish::Crypto::Key::Identifier &identifier);
 
     QDBusPendingReply<Sailfish::Crypto::Result, QVector<Sailfish::Crypto::Key::Identifier> > storedKeyIdentifiers(
             const QString &storagePluginName,
-            const QString &collectionName);
+            const QString &collectionName,
+            const QVariantMap &customParameters);
 
     QDBusPendingReply<Sailfish::Crypto::Result, QByteArray> calculateDigest(
             const QByteArray &data,

--- a/lib/Crypto/storedkeyidentifiersrequest.cpp
+++ b/lib/Crypto/storedkeyidentifiersrequest.cpp
@@ -173,10 +173,10 @@ void StoredKeyIdentifiersRequest::startRequest()
             emit resultChanged();
         }
 
-        // should we pass customParameters in this case, or not?
-        // there's no "specific plugin" which is the target of the request..
         QDBusPendingReply<Result, QVector<Key::Identifier> > reply =
-                d->m_manager->d_ptr->storedKeyIdentifiers(d->m_storagePluginName, d->m_collectionName);
+                d->m_manager->d_ptr->storedKeyIdentifiers(d->m_storagePluginName,
+                                                          d->m_collectionName,
+                                                          d->m_customParameters);
         if (!reply.isValid() && !reply.error().message().isEmpty()) {
             d->m_status = Request::Finished;
             d->m_result = Result(Result::CryptoManagerNotInitializedError,

--- a/lib/Crypto/storedkeyrequest.cpp
+++ b/lib/Crypto/storedkeyrequest.cpp
@@ -178,11 +178,10 @@ void StoredKeyRequest::startRequest()
             emit resultChanged();
         }
 
-        // should we pass customParameters in this case, or not?
-        // there's no "specific plugin" which is the target of the request..
         QDBusPendingReply<Result, Key> reply =
                 d->m_manager->d_ptr->storedKey(d->m_identifier,
-                                               d->m_keyComponents);
+                                               d->m_keyComponents,
+                                               d->m_customParameters);
         if (!reply.isValid() && !reply.error().message().isEmpty()) {
             d->m_status = Request::Finished;
             d->m_result = Result(Result::CryptoManagerNotInitializedError,

--- a/lib/CryptoPluginApi/extensionplugins.cpp
+++ b/lib/CryptoPluginApi/extensionplugins.cpp
@@ -358,7 +358,7 @@ CryptoPlugin::~CryptoPlugin()
  */
 
 /*!
- * \fn CryptoPlugin::storedKey(const Sailfish::Crypto::Key::Identifier &identifier, Sailfish::Crypto::Key::Components keyComponents, Sailfish::Crypto::Key *key)
+ * \fn CryptoPlugin::storedKey(const Sailfish::Crypto::Key::Identifier &identifier, Sailfish::Crypto::Key::Components keyComponents, const QVariantMap &customParameters, Sailfish::Crypto::Key *key)
  * \brief Retrieve the key identified by the specified \a identifier limited
  *        to those components specified in \a keyComponents and write it
  *        to the out-parameter \a key.
@@ -403,7 +403,7 @@ CryptoPlugin::~CryptoPlugin()
  */
 
 /*!
- * \fn CryptoPlugin::storedKeyIdentifiers(const QString &collectionName, QVector<Sailfish::Crypto::Key::Identifier> *identifiers)
+ * \fn CryptoPlugin::storedKeyIdentifiers(const QString &collectionName, const QVariantMap &customParameters, QVector<Sailfish::Crypto::Key::Identifier> *identifiers)
  * \brief Writes the identifiers of all keys stored by the plugin in the
  *        collection identified by the given \a collectionName into the
  *        out-parameter \a identifiers.

--- a/lib/CryptoPluginApi/extensionplugins.h
+++ b/lib/CryptoPluginApi/extensionplugins.h
@@ -99,6 +99,7 @@ public:
     virtual Sailfish::Crypto::Result storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
             Sailfish::Crypto::Key::Components keyComponents,
+            const QVariantMap &customParameters,
             Sailfish::Crypto::Key *key) = 0;
 
     // This doesn't exist - if you can store keys, then you must also
@@ -109,6 +110,7 @@ public:
 
     virtual Sailfish::Crypto::Result storedKeyIdentifiers(
             const QString &collectionName,
+            const QVariantMap &customParameters,
             QVector<Sailfish::Crypto::Key::Identifier> *identifiers) = 0;
 
     virtual Sailfish::Crypto::Result calculateDigest(

--- a/plugins/exampleusbtokenplugin/cryptoplugin.cpp
+++ b/plugins/exampleusbtokenplugin/cryptoplugin.cpp
@@ -99,9 +99,11 @@ Result
 ExampleUsbTokenPlugin::storedKey(
         const Key::Identifier &identifier,
         Key::Components keyComponents,
+        const QVariantMap &customParameters,
         Key *key)
 {
     Q_UNUSED(keyComponents) // we only ever return metadata and public key data, not private key data.
+    Q_UNUSED(customParameters)
     if (identifier.storagePluginName() == name()
             && identifier.collectionName() == QStringLiteral("Default")
             && identifier.name() == QStringLiteral("Default")) {
@@ -117,8 +119,10 @@ ExampleUsbTokenPlugin::storedKey(
 Result
 ExampleUsbTokenPlugin::storedKeyIdentifiers(
         const QString &collectionName,
+        const QVariantMap &customParameters,
         QVector<Key::Identifier> *identifiers)
 {
+    Q_UNUSED(customParameters)
     if (collectionName != QStringLiteral("Default")) {
         return Sailfish::Crypto::Result(Sailfish::Crypto::Result::InvalidKeyIdentifier,
                                         QLatin1String("The ExampleUsbToken plugin has only a single Default collection"));

--- a/plugins/exampleusbtokenplugin/encryptedstorageplugin.cpp
+++ b/plugins/exampleusbtokenplugin/encryptedstorageplugin.cpp
@@ -121,6 +121,7 @@ ExampleUsbTokenPlugin::getSecret(
     Sailfish::Crypto::Result cresult = storedKey(
                 Sailfish::Crypto::Key::Identifier(secretName, collectionName, name()),
                 Sailfish::Crypto::Key::MetaData | Sailfish::Crypto::Key::PublicKeyData,
+                QVariantMap(),
                 &key);
     if (cresult.code() != Sailfish::Crypto::Result::Succeeded) {
         return Result(Result::UnknownError, // internal error, a bug in this plugin's code
@@ -164,6 +165,7 @@ ExampleUsbTokenPlugin::findSecrets(
     Sailfish::Crypto::Result cresult = storedKey(
                 Sailfish::Crypto::Key::Identifier(QStringLiteral("Default"), collectionName, name()),
                 Sailfish::Crypto::Key::MetaData | Sailfish::Crypto::Key::PublicKeyData,
+                QVariantMap(),
                 &key);
     if (cresult.code() != Sailfish::Crypto::Result::Succeeded) {
         return Result(Result::UnknownError, // internal error, a bug in this plugin's code

--- a/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
+++ b/plugins/exampleusbtokenplugin/exampleusbtokenplugin.h
@@ -174,10 +174,12 @@ public:
     Sailfish::Crypto::Result storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
             Sailfish::Crypto::Key::Components keyComponents,
+            const QVariantMap &customParameters,
             Sailfish::Crypto::Key *key) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result storedKeyIdentifiers(
             const QString &collectionName,
+            const QVariantMap &customParameters,
             QVector<Sailfish::Crypto::Key::Identifier> *identifiers) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result calculateDigest(

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.cpp
@@ -109,10 +109,12 @@ Result
 Daemon::Plugins::OpenSslCryptoPlugin::storedKey(
         const Key::Identifier &identifier,
         Key::Components keyComponents,
+        const QVariantMap &customParameters,
         Key *key)
 {
     Q_UNUSED(identifier);
     Q_UNUSED(keyComponents);
+    Q_UNUSED(customParameters);
     Q_UNUSED(key);
     return Result(Result::OperationNotSupportedError,
                   QLatin1String("The OpenSSL crypto plugin doesn't support storing keys"));
@@ -121,9 +123,11 @@ Daemon::Plugins::OpenSslCryptoPlugin::storedKey(
 Result
 Daemon::Plugins::OpenSslCryptoPlugin::storedKeyIdentifiers(
         const QString &collectionName,
+        const QVariantMap &customParameters,
         QVector<Key::Identifier> *identifiers)
 {
     Q_UNUSED(collectionName);
+    Q_UNUSED(customParameters);
     Q_UNUSED(identifiers);
     return Result(Result::OperationNotSupportedError,
                   QLatin1String("The OpenSSL crypto plugin doesn't support storing keys"));

--- a/plugins/opensslcryptoplugin/opensslcryptoplugin.h
+++ b/plugins/opensslcryptoplugin/opensslcryptoplugin.h
@@ -114,10 +114,12 @@ public:
     Sailfish::Crypto::Result storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
             Sailfish::Crypto::Key::Components keyComponents,
+            const QVariantMap &customParameters,
             Sailfish::Crypto::Key *key) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result storedKeyIdentifiers(
             const QString &collectionName,
+            const QVariantMap &customParameters,
             QVector<Sailfish::Crypto::Key::Identifier> *identifiers) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result calculateDigest(

--- a/plugins/sqlcipherplugin/cryptoplugin.cpp
+++ b/plugins/sqlcipherplugin/cryptoplugin.cpp
@@ -217,8 +217,10 @@ Sailfish::Crypto::Result
 Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::storedKey(
         const Sailfish::Crypto::Key::Identifier &identifier,
         Sailfish::Crypto::Key::Components keyComponents,
+        const QVariantMap &customParameters,
         Sailfish::Crypto::Key *key)
 {
+    Q_UNUSED(customParameters);
     Sailfish::Crypto::Key fullKey;
     Sailfish::Crypto::Result retn = storedKey_internal(
                 identifier,
@@ -231,8 +233,10 @@ Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::storedKey(
 Sailfish::Crypto::Result
 Sailfish::Secrets::Daemon::Plugins::SqlCipherPlugin::storedKeyIdentifiers(
         const QString &collectionName,
+        const QVariantMap &customParameters,
         QVector<Sailfish::Crypto::Key::Identifier> *identifiers)
 {
+    Q_UNUSED(customParameters);
     bool locked = false;
     Sailfish::Secrets::Result result = isCollectionLocked(collectionName, &locked);
     if (result.code() != Result::Succeeded) {

--- a/plugins/sqlcipherplugin/sqlcipherplugin.h
+++ b/plugins/sqlcipherplugin/sqlcipherplugin.h
@@ -164,10 +164,12 @@ public:
     Sailfish::Crypto::Result storedKey(
             const Sailfish::Crypto::Key::Identifier &identifier,
             Sailfish::Crypto::Key::Components keyComponents,
+            const QVariantMap &customParameters,
             Sailfish::Crypto::Key *key) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result storedKeyIdentifiers(
             const QString &collectionName,
+            const QVariantMap &customParameters,
             QVector<Sailfish::Crypto::Key::Identifier> *identifiers) Q_DECL_OVERRIDE;
 
     Sailfish::Crypto::Result calculateDigest(

--- a/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
+++ b/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
@@ -532,7 +532,8 @@ void tst_cryptosecrets::cryptoStoredKey()
     // ensure that we can get a reference via a stored key request
     QDBusPendingReply<Sailfish::Crypto::Result, Sailfish::Crypto::Key> storedKeyReply = cm.storedKey(
             keyReference.identifier(),
-            Sailfish::Crypto::Key::MetaData);
+            Sailfish::Crypto::Key::MetaData,
+            QVariantMap());
     storedKeyReply.waitForFinished();
     QVERIFY(storedKeyReply.isValid());
     QCOMPARE(storedKeyReply.argumentAt<0>().code(), Sailfish::Crypto::Result::Succeeded);
@@ -544,7 +545,8 @@ void tst_cryptosecrets::cryptoStoredKey()
     storedKeyReply = cm.storedKey(
                 keyReference.identifier(),
                 Sailfish::Crypto::Key::MetaData
-                    | Sailfish::Crypto::Key::PublicKeyData);
+                    | Sailfish::Crypto::Key::PublicKeyData,
+                QVariantMap());
         storedKeyReply.waitForFinished();
         QVERIFY(storedKeyReply.isValid());
         QCOMPARE(storedKeyReply.argumentAt<0>().code(), Sailfish::Crypto::Result::Succeeded);
@@ -557,7 +559,8 @@ void tst_cryptosecrets::cryptoStoredKey()
                 keyReference.identifier(),
                 Sailfish::Crypto::Key::MetaData
                     | Sailfish::Crypto::Key::PublicKeyData
-                    | Sailfish::Crypto::Key::PrivateKeyData);
+                    | Sailfish::Crypto::Key::PrivateKeyData,
+                QVariantMap());
         storedKeyReply.waitForFinished();
         QVERIFY(storedKeyReply.isValid());
         QCOMPARE(storedKeyReply.argumentAt<0>().code(), Sailfish::Crypto::Result::Succeeded);
@@ -789,7 +792,8 @@ void tst_cryptosecrets::cryptoStoredKey()
     // ensure that we can get a reference via a stored key request
     storedKeyReply = cm.storedKey(
             keyReference.identifier(),
-            Sailfish::Crypto::Key::MetaData);
+            Sailfish::Crypto::Key::MetaData,
+            QVariantMap());
     storedKeyReply.waitForFinished();
     QVERIFY(storedKeyReply.isValid());
     QCOMPARE(storedKeyReply.argumentAt<0>().code(), Sailfish::Crypto::Result::Succeeded);
@@ -801,7 +805,8 @@ void tst_cryptosecrets::cryptoStoredKey()
     storedKeyReply = cm.storedKey(
                 keyReference.identifier(),
                 Sailfish::Crypto::Key::MetaData
-                    | Sailfish::Crypto::Key::PublicKeyData);
+                    | Sailfish::Crypto::Key::PublicKeyData,
+                QVariantMap());
     storedKeyReply.waitForFinished();
     QVERIFY(storedKeyReply.isValid());
     QCOMPARE(storedKeyReply.argumentAt<0>().code(), Sailfish::Crypto::Result::Succeeded);
@@ -814,7 +819,8 @@ void tst_cryptosecrets::cryptoStoredKey()
                 keyReference.identifier(),
                 Sailfish::Crypto::Key::MetaData
                     | Sailfish::Crypto::Key::PublicKeyData
-                    | Sailfish::Crypto::Key::PrivateKeyData);
+                    | Sailfish::Crypto::Key::PrivateKeyData,
+                QVariantMap());
     storedKeyReply.waitForFinished();
     QVERIFY(storedKeyReply.isValid());
     QCOMPARE(storedKeyReply.argumentAt<0>().code(), Sailfish::Crypto::Result::Succeeded);


### PR DESCRIPTION
Previously, those requests didn't have a target storage plugin,
however since the refactor they have.  As such, we should pass
the plugin-specific custom parameters to the plugin when we
call those methods.

Contributes to JB#40058