### PR TITLE
[sailfish-crypto] Trigger collection unlock flow for crypto operations. Contributes to JB#40058

### DIFF
--- a/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
+++ b/daemon/CryptoImpl/cryptopluginfunctionwrappers_p.h
@@ -151,6 +151,15 @@ struct DataAndIV {
     QByteArray initVector;
 };
 
+struct KeyAndCollectionKey {
+    KeyAndCollectionKey(const Sailfish::Crypto::Key &k, const QByteArray &ck)
+        : key(k), collectionKey(ck) {}
+    KeyAndCollectionKey(const KeyAndCollectionKey &other)
+        : key(other.key), collectionKey(other.collectionKey) {}
+    Sailfish::Crypto::Key key;
+    QByteArray collectionKey;
+};
+
 struct AuthDataAndTag {
     AuthDataAndTag(const QByteArray &ad = QByteArray(),
                    const QByteArray &t = QByteArray())
@@ -174,13 +183,16 @@ struct PluginAndCustomParams {
 };
 
 struct PluginWrapperAndCustomParams {
-    PluginWrapperAndCustomParams(Daemon::ApiImpl::CryptoStoragePluginWrapper *p = Q_NULLPTR,
+    PluginWrapperAndCustomParams(CryptoPlugin *p = Q_NULLPTR,
+                                 Daemon::ApiImpl::CryptoStoragePluginWrapper *w = Q_NULLPTR,
                                  const QVariantMap &cp = QVariantMap())
-        : plugin(p), customParameters(cp) {}
+        : plugin(p), wrapper(w), customParameters(cp) {}
     PluginWrapperAndCustomParams(const PluginWrapperAndCustomParams &other)
         : plugin(other.plugin)
+        , wrapper(other.wrapper)
         , customParameters(other.customParameters) {}
-    Daemon::ApiImpl::CryptoStoragePluginWrapper *plugin;
+    CryptoPlugin *plugin;
+    Daemon::ApiImpl::CryptoStoragePluginWrapper *wrapper;
     QVariantMap customParameters;
 };
 
@@ -254,37 +266,37 @@ DataResult calculateDigest(
         const SignatureOptions &options);
 
 DataResult sign(
-        const PluginAndCustomParams &pluginAndCustomParams,
+        const PluginWrapperAndCustomParams &pluginAndCustomParams,
         const QByteArray &data,
-        const Sailfish::Crypto::Key &key,
+        const KeyAndCollectionKey &keyAndCollectionKey,
         const SignatureOptions &options);
 
 ValidatedResult verify(
-        const PluginAndCustomParams &pluginAndCustomParams,
+        const PluginWrapperAndCustomParams &pluginAndCustomParams,
         const QByteArray &signature,
         const QByteArray &data,
-        const Sailfish::Crypto::Key &key,
+        const KeyAndCollectionKey &keyAndCollectionKey,
         const SignatureOptions &options);
 
 TagDataResult encrypt(
-        const PluginAndCustomParams &pluginAndCustomParams,
+        const PluginWrapperAndCustomParams &pluginAndCustomParams,
         const DataAndIV &dataAndIv,
-        const Sailfish::Crypto::Key &key,
+        const KeyAndCollectionKey &keyAndCollectionKey,
         const EncryptionOptions &options,
         const QByteArray &authenticationData);
 
 VerifiedDataResult decrypt(
-        const PluginAndCustomParams &pluginAndCustomParams,
+        const PluginWrapperAndCustomParams &pluginAndCustomParams,
         const DataAndIV &dataAndIv,
-        const Sailfish::Crypto::Key &key, // or keyreference, i.e. Key(keyName)
+        const KeyAndCollectionKey &keyAndCollectionKey,
         const EncryptionOptions &options,
         const AuthDataAndTag &authDataAndTag);
 
 CipherSessionTokenResult initializeCipherSession(
-        const PluginAndCustomParams &pluginAndCustomParams,
+        const PluginWrapperAndCustomParams &pluginAndCustomParams,
         quint64 clientId,
         const QByteArray &iv,
-        const Sailfish::Crypto::Key &key, // or keyreference, i.e. Key(keyName)
+        const KeyAndCollectionKey &keyAndCollectionKey,
         const CipherSessionOptions &options);
 
 Sailfish::Crypto::Result updateCipherSessionAuthentication(

--- a/daemon/CryptoImpl/cryptopluginwrapper_p.h
+++ b/daemon/CryptoImpl/cryptopluginwrapper_p.h
@@ -13,6 +13,8 @@
 #include "SecretsImpl/pluginwrapper_p.h"
 #include "SecretsImpl/metadatadb_p.h"
 
+#include "Secrets/result.h"
+
 #include "CryptoPluginApi/extensionplugins.h"
 
 #include <QtCore/QString>
@@ -60,6 +62,8 @@ public:
             const QVariantMap &customParameters,
             const QByteArray &collectionUnlockKey,
             Sailfish::Crypto::Key *keyReference);
+
+    Sailfish::Crypto::CryptoPlugin *cryptoPlugin() const { return m_cryptoPlugin; }
 
 protected:
     Sailfish::Crypto::CryptoPlugin *m_cryptoPlugin;

--- a/daemon/CryptoImpl/cryptorequestprocessor_p.h
+++ b/daemon/CryptoImpl/cryptorequestprocessor_p.h
@@ -303,6 +303,11 @@ public:
             const Sailfish::Crypto::InteractionParameters &interactionParameters);
 
 public Q_SLOTS:
+    void secretsUseKeyPreCheckCompleted(
+            quint64 requestId,
+            const Sailfish::Secrets::Result &result,
+            const QByteArray &collectionDecryptionKey);
+
     void secretsStoreKeyPreCheckCompleted(
             quint64 requestId,
             const Sailfish::Secrets::Result &result,
@@ -470,7 +475,7 @@ private:
             const Sailfish::Crypto::Result &result,
             const QVector<Sailfish::Crypto::Key::Identifier> &identifiers);
 
-    void sign2(
+    void sign_withKey(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
             const QByteArray &serializedKey,
@@ -480,7 +485,18 @@ private:
             const QVariantMap &customParameters,
             const QString &cryptoPluginName);
 
-    void verify2(
+    void sign_withCollectionKey(
+            quint64 requestId,
+            const QByteArray &data,
+            const Sailfish::Crypto::Key &key,
+            Sailfish::Crypto::CryptoManager::SignaturePadding padding,
+            Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
+            const QVariantMap &customParameters,
+            const QString &cryptosystemProviderName,
+            const Sailfish::Crypto::Result &result,
+            const QByteArray &collectionKey);
+
+    void verify_withKey(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
             const QByteArray &serializedKey,
@@ -491,7 +507,19 @@ private:
             const QVariantMap &customParameters,
             const QString &cryptoPluginName);
 
-    void encrypt2(
+    void verify_withCollectionKey(
+            quint64 requestId,
+            const QByteArray &signature,
+            const QByteArray &data,
+            const Sailfish::Crypto::Key &key,
+            Sailfish::Crypto::CryptoManager::SignaturePadding padding,
+            Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
+            const QVariantMap &customParameters,
+            const QString &cryptosystemProviderName,
+            const Sailfish::Crypto::Result &result,
+            const QByteArray &collectionKey);
+
+    void encrypt_withKey(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
             const QByteArray &serializedKey,
@@ -503,7 +531,20 @@ private:
             const QVariantMap &customParameters,
             const QString &cryptoPluginName);
 
-    void decrypt2(
+    void encrypt_withCollectionKey(
+            quint64 requestId,
+            const QByteArray &data,
+            const QByteArray &iv,
+            const Sailfish::Crypto::Key &key,
+            Sailfish::Crypto::CryptoManager::BlockMode blockMode,
+            Sailfish::Crypto::CryptoManager::EncryptionPadding padding,
+            const QByteArray &authenticationData,
+            const QVariantMap &customParameters,
+            const QString &cryptoPluginName,
+            const Sailfish::Crypto::Result &result,
+            const QByteArray &collectionKey);
+
+    void decrypt_withKey(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
             const QByteArray &serializedKey,
@@ -516,7 +557,21 @@ private:
             const QVariantMap &customParameters,
             const QString &cryptoPluginName);
 
-    void initializeCipherSession2(
+    void decrypt_withCollectionKey(
+            quint64 requestId,
+            const QByteArray &data,
+            const QByteArray &iv,
+            const Sailfish::Crypto::Key &key,
+            Sailfish::Crypto::CryptoManager::BlockMode blockMode,
+            Sailfish::Crypto::CryptoManager::EncryptionPadding padding,
+            const QByteArray &authenticationData,
+            const QByteArray &authenticationTag,
+            const QVariantMap &customParameters,
+            const QString &cryptoPluginName,
+            const Sailfish::Crypto::Result &result,
+            const QByteArray &collectionKey);
+
+    void initializeCipherSession_withKey(
             quint64 requestId,
             const Sailfish::Crypto::Result &result,
             const QByteArray &serializedKey,
@@ -529,6 +584,21 @@ private:
             Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
             const QVariantMap &customParameters,
             const QString &cryptoPluginName);
+
+    void initializeCipherSession_withCollectionKey(
+            quint64 requestId,
+            pid_t callerPid,
+            const QByteArray &iv,
+            const Sailfish::Crypto::Key &key,
+            Sailfish::Crypto::CryptoManager::Operation operation,
+            Sailfish::Crypto::CryptoManager::BlockMode blockMode,
+            Sailfish::Crypto::CryptoManager::EncryptionPadding encryptionPadding,
+            Sailfish::Crypto::CryptoManager::SignaturePadding signaturePadding,
+            Sailfish::Crypto::CryptoManager::DigestFunction digestFunction,
+            const QVariantMap &customParameters,
+            const QString &cryptoPluginName,
+            const Sailfish::Crypto::Result &result,
+            const QByteArray &collectionKey);
 
 private:
     Sailfish::Crypto::Daemon::ApiImpl::CryptoRequestQueue *m_requestQueue;

--- a/daemon/SecretsImpl/pluginfunctionwrappers_p.h
+++ b/daemon/SecretsImpl/pluginfunctionwrappers_p.h
@@ -345,7 +345,8 @@ namespace StoragePluginFunctionWrapper {
     Sailfish::Secrets::Result collectionSecretPreCheck(
             StoragePluginWrapper *plugin,
             const QString &collectionName,
-            const QString &secretName);
+            const QString &secretName,
+            bool newSecret);
 
 } // StoragePluginWrapper
 
@@ -471,10 +472,9 @@ namespace EncryptedStoragePluginFunctionWrapper {
 
     Sailfish::Secrets::Result collectionSecretPreCheck(
             EncryptedStoragePluginWrapper *plugin,
-            const QString &collectionName,
+            const CollectionInfo &collectionInfo,
             const QString &secretName,
-            const QByteArray &collectionKey,
-            bool requiresRelock);
+            bool newSecret);
 }
 
 } // ApiImpl

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -474,6 +474,7 @@ public: // Crypto API helper methods.
     // the first methods are synchronous:
     Sailfish::Secrets::Result storagePluginInfo(pid_t callerPid, quint64 cryptoRequestId, QVector<Sailfish::Secrets::PluginInfo> *info) const;
     // the others are asynchronous methods:
+    Sailfish::Secrets::Result useKeyPreCheck(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier, Sailfish::Crypto::CryptoManager::Operation operation, const QString &cryptoPluginName);
     Sailfish::Secrets::Result storedKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier, QByteArray *serializedKey, QMap<QString, QString> *filterData);
     Sailfish::Secrets::Result storeKeyPreCheck(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier);
     Sailfish::Secrets::Result storeKey(pid_t callerPid, quint64 cryptoRequestId, const Sailfish::Crypto::Key::Identifier &identifier, const QByteArray &serializedKey,
@@ -488,6 +489,7 @@ public: // Crypto API helper methods.
     Sailfish::Secrets::Result forgetCryptoPluginLockCode(pid_t callerPid, quint64 cryptoRequestId, const QString &cryptoPluginName, const Sailfish::Secrets::InteractionParameters &uiParams);
 
 Q_SIGNALS:
+    void useKeyPreCheckCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &collectionDecryptionKey);
     void storedKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &serializedKey, const QMap<QString,QString> &filterData);
     void storeKeyPreCheckCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result, const QByteArray &collectionDecryptionKey);
     void storeKeyCompleted(quint64 cryptoRequestId, const Sailfish::Secrets::Result &result);
@@ -503,6 +505,7 @@ private:
         StoredKeyCryptoApiHelperRequest,
         StoredKeyIdentifiersCryptoApiHelperRequest,
         DeleteStoredKeyCryptoApiHelperRequest,
+        UseKeyPreCheckCryptoApiHelperRequest,
         StoreKeyPreCheckCryptoApiHelperRequest,
         StoreKeyCryptoApiHelperRequest,
         UserInputCryptoApiHelperRequest,
@@ -540,6 +543,7 @@ enum RequestType {
     SetStandaloneDeviceLockUserInputSecretRequest,
     SetStandaloneCustomLockUserInputSecretRequest,
     // Crypto API helper request types:
+    UseCollectionKeyPreCheckRequest,
     SetCollectionKeyPreCheckRequest,
     SetCollectionKeyRequest,
     StoredKeyIdentifiersRequest

--- a/daemon/SecretsImpl/secretsrequestprocessor.cpp
+++ b/daemon/SecretsImpl/secretsrequestprocessor.cpp
@@ -5521,7 +5521,6 @@ Daemon::ApiImpl::RequestProcessor::setCollectionKeyPreCheckWithMetadata(
                                          requestId,
                                          Daemon::ApiImpl::SetCollectionKeyPreCheckRequest,
                                          QVariantList() << QVariant::fromValue<Secret::Identifier>(identifier)
-                                                        << userInteractionMode
                                                         << QVariant::fromValue<CollectionMetadata>(collectionMetadata)));
             return result;
         } else if (userInteractionMode == SecretManager::PreventInteraction) {
@@ -5605,7 +5604,6 @@ Daemon::ApiImpl::RequestProcessor::setCollectionKeyPreCheckWithMetadata(
                                      requestId,
                                      Daemon::ApiImpl::SetCollectionKeyPreCheckRequest,
                                      QVariantList() << QVariant::fromValue<Secret::Identifier>(identifier)
-                                                    << userInteractionMode
                                                     << QVariant::fromValue<CollectionMetadata>(collectionMetadata)));
         return result;
     } else if (userInteractionMode == SecretManager::PreventInteraction) {
@@ -6264,7 +6262,7 @@ void Daemon::ApiImpl::RequestProcessor::authenticationCompleted(
                     break;
                 }
                 case SetCollectionKeyPreCheckRequest: {
-                    if (pr.parameters.size() != 3) {
+                    if (pr.parameters.size() != 2) {
                         returnResult = Result(Result::UnknownError,
                                               QLatin1String("Internal error: incorrect parameter count!"));
                     } else {

--- a/daemon/SecretsImpl/secretsrequestprocessor.cpp
+++ b/daemon/SecretsImpl/secretsrequestprocessor.cpp
@@ -4894,6 +4894,469 @@ Daemon::ApiImpl::RequestProcessor::forgetLockCode(
 }
 
 Result
+Daemon::ApiImpl::RequestProcessor::useCollectionKeyPreCheck(
+        pid_t callerPid,
+        quint64 requestId,
+        const Secret::Identifier &identifier,
+        Sailfish::Crypto::CryptoManager::Operation operation,
+        const QString &cryptoPluginName,
+        SecretManager::UserInteractionMode userInteractionMode,
+        QByteArray *collectionDecryptionKey)
+{
+    Q_UNUSED(collectionDecryptionKey); // asynchronous out-params.
+    if (identifier.name().isEmpty()) {
+        return Result(Result::InvalidSecretError,
+                      QLatin1String("Empty secret name given"));
+    } else if (identifier.collectionName().isEmpty()) {
+        return Result(Result::InvalidCollectionError,
+                      QLatin1String("Empty collection name given"));
+    } else if (identifier.collectionName().compare(QStringLiteral("standalone"), Qt::CaseInsensitive) == 0) {
+        return Result(Result::InvalidCollectionError,
+                      QLatin1String("Reserved collection name given"));
+    } else if (identifier.storagePluginName().isEmpty()) {
+        return Result(Result::InvalidExtensionPluginError,
+                      QLatin1String("Empty storage plugin name given"));
+    } else if (!m_storagePlugins.contains(identifier.storagePluginName())
+               && !m_encryptedStoragePlugins.contains(identifier.storagePluginName())) {
+        return Result(Result::InvalidExtensionPluginError,
+                      QLatin1String("Unknown storage plugin name given"));
+    }
+
+    // Read the metadata about the target collection
+    QFutureWatcher<CollectionMetadataResult> *watcher
+            = new QFutureWatcher<CollectionMetadataResult>(this);
+    QFuture<CollectionMetadataResult> future;
+    if (m_encryptedStoragePlugins.contains(identifier.storagePluginName())) {
+        future = QtConcurrent::run(
+                    m_requestQueue->secretsThreadPool().data(),
+                    EncryptedStoragePluginFunctionWrapper::collectionMetadata,
+                    m_encryptedStoragePlugins[identifier.storagePluginName()],
+                    identifier.collectionName());
+    } else {
+        future = QtConcurrent::run(
+                    m_requestQueue->secretsThreadPool().data(),
+                    StoragePluginFunctionWrapper::collectionMetadata,
+                    m_storagePlugins[identifier.storagePluginName()],
+                    identifier.collectionName());
+    }
+
+    watcher->setFuture(future);
+    connect(watcher, &QFutureWatcher<CollectionMetadataResult>::finished, [=] {
+        watcher->deleteLater();
+        CollectionMetadataResult cmr = watcher->future().result();
+        Result result = cmr.result.code() != Result::Succeeded
+                ? cmr.result
+                : useCollectionKeyPreCheckWithMetadata(
+                      callerPid,
+                      requestId,
+                      identifier,
+                      operation,
+                      cryptoPluginName,
+                      userInteractionMode,
+                      cmr.metadata);
+        if (result.code() != Result::Pending) {
+            QVariantList outParams;
+            outParams << QVariant::fromValue<Result>(result);
+            outParams << QVariant::fromValue<QByteArray>(QByteArray());
+            m_requestQueue->requestFinished(requestId, outParams);
+        }
+    });
+
+    return Result(Result::Pending);
+}
+
+Result
+Daemon::ApiImpl::RequestProcessor::useCollectionKeyPreCheckWithMetadata(
+        pid_t callerPid,
+        quint64 requestId,
+        const Secret::Identifier &identifier,
+        Sailfish::Crypto::CryptoManager::Operation operation,
+        const QString &cryptoPluginName,
+        SecretManager::UserInteractionMode userInteractionMode,
+        const CollectionMetadata &collectionMetadata)
+{
+    const bool applicationIsPlatformApplication = m_appPermissions->applicationIsPlatformApplication(callerPid);
+    const QString callerApplicationId = applicationIsPlatformApplication
+                ? m_appPermissions->platformApplicationId()
+                : m_appPermissions->applicationId(callerPid);
+
+    const QString authPluginName = determineAuthPlugin(
+                collectionMetadata.ownerApplicationId,
+                callerApplicationId,
+                applicationIsPlatformApplication,
+                collectionMetadata.authenticationPluginName,
+                QString(),
+                m_autotestMode);
+
+    if (collectionMetadata.accessControlMode == SecretManager::SystemAccessControlMode) {
+        // TODO: perform access control request, to ask for permission to set the secret in the collection.
+        return Result(Result::OperationNotSupportedError,
+                      QLatin1String("Access control requests are not currently supported. TODO!"));
+    } else if (collectionMetadata.accessControlMode == SecretManager::OwnerOnlyMode
+               && collectionMetadata.ownerApplicationId != callerApplicationId) {
+        return Result(Result::PermissionsError,
+                      QString::fromLatin1("Collection %1 in plugin %2 is owned by a different application")
+                      .arg(identifier.collectionName(), identifier.storagePluginName()));
+    }
+
+    //: This will be displayed to the user, prompting them to enter the passphrase to unlock the collection prior to using the key to sign data. %1 is the application name, %2 is the crypto plugin name, %3 is the key name, %4 is the collection name, %5 is the storage plugin name.
+    //% "%1 wants to use plugin %2 to sign data using the key named %3 from collection %4 in plugin %5."
+    const QString signMessage = qtTrId("sailfish_secrets-use_collection_key_precheck-la-sign_message")
+                                  .arg(callerApplicationId,
+                                       m_requestQueue->controller()->displayNameForPlugin(cryptoPluginName),
+                                       identifier.name(),
+                                       identifier.collectionName(),
+                                       m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName()));
+    //: This will be displayed to the user, prompting them to enter the passphrase to unlock the collection prior to using the key to verify a signature. %1 is the application name, %2 is the crypto plugin name, %3 is the key name, %4 is the collection name, %5 is the storage plugin name.
+    //% "%1 wants to use plugin %2 to verify a signature using the key named %3 from collection %4 in plugin %5."
+    const QString verifyMessage = qtTrId("sailfish_secrets-use_collection_key_precheck-la-verify_message")
+                                    .arg(callerApplicationId,
+                                         m_requestQueue->controller()->displayNameForPlugin(cryptoPluginName),
+                                         identifier.name(),
+                                         identifier.collectionName(),
+                                         m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName()));
+    //: This will be displayed to the user, prompting them to enter the passphrase to unlock the collection prior to using the key to encrypt data. %1 is the application name, %2 is the crypto plugin name, %3 is the key name, %4 is the collection name, %5 is the storage plugin name.
+    //% "%1 wants to use plugin %2 to encrypt data using the key named %3 from collection %4 in plugin %5."
+    const QString encryptMessage = qtTrId("sailfish_secrets-use_collection_key_precheck-la-encrypt_message")
+                                     .arg(callerApplicationId,
+                                          m_requestQueue->controller()->displayNameForPlugin(cryptoPluginName),
+                                          identifier.name(),
+                                          identifier.collectionName(),
+                                          m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName()));
+    //: This will be displayed to the user, prompting them to enter the passphrase to unlock the collection prior to using the key to decrypt data. %1 is the application name, %2 is the crypto plugin name, %3 is the key name, %4 is the collection name, %5 is the storage plugin name.
+    //% "%1 wants to use plugin %2 to decrypt data using the key named %3 from collection %4 in plugin %5."
+    const QString decryptMessage = qtTrId("sailfish_secrets-use_collection_key_precheck-la-decrypt_message")
+                                     .arg(callerApplicationId,
+                                          m_requestQueue->controller()->displayNameForPlugin(cryptoPluginName),
+                                          identifier.name(),
+                                          identifier.collectionName(),
+                                          m_requestQueue->controller()->displayNameForPlugin(identifier.storagePluginName()));
+
+    QString message;
+    if (operation == Sailfish::Crypto::CryptoManager::OperationSign) {
+        message = signMessage;
+    } else if (operation == Sailfish::Crypto::CryptoManager::OperationVerify) {
+        message = verifyMessage;
+    } else if (operation == Sailfish::Crypto::CryptoManager::OperationEncrypt) {
+        message = encryptMessage;
+    } else {
+        message = decryptMessage;
+    }
+
+    Sailfish::Secrets::InteractionParameters::PromptText promptText({
+        { InteractionParameters::Message, message },
+        //% "Enter the passphrase to unlock the collection."
+        { InteractionParameters::Instruction, qtTrId("sailfish_secrets-use_collection_key_precheck-la-enter_collection_passphrase") }
+    });
+
+    if (m_encryptedStoragePlugins.contains(identifier.storagePluginName())) {
+        // TODO: make this asynchronous instead of blocking the main thread!
+        QFuture<LockedResult> future
+                = QtConcurrent::run(
+                        m_requestQueue->secretsThreadPool().data(),
+                        EncryptedStoragePluginFunctionWrapper::isCollectionLocked,
+                        m_encryptedStoragePlugins[identifier.storagePluginName()],
+                        identifier.collectionName());
+        future.waitForFinished();
+        LockedResult lr = future.result();
+        Result pluginResult = lr.result;
+        bool locked = lr.locked;
+        if (pluginResult.code() != Result::Succeeded) {
+            return pluginResult;
+        }
+        if (!locked) {
+            useCollectionKeyPreCheckWithEncryptionKey(
+                        callerPid,
+                        requestId,
+                        identifier,
+                        collectionMetadata,
+                        QByteArray());
+            return Result(Result::Pending);
+        }
+
+        if (collectionMetadata.usesDeviceLockKey) {
+            // Perform a "verify" UI flow (if the user interaction mode allows).
+            // If that succeeds, unlock the collection with the stored devicelock key and continue.
+            if (userInteractionMode == Sailfish::Secrets::SecretManager::PreventInteraction) {
+                return Result(Result::CollectionIsLockedError,
+                              QString::fromLatin1("Collection %1 is locked and requires device lock authentication")
+                              .arg(identifier.collectionName()));
+            }
+
+            // always use the system authentication plugin for device lock authentication requests.
+            const QString systemAuthenticationPlugin = m_autotestMode
+                    ? (SecretManager::DefaultAuthenticationPluginName + QLatin1String(".test"))
+                    : SecretManager::DefaultAuthenticationPluginName;
+            Result result = m_authenticationPlugins[systemAuthenticationPlugin]->beginAuthentication(
+                        callerPid,
+                        requestId,
+                        promptText);
+            if (result.code() == Result::Failed) {
+                return result;
+            }
+
+            // calls useCollectionKeyPreCheckWithEncryptionKey when finished
+            m_pendingRequests.insert(requestId,
+                                     Daemon::ApiImpl::RequestProcessor::PendingRequest(
+                                         callerPid,
+                                         requestId,
+                                         Daemon::ApiImpl::UseCollectionKeyPreCheckRequest,
+                                         QVariantList() << QVariant::fromValue<Secret::Identifier>(identifier)
+                                                        << QVariant::fromValue<CollectionMetadata>(collectionMetadata)));
+            return result;
+        } else if (userInteractionMode == SecretManager::PreventInteraction) {
+            return Result(Result::OperationRequiresUserInteraction,
+                          QString::fromLatin1("Authentication plugin %1 requires user interaction")
+                          .arg(authPluginName));
+        } else if (!m_authenticationPlugins.contains(authPluginName)) {
+            return Result(Result::InvalidExtensionPluginError,
+                          QStringLiteral("Unknown collection authentication plugin: %1")
+                          .arg(authPluginName));
+        }
+
+        // perform the user input flow required to get the input key data which will be used
+        // to unlock this collection.
+        InteractionParameters promptParams;
+        promptParams.setApplicationId(callerApplicationId);
+        promptParams.setPluginName(identifier.storagePluginName());
+        promptParams.setCollectionName(identifier.collectionName());
+        promptParams.setSecretName(identifier.name());
+        promptParams.setOperation(InteractionParameters::StoreKey);
+        promptParams.setInputType(InteractionParameters::AlphaNumericInput);
+        promptParams.setEchoMode(InteractionParameters::PasswordEcho);
+        promptParams.setPromptText(promptText);
+        Result interactionResult = m_authenticationPlugins[authPluginName]->beginUserInputInteraction(
+                    callerPid,
+                    requestId,
+                    promptParams,
+                    QString());
+        if (interactionResult.code() == Result::Failed) {
+            return interactionResult;
+        }
+
+        // calls useCollectionKeyPreCheckWithAuthenticationCode when finished
+        m_pendingRequests.insert(requestId,
+                                 Daemon::ApiImpl::RequestProcessor::PendingRequest(
+                                     callerPid,
+                                     requestId,
+                                     Daemon::ApiImpl::UseCollectionKeyPreCheckRequest,
+                                     QVariantList() << QVariant::fromValue<Secret::Identifier>(identifier)
+                                                    << QVariant::fromValue<Sailfish::Crypto::CryptoManager::Operation>(operation)
+                                                    << cryptoPluginName
+                                                    << userInteractionMode
+                                                    << QVariant::fromValue<CollectionMetadata>(collectionMetadata)));
+        return Result(Result::Pending);
+    }
+
+    const QString hashedCollectionName = calculateSecretNameHash(
+                Secret::Identifier(QString(), identifier.collectionName(), identifier.storagePluginName()));
+    if (m_collectionEncryptionKeys.contains(hashedCollectionName)) {
+        useCollectionKeyPreCheckWithEncryptionKey(
+                    callerPid,
+                    requestId,
+                    identifier,
+                    collectionMetadata,
+                    m_collectionEncryptionKeys.value(hashedCollectionName));
+        return Result(Result::Pending);
+    }
+
+    if (collectionMetadata.usesDeviceLockKey) {
+        // Perform a "verify" UI flow (if the user interaction mode allows).
+        // If that succeeds, unlock the collection with the stored devicelock key and continue.
+        if (userInteractionMode == Sailfish::Secrets::SecretManager::PreventInteraction) {
+            return Result(Result::CollectionIsLockedError,
+                          QString::fromLatin1("Collection %1 is locked and requires device lock authentication")
+                          .arg(identifier.collectionName()));
+        }
+
+        // always use the system authentication plugin for device lock authentication requests.
+        const QString systemAuthenticationPlugin = m_autotestMode
+                ? (SecretManager::DefaultAuthenticationPluginName + QLatin1String(".test"))
+                : SecretManager::DefaultAuthenticationPluginName;
+        Result result = m_authenticationPlugins[systemAuthenticationPlugin]->beginAuthentication(
+                    callerPid,
+                    requestId,
+                    promptText);
+        if (result.code() == Result::Failed) {
+            return result;
+        }
+
+        // calls useCollectionKeyPreCheckWithEncryptionKey when finished
+        m_pendingRequests.insert(requestId,
+                                 Daemon::ApiImpl::RequestProcessor::PendingRequest(
+                                     callerPid,
+                                     requestId,
+                                     Daemon::ApiImpl::UseCollectionKeyPreCheckRequest,
+                                     QVariantList() << QVariant::fromValue<Secret::Identifier>(identifier)
+                                                    << QVariant::fromValue<CollectionMetadata>(collectionMetadata)));
+        return result;
+    } else if (userInteractionMode == SecretManager::PreventInteraction) {
+        return Result(Result::OperationRequiresUserInteraction,
+                      QString::fromLatin1("Authentication plugin %1 requires user interaction")
+                      .arg(authPluginName));
+    } else if (!m_authenticationPlugins.contains(authPluginName)) {
+        // TODO: stale data in metadata db?
+        return Result(Result::InvalidExtensionPluginError,
+                      QStringLiteral("Unknown collection authentication plugin: %1")
+                      .arg(authPluginName));
+    }
+
+    // perform the user input flow required to get the input key data which will be used
+    // to unlock this collection.
+    InteractionParameters promptParams;
+    promptParams.setApplicationId(callerApplicationId);
+    promptParams.setPluginName(identifier.storagePluginName());
+    promptParams.setCollectionName(identifier.collectionName());
+    promptParams.setSecretName(identifier.name());
+    promptParams.setOperation(InteractionParameters::StoreSecret);
+    promptParams.setInputType(InteractionParameters::AlphaNumericInput);
+    promptParams.setEchoMode(InteractionParameters::PasswordEcho);
+    promptParams.setPromptText(promptText);
+    Result interactionResult = m_authenticationPlugins[authPluginName]->beginUserInputInteraction(
+                callerPid,
+                requestId,
+                promptParams,
+                QString());
+    if (interactionResult.code() == Result::Failed) {
+        return interactionResult;
+    }
+
+    // calls useCollectionKeyPreCheckWithAuthenticationCode when finished
+    m_pendingRequests.insert(requestId,
+                             Daemon::ApiImpl::RequestProcessor::PendingRequest(
+                                 callerPid,
+                                 requestId,
+                                 Daemon::ApiImpl::UseCollectionKeyPreCheckRequest,
+                                 QVariantList() << QVariant::fromValue<Secret::Identifier>(identifier)
+                                                << QVariant::fromValue<Sailfish::Crypto::CryptoManager::Operation>(operation)
+                                                << cryptoPluginName
+                                                << userInteractionMode
+                                                << QVariant::fromValue<CollectionMetadata>(collectionMetadata)));
+    return Result(Result::Pending);
+}
+
+Result
+Daemon::ApiImpl::RequestProcessor::useCollectionKeyPreCheckWithAuthenticationCode(
+        pid_t callerPid,
+        quint64 requestId,
+        const Secret::Identifier &identifier,
+        Sailfish::Crypto::CryptoManager::Operation operation,
+        const QString &cryptoPluginName,
+        SecretManager::UserInteractionMode userInteractionMode,
+        const CollectionMetadata &collectionMetadata,
+        const QByteArray &authenticationCode)
+{
+    // TODO: we may need to automatically unlock the plugin if plugin is locked?
+    Q_UNUSED(operation)
+    Q_UNUSED(cryptoPluginName);
+    Q_UNUSED(userInteractionMode);
+
+    // generate the encryption key from the authentication code
+    if (identifier.storagePluginName() == collectionMetadata.encryptionPluginName
+            || collectionMetadata.encryptionPluginName.isEmpty()) {
+        if (!m_encryptedStoragePlugins.contains(identifier.storagePluginName())) {
+            // TODO: stale data in the database?
+            return Result(Result::InvalidExtensionPluginError,
+                          QStringLiteral("Unknown collection encrypted storage plugin: %1")
+                          .arg(identifier.storagePluginName()));
+        }
+    } else if (!m_encryptionPlugins.contains(collectionMetadata.encryptionPluginName)) {
+        // TODO: stale data in the database?
+        return Result(Result::InvalidExtensionPluginError,
+                      QStringLiteral("Unknown collection encryption plugin: %1").arg(collectionMetadata.encryptionPluginName));
+    }
+
+    QFutureWatcher<DerivedKeyResult> *watcher
+            = new QFutureWatcher<DerivedKeyResult>(this);
+    QFuture<DerivedKeyResult> future;
+    if (identifier.storagePluginName() == collectionMetadata.encryptionPluginName
+            || collectionMetadata.encryptionPluginName.isEmpty()) {
+        future = QtConcurrent::run(
+                    m_requestQueue->secretsThreadPool().data(),
+                    EncryptedStoragePluginFunctionWrapper::deriveKeyFromCode,
+                    m_encryptedStoragePlugins[identifier.storagePluginName()],
+                    authenticationCode,
+                    m_requestQueue->saltData());
+    } else {
+        future = QtConcurrent::run(
+                    m_requestQueue->secretsThreadPool().data(),
+                    EncryptionPluginFunctionWrapper::deriveKeyFromCode,
+                    m_encryptionPlugins[collectionMetadata.encryptionPluginName],
+                    authenticationCode,
+                    m_requestQueue->saltData());
+    }
+
+    watcher->setFuture(future);
+    connect(watcher, &QFutureWatcher<DerivedKeyResult>::finished, [=] {
+        watcher->deleteLater();
+        DerivedKeyResult dkr = watcher->future().result();
+        if (dkr.result.code() != Result::Succeeded) {
+            QVariantList outParams;
+            outParams << QVariant::fromValue<Result>(dkr.result);
+            m_requestQueue->requestFinished(requestId, outParams);
+        } else {
+            useCollectionKeyPreCheckWithEncryptionKey(
+                        callerPid,
+                        requestId,
+                        identifier,
+                        collectionMetadata,
+                        dkr.key);
+        }
+    });
+
+    return Result(Result::Pending);
+}
+
+void
+Daemon::ApiImpl::RequestProcessor::useCollectionKeyPreCheckWithEncryptionKey(
+        pid_t callerPid,
+        quint64 requestId,
+        const Secret::Identifier &identifier,
+        const CollectionMetadata &collectionMetadata,
+        const QByteArray &collectionDecryptionKey)
+{
+    Q_UNUSED(callerPid);
+    QFutureWatcher<Result> *watcher
+            = new QFutureWatcher<Result>(this);
+    QFuture<Result> future;
+    if (identifier.storagePluginName() == collectionMetadata.encryptionPluginName
+            || collectionMetadata.encryptionPluginName.isEmpty()) {
+        bool requiresRelock = !collectionDecryptionKey.isEmpty() &&
+                ((!collectionMetadata.usesDeviceLockKey
+                  && collectionMetadata.unlockSemantic != SecretManager::CustomLockKeepUnlocked)
+                || (collectionMetadata.usesDeviceLockKey
+                  && collectionMetadata.unlockSemantic != SecretManager::DeviceLockKeepUnlocked));
+        future = QtConcurrent::run(
+                    m_requestQueue->secretsThreadPool().data(),
+                    EncryptedStoragePluginFunctionWrapper::collectionSecretPreCheck,
+                    m_encryptedStoragePlugins[identifier.storagePluginName()],
+                    CollectionInfo(identifier.collectionName(),
+                                   collectionDecryptionKey,
+                                   requiresRelock),
+                    identifier.name(),
+                    false);
+    } else {
+        future = QtConcurrent::run(
+                    m_requestQueue->secretsThreadPool().data(),
+                    StoragePluginFunctionWrapper::collectionSecretPreCheck,
+                    m_storagePlugins[identifier.storagePluginName()],
+                    identifier.collectionName(),
+                    identifier.name(),
+                    false);
+    }
+
+    watcher->setFuture(future);
+    connect(watcher, &QFutureWatcher<Result>::finished, [=] {
+        watcher->deleteLater();
+        Result result = watcher->future().result();
+        QVariantList outParams;
+        outParams << QVariant::fromValue<Result>(result);
+        outParams << QVariant::fromValue<QByteArray>(collectionDecryptionKey);
+        m_requestQueue->requestFinished(requestId, outParams);
+    });
+}
+
+Result
 Daemon::ApiImpl::RequestProcessor::setCollectionKeyPreCheck(
         pid_t callerPid,
         quint64 requestId,
@@ -5277,17 +5740,19 @@ Daemon::ApiImpl::RequestProcessor::setCollectionKeyPreCheckWithEncryptionKey(
                     m_requestQueue->secretsThreadPool().data(),
                     EncryptedStoragePluginFunctionWrapper::collectionSecretPreCheck,
                     m_encryptedStoragePlugins[identifier.storagePluginName()],
-                    identifier.collectionName(),
+                    CollectionInfo(identifier.collectionName(),
+                                   collectionDecryptionKey,
+                                   requiresRelock),
                     identifier.name(),
-                    collectionDecryptionKey,
-                    requiresRelock);
+                    true);
     } else {
         future = QtConcurrent::run(
                     m_requestQueue->secretsThreadPool().data(),
                     StoragePluginFunctionWrapper::collectionSecretPreCheck,
                     m_storagePlugins[identifier.storagePluginName()],
                     identifier.collectionName(),
-                    identifier.name());
+                    identifier.name(),
+                    true);
     }
 
     watcher->setFuture(future);
@@ -5567,6 +6032,23 @@ Daemon::ApiImpl::RequestProcessor::userInputInteractionCompleted(
                     }
                     break;
                 }
+                case UseCollectionKeyPreCheckRequest: {
+                    if (pr.parameters.size() != 5) {
+                        returnResult = Result(Result::UnknownError,
+                                              QLatin1String("Internal error: incorrect parameter count!"));
+                    } else {
+                        returnResult = useCollectionKeyPreCheckWithAuthenticationCode(
+                                    pr.callerPid,
+                                    pr.requestId,
+                                    pr.parameters.takeFirst().value<Secret::Identifier>(),
+                                    pr.parameters.takeFirst().value<Sailfish::Crypto::CryptoManager::Operation>(),
+                                    pr.parameters.takeFirst().value<QString>(),
+                                    static_cast<SecretManager::UserInteractionMode>(pr.parameters.takeFirst().value<int>()),
+                                    pr.parameters.takeFirst().value<CollectionMetadata>(),
+                                    userInput);
+                    }
+                    break;
+                }
                 case SetCollectionKeyPreCheckRequest: {
                     if (pr.parameters.size() != 3) {
                         returnResult = Result(Result::UnknownError,
@@ -5760,6 +6242,21 @@ void Daemon::ApiImpl::RequestProcessor::authenticationCompleted(
                                     pr.parameters.takeFirst().value<Secret::Identifier>(),
                                     static_cast<SecretManager::UserInteractionMode>(pr.parameters.takeFirst().value<int>()),
                                     pr.parameters.takeFirst().value<QString>(),
+                                    pr.parameters.takeFirst().value<CollectionMetadata>(),
+                                    m_requestQueue->deviceLockKey());
+                        returnResult = Result(Result::Pending);
+                    }
+                    break;
+                }
+                case UseCollectionKeyPreCheckRequest: {
+                    if (pr.parameters.size() != 3) {
+                        returnResult = Result(Result::UnknownError,
+                                              QLatin1String("Internal error: incorrect parameter count!"));
+                    } else {
+                        useCollectionKeyPreCheckWithEncryptionKey(
+                                    pr.callerPid,
+                                    pr.requestId,
+                                    pr.parameters.takeFirst().value<Secret::Identifier>(),
                                     pr.parameters.takeFirst().value<CollectionMetadata>(),
                                     m_requestQueue->deviceLockKey());
                         returnResult = Result(Result::Pending);

--- a/daemon/SecretsImpl/secretsrequestprocessor_p.h
+++ b/daemon/SecretsImpl/secretsrequestprocessor_p.h
@@ -39,6 +39,8 @@
 
 #include "requestqueue_p.h"
 
+#include "Crypto/cryptomanager.h"
+
 namespace Sailfish {
 
 namespace Crypto {
@@ -248,6 +250,16 @@ public:
             const Sailfish::Secrets::InteractionParameters &interactionParams,
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress);
+
+    // use a crypto key pre-check (crypto api bridge)
+    Sailfish::Secrets::Result useCollectionKeyPreCheck(
+            pid_t callerPid,
+            quint64 requestId,
+            const Sailfish::Secrets::Secret::Identifier &identifier,
+            Sailfish::Crypto::CryptoManager::Operation operation,
+            const QString &cryptoPluginName,
+            Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
+            QByteArray *collectionDecryptionKey);
 
     // store a crypto key pre-check (crypto api bridge)
     Sailfish::Secrets::Result setCollectionKeyPreCheck(
@@ -577,6 +589,32 @@ private:
             Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
             const QString &interactionServiceAddress,
             const QByteArray &lockCode);
+
+    Sailfish::Secrets::Result useCollectionKeyPreCheckWithMetadata(
+            pid_t callerPid,
+            quint64 requestId,
+            const Sailfish::Secrets::Secret::Identifier &identifier,
+            Sailfish::Crypto::CryptoManager::Operation operation,
+            const QString &cryptoPluginName,
+            Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
+            const CollectionMetadata &collectionMetadata);
+
+    Sailfish::Secrets::Result useCollectionKeyPreCheckWithAuthenticationCode(
+            pid_t callerPid,
+            quint64 requestId,
+            const Sailfish::Secrets::Secret::Identifier &identifier,
+            Sailfish::Crypto::CryptoManager::Operation operation,
+            const QString &cryptoPluginName,
+            Sailfish::Secrets::SecretManager::UserInteractionMode userInteractionMode,
+            const CollectionMetadata &collectionMetadata,
+            const QByteArray &authenticationCode);
+
+    void useCollectionKeyPreCheckWithEncryptionKey(
+            pid_t callerPid,
+            quint64 requestId,
+            const Sailfish::Secrets::Secret::Identifier &identifier,
+            const CollectionMetadata &collectionMetadata,
+            const QByteArray &collectionDecryptionKey);
 
     Sailfish::Secrets::Result setCollectionKeyPreCheckWithMetadata(
             pid_t callerPid,

--- a/lib/Crypto/key.h
+++ b/lib/Crypto/key.h
@@ -30,6 +30,7 @@ class SAILFISH_CRYPTO_API Key
     Q_GADGET
     Q_PROPERTY(QString name READ name WRITE setName)
     Q_PROPERTY(QString collectionName READ collectionName WRITE setCollectionName)
+    Q_PROPERTY(QString storagePluginName READ storagePluginName WRITE setStoragePluginName)
     Q_PROPERTY(Origin origin READ origin WRITE setOrigin)
     Q_PROPERTY(Sailfish::Crypto::CryptoManager::Algorithm algorithm READ algorithm WRITE setAlgorithm)
     Q_PROPERTY(Sailfish::Crypto::CryptoManager::Operations operations READ operations WRITE setOperations)

--- a/tests/qml/tst_qml_signing/tst_qml_signing.qml
+++ b/tests/qml/tst_qml_signing/tst_qml_signing.qml
@@ -115,6 +115,7 @@ TestCase {
     CollectionNamesRequest {
         id: collectionNamesRequest
         manager: secretManager
+        storagePluginName: cryptoManager.defaultCryptoStoragePluginName + ".test"
     }
 
     CreateCollectionRequest {
@@ -140,19 +141,20 @@ TestCase {
     StoredKeyIdentifiersRequest {
         id: storedKeyIdentifiersRequest
         manager: cryptoManager
+        storagePluginName: cryptoManager.defaultCryptoStoragePluginName + ".test"
     }
 
     GenerateStoredKeyRequest {
         id: generateStoredKeyRequest
         manager: cryptoManager
         cryptoPluginName: cryptoManager.defaultCryptoStoragePluginName + ".test"
-        storagePluginName: cryptoManager.defaultCryptoStoragePluginName + ".test"
         keyTemplate {
             size: 4096
             origin: Key.OriginDevice
             algorithm: CryptoManager.AlgorithmRsa
             name: testKeyName
             collectionName: testCaseCollectionName
+            storagePluginName: cryptoManager.defaultCryptoStoragePluginName + ".test"
         }
         keyPairGenerationParameters: cryptoManager.constructRsaKeygenParams()
     }
@@ -165,6 +167,7 @@ TestCase {
             algorithm: CryptoManager.AlgorithmRsa
             name: testKeyName
             collectionName: testCaseCollectionName
+            storagePluginName: cryptoManager.defaultCryptoStoragePluginName + ".test"
         }
         digestFunction: CryptoManager.DigestSha512
         padding: CryptoManager.SignaturePaddingNone
@@ -178,6 +181,7 @@ TestCase {
             algorithm: CryptoManager.AlgorithmRsa
             name: testKeyName
             collectionName: testCaseCollectionName
+            storagePluginName: cryptoManager.defaultCryptoStoragePluginName + ".test"
         }
         digestFunction: CryptoManager.DigestSha512
         padding: CryptoManager.SignaturePaddingNone

--- a/tools/secrets-tool/manual-test.sh
+++ b/tools/secrets-tool/manual-test.sh
@@ -17,7 +17,7 @@ secrets-tool --test --delete-collection-secret org.sailfishos.secrets.plugin.enc
 echo "Generating 2048-bit RSA key within MyCollection..."
 secrets-tool --test --generate-stored-key org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyRsaKey RSA 2048
 echo "Listing keys from MyCollection to ensure key generation succeeded..."
-secrets-tool --test --list-keys org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test
+secrets-tool --test --list-keys org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection
 echo "Generating test document to sign..."
 echo "This is a text document containing some plain text data which I would like signed or encrypted." > document.txt
 echo "Signing test document with RSA key..."
@@ -30,8 +30,8 @@ echo "Generating salt data for AES key generation..."
 head -c 16 /dev/urandom > salt.data
 echo "Generating 256-bit AES key from passphrase..."
 secrets-tool --test --derive-stored-key org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyAesKey AES 256 salt.data
-echo "Listing keys from MyCollection to ensure key generation succeeded..."
-secrets-tool --test --list-keys org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test
+echo "Listing keys from MyCollection to ensure key derivation succeeded..."
+secrets-tool --test --list-keys org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection
 echo "Encrypting test document with AES key..."
 secrets-tool --test --encrypt org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyAesKey document.txt > document.txt.enc
 echo "Decrypting ciphertext with AES key..."
@@ -42,6 +42,8 @@ echo "Using ssh-keygen to generate RSA key to import..."
 ssh-keygen -t rsa -b 2048 -N abcde -f importfile.pem
 echo "Importing generated RSA key from file..."
 secrets-tool --test --import-stored-key org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyImportedKey importfile.pem
+echo "Listing keys from MyCollection to ensure key import succeeded..."
+secrets-tool --test --list-keys org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection
 echo "Signing test document with imported RSA key..."
 secrets-tool --test --sign org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test MyCollection MyImportedKey SHA256 document.txt > document.txt.sig2
 echo "Verifying signature with imported RSA key..."


### PR DESCRIPTION
If a collection which contains a key is currently locked (due to the
unlock semantic being AccessRelock, for example), then if a client
attempts to use that key (e.g. to encrypt/decrypt/sign/verify) the
user should be prompted to unlock the collection in order to allow
the key to be retrieved in order to perform the operation.

This commit ensures that this occurs, where previously the operations
would have failed with a CollectionLocked error.

Contributes to JB#40058