### PR TITLE
[sailfish-secrets] Make PluginInfo read-only, fixes #90.

### DIFF
--- a/lib/Crypto/plugininfo.cpp
+++ b/lib/Crypto/plugininfo.cpp
@@ -91,14 +91,6 @@ PluginInfo& PluginInfo::operator=(const PluginInfo &other)
 }
 
 /*!
- * \brief Sets the display name reported for the plugin to \a dispName
- */
-void PluginInfo::setDisplayName(const QString &dispName)
-{
-    d_ptr->m_displayName = dispName;
-}
-
-/*!
  * \brief Returns the display name of the plugin
  *
  * This is the user-friendly, human-readable name reported by the
@@ -107,14 +99,6 @@ void PluginInfo::setDisplayName(const QString &dispName)
 QString PluginInfo::displayName() const
 {
     return d_ptr->m_displayName;
-}
-
-/*!
- * \brief Sets the name reported for the plugin to \a name
- */
-void PluginInfo::setName(const QString &name)
-{
-    d_ptr->m_name = name;
 }
 
 /*!
@@ -129,27 +113,11 @@ QString PluginInfo::name() const
 }
 
 /*!
- * \brief Sets the version of the plugin to \a version
- */
-void PluginInfo::setVersion(int version)
-{
-    d_ptr->m_version = version;
-}
-
-/*!
  * \brief Returns the version of the plugin
  */
 int PluginInfo::version() const
 {
     return d_ptr->m_version;
-}
-
-/*!
- * \brief Sets the status flags of the plugin to \a status
- */
-void PluginInfo::setStatusFlags(PluginInfo::StatusFlags status)
-{
-    d_ptr->m_statusFlags = status;
 }
 
 /*!

--- a/lib/Crypto/plugininfo.h
+++ b/lib/Crypto/plugininfo.h
@@ -22,10 +22,10 @@ class PluginInfoPrivate;
 class SAILFISH_CRYPTO_API PluginInfo
 {
     Q_GADGET
-    Q_PROPERTY(QString displayName READ displayName WRITE setDisplayName)
-    Q_PROPERTY(QString name READ name WRITE setName)
-    Q_PROPERTY(int version READ version WRITE setVersion)
-    Q_PROPERTY(StatusFlags statusFlags READ statusFlags WRITE setStatusFlags)
+    Q_PROPERTY(QString displayName READ displayName CONSTANT)
+    Q_PROPERTY(QString name READ name CONSTANT)
+    Q_PROPERTY(int version READ version CONSTANT)
+    Q_PROPERTY(StatusFlags statusFlags READ statusFlags CONSTANT)
 
 public:
     enum Status {
@@ -49,17 +49,13 @@ public:
 
     PluginInfo &operator=(const Sailfish::Crypto::PluginInfo &other);
 
-    void setDisplayName(const QString &dispName);
     QString displayName() const;
 
-    void setName(const QString &name);
     QString name() const;
 
-    void setVersion(int version);
     int version() const;
 
     StatusFlags statusFlags() const;
-    void setStatusFlags(StatusFlags status);
 
 private:
     QSharedDataPointer<PluginInfoPrivate> d_ptr;

--- a/lib/Crypto/serialization.cpp
+++ b/lib/Crypto/serialization.cpp
@@ -660,10 +660,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, PluginInfo &info)
     argument.beginStructure();
     argument >> displayName >> name >> version >> iStatusFlags;
     argument.endStructure();
-    info.setDisplayName(displayName);
-    info.setName(name);
-    info.setVersion(version);
-    info.setStatusFlags(static_cast<PluginInfo::StatusFlags>(iStatusFlags));
+    info = PluginInfo(displayName, name, version, static_cast<PluginInfo::StatusFlags>(iStatusFlags));
     return argument;
 }
 

--- a/lib/Secrets/plugininfo.cpp
+++ b/lib/Secrets/plugininfo.cpp
@@ -91,14 +91,6 @@ PluginInfo& PluginInfo::operator=(const PluginInfo &other)
 }
 
 /*!
- * \brief Sets the display name reported for the plugin to \a dispName
- */
-void PluginInfo::setDisplayName(const QString &dispName)
-{
-    d_ptr->m_displayName = dispName;
-}
-
-/*!
  * \brief Returns the display name of the plugin
  *
  * This is the user-friendly, human-readable name reported by the
@@ -107,14 +99,6 @@ void PluginInfo::setDisplayName(const QString &dispName)
 QString PluginInfo::displayName() const
 {
     return d_ptr->m_displayName;
-}
-
-/*!
- * \brief Sets the name reported for the plugin to \a name
- */
-void PluginInfo::setName(const QString &name)
-{
-    d_ptr->m_name = name;
 }
 
 /*!
@@ -129,27 +113,11 @@ QString PluginInfo::name() const
 }
 
 /*!
- * \brief Sets the version of the plugin to \a version
- */
-void PluginInfo::setVersion(int version)
-{
-    d_ptr->m_version = version;
-}
-
-/*!
  * \brief Returns the version of the plugin
  */
 int PluginInfo::version() const
 {
     return d_ptr->m_version;
-}
-
-/*!
- * \brief Sets the status flags of the plugin to \a status
- */
-void PluginInfo::setStatusFlags(PluginInfo::StatusFlags status)
-{
-    d_ptr->m_statusFlags = status;
 }
 
 /*!

--- a/lib/Secrets/plugininfo.h
+++ b/lib/Secrets/plugininfo.h
@@ -22,10 +22,10 @@ class PluginInfoPrivate;
 class SAILFISH_SECRETS_API PluginInfo
 {
     Q_GADGET
-    Q_PROPERTY(QString displayName READ displayName WRITE setDisplayName)
-    Q_PROPERTY(QString name READ name WRITE setName)
-    Q_PROPERTY(int version READ version WRITE setVersion)
-    Q_PROPERTY(StatusFlags statusFlags READ statusFlags WRITE setStatusFlags)
+    Q_PROPERTY(QString displayName READ displayName CONSTANT)
+    Q_PROPERTY(QString name READ name CONSTANT)
+    Q_PROPERTY(int version READ version CONSTANT)
+    Q_PROPERTY(StatusFlags statusFlags READ statusFlags CONSTANT)
 
 public:
     enum Status {
@@ -49,17 +49,13 @@ public:
 
     PluginInfo &operator=(const Sailfish::Secrets::PluginInfo &other);
 
-    void setDisplayName(const QString &dispName);
     QString displayName() const;
 
-    void setName(const QString &name);
     QString name() const;
 
-    void setVersion(int version);
     int version() const;
 
     StatusFlags statusFlags() const;
-    void setStatusFlags(StatusFlags status);
 
 private:
     QSharedDataPointer<PluginInfoPrivate> d_ptr;

--- a/lib/Secrets/serialization.cpp
+++ b/lib/Secrets/serialization.cpp
@@ -207,10 +207,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, PluginInfo &info)
     argument.beginStructure();
     argument >> displayName >> name >> version >> iStatusFlags;
     argument.endStructure();
-    info.setDisplayName(displayName);
-    info.setName(name);
-    info.setVersion(version);
-    info.setStatusFlags(static_cast<PluginInfo::StatusFlags>(iStatusFlags));
+    info = PluginInfo(displayName, name, version, static_cast<PluginInfo::StatusFlags>(iStatusFlags));
     return argument;
 }
 


### PR DESCRIPTION
This PR removes the setters method from PluginInfo structure to better reflect its read-only purpose, as discussed in #90.