### PR TITLE
[secrets] Change SecretsDaemonLocked error to IncorrectAuthenticationCode when unlocking master. Contributes to JB#41552

### DIFF
--- a/daemon/SecretsImpl/secretsrequestprocessor.cpp
+++ b/daemon/SecretsImpl/secretsrequestprocessor.cpp
@@ -4509,7 +4509,7 @@ Daemon::ApiImpl::RequestProcessor::modifyLockCodeWithLockCodes(
 
     // otherwise, we are modifying the "master" lock code for the bookkeeping database.
     if (!m_requestQueue->testLockCode(oldLockCode)) {
-        return Result(Result::SecretsDaemonLockedError,
+        return Result(Result::IncorrectAuthenticationCodeError,
                       QLatin1String("The given old lock code was incorrect"));
     }
 


### PR DESCRIPTION
Another similar one

See also: https://github.com/sailfishos/sailfish-secrets/pull/107