### PR TITLE
[sailfish-secrets] Add InteractionViewUserCanceledError error code. Contributes to JB#36797

### DIFF
--- a/lib/Secrets/interactionrequest.cpp
+++ b/lib/Secrets/interactionrequest.cpp
@@ -36,7 +36,7 @@ InteractionRequestPrivate::InteractionRequestPrivate()
  * input directly that way, however some daemon services without any
  * UI capability may need to use this request type to retrieve
  * non-sensitive or transient data from the user.
- * *
+ *
  * An example of retrieving user input follows:
  *
  * \code
@@ -55,6 +55,10 @@ InteractionRequestPrivate::InteractionRequestPrivate()
  * ir.waitForFinished(); // or better: connect to statusChanged()
  * QByteArray userInput = ir.userInput();
  * \endcode
+ *
+ * Note that if the user canceled the user input (or authentication
+ * or confirmation) dialog the result will contain the
+ * \c{Result::InteractionViewUserCanceledError} error code.
  */
 
 /*!

--- a/lib/Secrets/result.h
+++ b/lib/Secrets/result.h
@@ -85,6 +85,7 @@ public:
         InteractionViewParentError,
         InteractionViewChildError,
         InteractionViewError,
+        InteractionViewUserCanceledError,
 
         NetworkError = 98,
         NetworkSslError = 99,


### PR DESCRIPTION
If the user cancels a user input dialog, we should report this as
differently to other failures (e.g. dbus communication failure).
This commit adds a specific error code to denote this case, and
ensures that the passwordagent plugin returns that error code
from user input flows which are canceled.

Contributes to JB#36797