### PR TITLE
[sailfish-secrets] Report collection lock state from CollectionNamesRequest. Contributes to JB#36797

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -4,3 +4,4 @@ unix|macx {
 
 QT -= gui
 CONFIG += rtti_off
+CONFIG += c++11

--- a/daemon/SecretsImpl/pluginfunctionwrappers.cpp
+++ b/daemon/SecretsImpl/pluginfunctionwrappers.cpp
@@ -292,9 +292,11 @@ IdentifiersResult Daemon::ApiImpl::storedKeyIdentifiers(
                       const QVariantMap &customParameters,
                       Result *result,
                       QVector<Secret::Identifier> *idents) {
+        QVariantMap cnamesMap;
         QStringList cnames;
         QStringList knames;
-        *result = p->collectionNames(&cnames);
+        *result = p->collectionNames(&cnamesMap);
+        cnames = cnamesMap.keys();
         if (result->code() != Result::Succeeded) {
             return;
         }
@@ -529,9 +531,9 @@ SecretMetadataResult StoragePluginFunctionWrapper::secretMetadata(
 CollectionNamesResult StoragePluginFunctionWrapper::collectionNames(
         StoragePluginWrapper *plugin)
 {
-    QStringList cnames;
-    Result result = plugin->collectionNames(&cnames);
-    return CollectionNamesResult(result, cnames);
+    QVariantMap cnamesMap;
+    Result result = plugin->collectionNames(&cnamesMap);
+    return CollectionNamesResult(result, cnamesMap);
 }
 
 Result StoragePluginFunctionWrapper::createCollection(
@@ -671,7 +673,9 @@ StoragePluginFunctionWrapper::reencryptDeviceLockedCollectionsAndSecrets(
     // foreach collection, get metadata
     // if usesDeviceLockKey, re-encrypt
     QStringList cnames;
-    Result result = plugin->collectionNames(&cnames);
+    QVariantMap cnamesMap;
+    Result result = plugin->collectionNames(&cnamesMap);
+    cnames = cnamesMap.keys();
     if (result.code() != Result::Succeeded) {
         return result;
     }
@@ -754,7 +758,9 @@ StoragePluginFunctionWrapper::collectionSecretPreCheck(
         bool newSecret)
 {
     QStringList cnames;
-    Result result = plugin->collectionNames(&cnames);
+    QVariantMap cnamesMap;
+    Result result = plugin->collectionNames(&cnamesMap);
+    cnames = cnamesMap.keys();
     if (result.code() != Result::Succeeded) {
         return result;
     }
@@ -842,9 +848,9 @@ SecretMetadataResult EncryptedStoragePluginFunctionWrapper::secretMetadata(
 CollectionNamesResult EncryptedStoragePluginFunctionWrapper::collectionNames(
         EncryptedStoragePluginWrapper *plugin)
 {
-    QStringList cnames;
-    Result result = plugin->collectionNames(&cnames);
-    return CollectionNamesResult(result, cnames);
+    QVariantMap cnamesMap;
+    Result result = plugin->collectionNames(&cnamesMap);
+    return CollectionNamesResult(result, cnamesMap);
 }
 
 Result EncryptedStoragePluginFunctionWrapper::createCollection(
@@ -1231,7 +1237,9 @@ Result EncryptedStoragePluginFunctionWrapper::unlockDeviceLockedCollectionsAndRe
 {
     // find out which collections are device-locked
     QStringList cnames;
-    Result result = plugin->collectionNames(&cnames);
+    QVariantMap cnamesMap;
+    Result result = plugin->collectionNames(&cnamesMap);
+    cnames = cnamesMap.keys();
     if (result.code() != Result::Succeeded) {
         return result;
     }
@@ -1351,7 +1359,9 @@ Result EncryptedStoragePluginFunctionWrapper::collectionSecretPreCheck(
         bool newSecret)
 {
     QStringList cnames;
-    Result result = plugin->collectionNames(&cnames);
+    QVariantMap cnamesMap;
+    Result result = plugin->collectionNames(&cnamesMap);
+    cnames = cnamesMap.keys();
     if (result.code() != Result::Succeeded) {
         return result;
     }

--- a/daemon/SecretsImpl/pluginfunctionwrappers_p.h
+++ b/daemon/SecretsImpl/pluginfunctionwrappers_p.h
@@ -63,12 +63,12 @@ struct CollectionMetadataResult {
 
 struct CollectionNamesResult {
     CollectionNamesResult(const Sailfish::Secrets::Result &r = Sailfish::Secrets::Result(),
-                      const QStringList &cns = QStringList())
+                      const QVariantMap &cns = QVariantMap())
         : result(r), collectionNames(cns) {}
     CollectionNamesResult(const CollectionNamesResult &other)
         : result(other.result), collectionNames(other.collectionNames) {}
     Sailfish::Secrets::Result result;
-    QStringList collectionNames;
+    QVariantMap collectionNames;
 };
 
 struct IdentifiersResult {

--- a/daemon/SecretsImpl/pluginwrapper_p.h
+++ b/daemon/SecretsImpl/pluginwrapper_p.h
@@ -43,7 +43,7 @@ public:
     virtual Sailfish::Secrets::Result collectionMetadata(const QString &collectionName, CollectionMetadata *metadata) = 0;
     virtual Sailfish::Secrets::Result secretMetadata(const QString &collectionName, const QString &secretName, SecretMetadata *metadata) = 0;
     virtual Sailfish::Secrets::Result keyNames(const QString &collectionName, const QVariantMap &customParameters, QStringList *keyNames) = 0;
-    virtual Sailfish::Secrets::Result collectionNames(QStringList *names) const = 0;
+    virtual Sailfish::Secrets::Result collectionNames(QVariantMap *names) const = 0; // map of name to isLocked
     virtual Sailfish::Secrets::Result secretNames(const QString &collectionName, QStringList *secretNames) const = 0;
 
     QString displayName() const Q_DECL_OVERRIDE;
@@ -81,7 +81,7 @@ public:
     Sailfish::Secrets::Result collectionMetadata(const QString &collectionName, CollectionMetadata *metadata) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result secretMetadata(const QString &collectionName, const QString &secretName, SecretMetadata *metadata) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result keyNames(const QString &collectionName, const QVariantMap &customParameters, QStringList *keyNames) Q_DECL_OVERRIDE;
-    Sailfish::Secrets::Result collectionNames(QStringList *names) const Q_DECL_OVERRIDE;
+    Sailfish::Secrets::Result collectionNames(QVariantMap *names) const Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result secretNames(const QString &collectionName, QStringList *secretNames) const Q_DECL_OVERRIDE;
 
     Sailfish::Secrets::StoragePlugin::StorageType storageType() const;
@@ -113,7 +113,7 @@ public:
     Sailfish::Secrets::Result collectionMetadata(const QString &collectionName, CollectionMetadata *metadata) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result secretMetadata(const QString &collectionName, const QString &secretName, SecretMetadata *metadata) Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result keyNames(const QString &collectionName, const QVariantMap &customParameters, QStringList *keyNames) Q_DECL_OVERRIDE;
-    Sailfish::Secrets::Result collectionNames(QStringList *names) const Q_DECL_OVERRIDE;
+    Sailfish::Secrets::Result collectionNames(QVariantMap *names) const Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result secretNames(const QString &collectionName, QStringList *secretNames) const Q_DECL_OVERRIDE;
 
     Sailfish::Secrets::StoragePlugin::StorageType storageType() const;

--- a/daemon/SecretsImpl/secrets.cpp
+++ b/daemon/SecretsImpl/secrets.cpp
@@ -97,7 +97,7 @@ void Daemon::ApiImpl::SecretsDBusObject::collectionNames(
         const QString &storagePluginName,
         const QDBusMessage &message,
         Sailfish::Secrets::Result &result,
-        QStringList &names)
+        QVariantMap &names)
 {
     Q_UNUSED(names); // outparam, set in handlePendingRequest / handleFinishedRequest
     QList<QVariant> inParams;
@@ -1004,7 +1004,7 @@ void Daemon::ApiImpl::SecretsRequestQueue::handlePendingRequest(
         case CollectionNamesRequest: {
             qCDebug(lcSailfishSecretsDaemon) << "Handling CollectionNamesRequest from client:" << request->remotePid << ", request number:" << request->requestId;
             QString storagePluginName = request->inParams.size() ? request->inParams.takeFirst().value<QString>() : QString();
-            QStringList names;
+            QVariantMap names;
             Result result = masterLocked()
                     ? Result(Result::SecretsDaemonLockedError,
                              QLatin1String("The secrets database is locked"))
@@ -1019,10 +1019,10 @@ void Daemon::ApiImpl::SecretsRequestQueue::handlePendingRequest(
                 *completed = false;
             } else {
                 if (request->isSecretsCryptoRequest) {
-                    asynchronousCryptoRequestCompleted(request->cryptoRequestId, result, QVariantList() << QVariant::fromValue<QStringList>(names));
+                    asynchronousCryptoRequestCompleted(request->cryptoRequestId, result, QVariantList() << QVariant::fromValue<QVariantMap>(names));
                 } else {
                     request->connection.send(request->message.createReply() << QVariant::fromValue<Result>(result)
-                                                                            << QVariant::fromValue<QStringList>(names));
+                                                                            << QVariant::fromValue<QVariantMap>(names));
                 }
                 *completed = true;
             }
@@ -1901,14 +1901,14 @@ void Daemon::ApiImpl::SecretsRequestQueue::handleFinishedRequest(
                 qCWarning(lcSailfishSecretsDaemon) << "CollectionNamesRequest:" << request->requestId << "finished as pending!";
                 *completed = true;
             } else {
-                QStringList names = request->outParams.size()
-                                  ? request->outParams.takeFirst().value<QStringList>()
-                                  : QStringList();
+                QVariantMap names = request->outParams.size()
+                                  ? request->outParams.takeFirst().value<QVariantMap>()
+                                  : QVariantMap();
                 if (request->isSecretsCryptoRequest) {
                     asynchronousCryptoRequestCompleted(request->cryptoRequestId, result, QVariantList() << names);
                 } else {
                     request->connection.send(request->message.createReply() << QVariant::fromValue<Result>(result)
-                                                                            << QVariant::fromValue<QStringList>(names));
+                                                                            << QVariant::fromValue<QVariantMap>(names));
                 }
                 *completed = true;
             }

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -73,7 +73,7 @@ class SecretsDBusObject : public QObject, protected QDBusContext
     "      <method name=\"collectionNames\">\n"
     "          <arg name=\"storagePluginName\" type=\"s\" direction=\"in\" />\n"
     "          <arg name=\"result\" type=\"(iis)\" direction=\"out\" />\n"
-    "          <arg name=\"names\" type=\"as\" direction=\"out\" />\n"
+    "          <arg name=\"names\" type=\"a{sv}\" direction=\"out\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Secrets::Result\" />\n"
     "      </method>\n"
     "      <method name=\"createCollection\">\n"
@@ -263,7 +263,7 @@ public Q_SLOTS:
             const QString &storagePluginName,
             const QDBusMessage &message,
             Sailfish::Secrets::Result &result,
-            QStringList &names);
+            QVariantMap &names);
 
     // create a DeviceLock-protected collection
     void createCollection(

--- a/daemon/SecretsImpl/secretsrequestprocessor.cpp
+++ b/daemon/SecretsImpl/secretsrequestprocessor.cpp
@@ -191,7 +191,7 @@ Daemon::ApiImpl::RequestProcessor::collectionNames(
         pid_t callerPid,
         quint64 requestId,
         const QString &storagePluginName,
-        QStringList *names)
+        QVariantMap *names)
 {
     Q_UNUSED(names); // asynchronous out-parameter.
 
@@ -232,7 +232,7 @@ Daemon::ApiImpl::RequestProcessor::collectionNames(
         CollectionNamesResult cnr = watcher->future().result();
         QVariantList outParams;
         outParams << QVariant::fromValue<Result>(cnr.result);
-        outParams << QVariant::fromValue<QStringList>(cnr.collectionNames);
+        outParams << QVariant::fromValue<QVariantMap>(cnr.collectionNames);
         m_requestQueue->requestFinished(requestId, outParams);
     });
 

--- a/daemon/SecretsImpl/secretsrequestprocessor_p.h
+++ b/daemon/SecretsImpl/secretsrequestprocessor_p.h
@@ -89,7 +89,7 @@ public:
             pid_t callerPid,
             quint64 requestId,
             const QString &storagePluginName,
-            QStringList *names);
+            QVariantMap *names);
 
     // create a DeviceLock-protected collection
     Sailfish::Secrets::Result createDeviceLockCollection(

--- a/lib/Secrets/collectionnamesrequest.h
+++ b/lib/Secrets/collectionnamesrequest.h
@@ -36,6 +36,8 @@ public:
 
     QStringList collectionNames() const;
 
+    Q_INVOKABLE bool isCollectionLocked(const QString &collectionName) const;
+
     Sailfish::Secrets::Request::Status status() const Q_DECL_OVERRIDE;
     Sailfish::Secrets::Result result() const Q_DECL_OVERRIDE;
 

--- a/lib/Secrets/collectionnamesrequest_p.h
+++ b/lib/Secrets/collectionnamesrequest_p.h
@@ -30,7 +30,7 @@ public:
 
     QPointer<Sailfish::Secrets::SecretManager> m_manager;
     QString m_storagePluginName;
-    QStringList m_collectionNames;
+    QMap<QString, bool> m_collectionNames; // name,isLocked
 
     QScopedPointer<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;

--- a/lib/Secrets/secretmanager.cpp
+++ b/lib/Secrets/secretmanager.cpp
@@ -128,17 +128,17 @@ SecretManagerPrivate::userInput(
 }
 
 
-QDBusPendingReply<Result, QStringList>
+QDBusPendingReply<Result, QVariantMap>
 SecretManagerPrivate::collectionNames(
         const QString &storagePluginName)
 {
     if (!m_interface) {
-        return QDBusPendingReply<Result, QStringList>(
+        return QDBusPendingReply<Result, QVariantMap>(
                     QDBusMessage::createError(QDBusError::Other,
                                               QStringLiteral("Not connected to daemon")));
     }
 
-    QDBusPendingReply<Result, QStringList> reply
+    QDBusPendingReply<Result, QVariantMap> reply
             = m_interface->asyncCallWithArgumentList(
                 QStringLiteral("collectionNames"),
                 QVariantList() << QVariant::fromValue<QString>(storagePluginName));

--- a/lib/Secrets/secretmanager_p.h
+++ b/lib/Secrets/secretmanager_p.h
@@ -58,8 +58,8 @@ public:
     QDBusPendingReply<Sailfish::Secrets::Result, QByteArray> userInput(
             const Sailfish::Secrets::InteractionParameters &uiParams);
 
-    // retrieve the names of collections
-    QDBusPendingReply<Sailfish::Secrets::Result, QStringList> collectionNames(
+    // retrieve the names of collections (map<name,isLocked>)
+    QDBusPendingReply<Sailfish::Secrets::Result, QVariantMap> collectionNames(
             const QString &storagePluginName);
 
     // create a DeviceLock-protected collection


### PR DESCRIPTION
This commit modifies the CollectionNamesRequest so that the lock
state of the collection is exposed, allowing the client to
modify its behaviour depending on the lock state of the collection,
rather than reacting to CollectionLocked errors.

Contributes to JB#36797