### PR TITLE
[sailfish-secrets] Initialize passwordagent once accepted. Contributes to JB#36797

### DIFF
--- a/daemon/plugin_p.cpp
+++ b/daemon/plugin_p.cpp
@@ -79,7 +79,7 @@ QVector<QPluginLoader*> Daemon::ApiImpl::PluginManager::loadPluginFiles()
     return result;
 }
 
-void Daemon::ApiImpl::PluginManager::addPlugin(QPluginLoader *loader, const PluginHelpers::PluginInfo &info, QObject *obj)
+bool Daemon::ApiImpl::PluginManager::addPlugin(QPluginLoader *loader, const PluginHelpers::PluginInfo &info, QObject *obj)
 {
     bool use = true;
 
@@ -102,11 +102,11 @@ void Daemon::ApiImpl::PluginManager::addPlugin(QPluginLoader *loader, const Plug
         if (!loader->unload()) {
             qCWarning(lcSailfishSecretsPlugins) << "Could not unload plugin:" << loader->fileName();
         }
-        delete loader;
-        return;
+    } else {
+        qCDebug(lcSailfishSecretsPlugins) << "Adding plugin:" << info.name << "from:" << loader->fileName();
+        m_plugins.insert(info.name, obj);
     }
 
-    qCDebug(lcSailfishSecretsPlugins) << "Adding plugin:" << info.name << "from:" << loader->fileName();
-    m_plugins.insert(info.name, obj);
     delete loader;
+    return use;
 }

--- a/lib/Secrets/Plugins/extensionplugins.cpp
+++ b/lib/Secrets/Plugins/extensionplugins.cpp
@@ -114,6 +114,21 @@ PluginBase::~PluginBase()
 }
 
 /*!
+ * \brief Initialize the plugin
+ *
+ * Derived types should override this method in order to perform
+ * initialization rather than doing so in the constructor, as this
+ * method will be called once the loaded plugin is accepted for
+ * use by the daemon.
+ *
+ * This allows the creation of e.g. socket files or other such
+ * system side effects to be meaningful and non-interfering.
+ */
+void PluginBase::initialize()
+{
+}
+
+/*!
  * \brief Returns true if the plugin supports locking semantics.
  *
  * The default implementation returns false.  This method should

--- a/lib/Secrets/Plugins/extensionplugins.h
+++ b/lib/Secrets/Plugins/extensionplugins.h
@@ -35,6 +35,8 @@ public:
     PluginBase();
     virtual ~PluginBase();
 
+    virtual void initialize();
+
     virtual QString displayName() const = 0;
     virtual QString name() const = 0;
     virtual int version() const = 0;

--- a/plugins/passwordagentauthplugin/passwordagentplugin.cpp
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.cpp
@@ -384,14 +384,19 @@ struct PasswordAgentPlugin::Agent
 
 PasswordAgentPlugin::PasswordAgentPlugin(QObject *parent)
     : AuthenticationPlugin(parent)
-    , m_server(QStringLiteral("unix:path=%1/sailfishsecretsd-p2pSocket-agent").arg(
-                QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation)))
 {
+}
+
+void PasswordAgentPlugin::initialize()
+{
+    m_server.reset(new QDBusServer(QStringLiteral("unix:path=%1/sailfishsecretsd-p2pSocket-agent").arg(
+                QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation))));
+
     qDBusRegisterMetaType<PolkitSubject>();
     qDBusRegisterMetaType<PolkitAuthorizationResult>();
     qDBusRegisterMetaType<QHash<QString, QString>>();
 
-    connect(&m_server, &QDBusServer::newConnection, this, [this](const QDBusConnection &connection) {
+    connect(m_server.data(), &QDBusServer::newConnection, this, [this](const QDBusConnection &connection) {
         if (!QDBusConnection(connection).connect(
                     QString(),
                     QStringLiteral("/org/freedesktop/DBus/Local"),

--- a/plugins/passwordagentauthplugin/passwordagentplugin.h
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.h
@@ -55,6 +55,8 @@ public:
     }
     int version() const Q_DECL_OVERRIDE { return 1; }
 
+    void initialize() Q_DECL_OVERRIDE;
+
     AuthenticationPlugin::AuthenticationTypes authenticationTypes() const Q_DECL_OVERRIDE;
     InteractionParameters::InputTypes inputTypes() const Q_DECL_OVERRIDE;
 
@@ -86,7 +88,7 @@ private:
     class PolkitResponse;
 
     QScopedPointer<Agent> m_sessionAgent;
-    QDBusServer m_server;
+    QScopedPointer<QDBusServer> m_server;
     QHash<QString, PolkitResponse *> m_polkitResponses;
 
     inline void destroyAgent(Agent *agent);


### PR DESCRIPTION
We build both a "normal" and a "test" version of various plugins.
Upon daemon startup, we load all plugins, and then unload any which
don't match the current mode (autotest = true/false).

This has the unfortunate side effect that the test version of the
passwordagent plugin will overwrite the socket file originally
created by the normal version of the password agent plugin, before
being unloaded.

This commit ensures that we allow plugins to perform initialization
in a specific initialize() method which is only called once the
plugin has been "accepted" for use by the daemon according to the
current mode.

Contributes to JB#36797