### PR TITLE
[sailfish-secrets] Add support to pass custom parameters on CLI, fixes Github#122.

### DIFF
--- a/tools/secrets-tool/commandhelper.h
+++ b/tools/secrets-tool/commandhelper.h
@@ -25,7 +25,7 @@ class CommandHelper : public QObject
 
 public:
     CommandHelper(bool autotestMode, QObject *parent = Q_NULLPTR);
-    void start(const QString &command, const QStringList &args);
+    void start(const QString &command, const QStringList &args, const QStringList &options);
     int exitCode() const;
 
 public Q_SLOTS:

--- a/tools/secrets-tool/main.cpp
+++ b/tools/secrets-tool/main.cpp
@@ -224,6 +224,22 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     }
 
     const QString command = args.takeFirst();
+    QStringList options;
+    bool isOption = false;
+    for (QList<QString>::Iterator it = args.begin(); it != args.end();) {
+        if (isOption) {
+            options << *it;
+            isOption = false;
+            it = args.erase(it);
+        } else {
+            if (it->startsWith("-o")) {
+                isOption = true;
+                it = args.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
     if (args.size() < paramOptionsMin.value(command)
             || args.size() > paramOptionsMax.value(command)) {
         qInfo() << "  Usage:" << appName << command << paramOptions.value(command);
@@ -234,7 +250,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     CommandHelper helper(autotestMode);
     QObject::connect(&helper, &CommandHelper::finished,
                      &app, &QCoreApplication::quit);
-    helper.start(command, args);
+    helper.start(command, args, options);
     app.exec();
     return helper.exitCode();
 }


### PR DESCRIPTION
Add support to add ```-o key=value``` options in the command line for crypto requests. This is then passed to the crypto API as customParameters. It implements #122.