### PR TITLE
[sailfish-secrets] Correct segfaults on exit in plugin cleanup code.

### DIFF
--- a/database/database.cpp
+++ b/database/database.cpp
@@ -264,7 +264,9 @@ Database::Database()
 
 Database::~Database()
 {
-    m_database.close();
+    if (m_database.isValid() && m_database.isOpen()) {
+        m_database.close();
+    }
 }
 
 QMutex *Database::accessMutex() const


### PR DESCRIPTION
When you run the daemon twice, the second instance cannot establish a DBus session and stop. When stopping it segfaults. It appears that some plugin objects cannot be destroied properly. There are two issues:

- plugin using database.cpp that are started but the database not created yet, should not call ```close()``` on the database object. Otherwise it segfaults in Qt. The ```isValid()``` safeguard the segfault.
- plugin using evp.cpp have an issue with the static variable s_mutexes. This static variable is created after the plugin instance and is thus destroyed before it, but the plugin destroy function calls the cleanup() function that result is a double free… see https://stackoverflow.com/questions/2204608/does-c-call-destructors-for-global-and-class-static-variables for destruction of static object (I didn't know about it before). The proposed solution is to let the compiler destroy the static variable itself and not make the plugin do it. Here is the Valgrind error before correction:
<pre>
==29759== Invalid read of size 4
==29759==    at 0x712A444: data (qarraydata.h:62)
==29759==    by 0x712A444: data (qarraydata.h:200)
==29759==    by 0x712A444: constBegin (qarraydata.h:206)
==29759==    by 0x712A444: begin (qvector.h:199)
==29759==    by 0x712A444: qDeleteAll<QVector<QMutex*> > (qalgorithms.h:358)
==29759==    by 0x712A444: OpenSslEvp::cleanup() (evp.cpp:112)
==29759==    by 0x712FA59: Sailfish::Crypto::Daemon::Plugins::OpenSslCryptoPlugin::~OpenSslCryptoPlugin() (opensslcryptoplugin.cpp:51)
==29759==    by 0x712FC4B: Sailfish::Crypto::Daemon::Plugins::OpenSslCryptoPlugin::~OpenSslCryptoPlugin() (opensslcryptoplugin.cpp:52)
==29759==    by 0x4BF17BF: ??? (in /usr/lib/libQt5Core.so.5.6.3)
==29759==  Address 0x6e2934c is 12 bytes inside a block of size 256 free'd
==29759==    at 0x4840B28: free (vg_replace_malloc.c:530)
==29759==    by 0x712C33B: deallocate (qarraydata.h:222)
==29759==    by 0x712C33B: freeData (qvector.h:522)
==29759==    by 0x712C33B: QVector<QMutex*>::~QVector() (qvector.h:69)
==29759==    by 0x4F37299: __run_exit_handlers (exit.c:82)
==29759==    by 0x4F372BF: exit (exit.c:104)
==29759==    by 0x4F2297D: (below main) (libc-start.c:321)
==29759==  Block was alloc'd at
==29759==    at 0x483F3EC: malloc (vg_replace_malloc.c:299)
==29759==    by 0x4AD0155: QArrayData::allocate(unsigned int, unsigned int, unsigned int, QFlags<QArrayData::AllocationOption>) (in /usr/lib/libQt5Core.so.5.6.3)
</pre>

@venemo and @chriadam what do you think? It's not very important, but it's a bit ugly to see the program segfault on exit.