### PR TITLE
[sailfish-secrets] Perform plugin name mapping. Contributes to JB#42192

### DIFF
--- a/daemon/CryptoImpl/cryptopluginwrapper.cpp
+++ b/daemon/CryptoImpl/cryptopluginwrapper.cpp
@@ -14,10 +14,15 @@ using namespace Sailfish::Crypto::Daemon::ApiImpl;
 using namespace Sailfish::Secrets::Daemon::Util;
 
 CryptoStoragePluginWrapper::CryptoStoragePluginWrapper(
+        const QString &defaultEncryptionPluginName,
+        const QString &defaultAuthPluginName,
         Sailfish::Crypto::CryptoPlugin *cryptoPlugin,
         Sailfish::Secrets::EncryptedStoragePlugin *plugin,
         bool autotestMode)
-    : Sailfish::Secrets::Daemon::ApiImpl::EncryptedStoragePluginWrapper(plugin, autotestMode)
+    : Sailfish::Secrets::Daemon::ApiImpl::EncryptedStoragePluginWrapper(
+            defaultEncryptionPluginName,
+            defaultAuthPluginName,
+            plugin, autotestMode)
     , m_cryptoPlugin(cryptoPlugin)
 {
 }

--- a/daemon/CryptoImpl/cryptopluginwrapper_p.h
+++ b/daemon/CryptoImpl/cryptopluginwrapper_p.h
@@ -31,7 +31,9 @@ namespace ApiImpl {
 class CryptoStoragePluginWrapper : public Sailfish::Secrets::Daemon::ApiImpl::EncryptedStoragePluginWrapper
 {
 public:
-    CryptoStoragePluginWrapper(Sailfish::Crypto::CryptoPlugin *cryptoPlugin,
+    CryptoStoragePluginWrapper(const QString &defaultEncryptionPluginName,
+                               const QString &defaultAuthPluginName,
+                               Sailfish::Crypto::CryptoPlugin *cryptoPlugin,
                                Sailfish::Secrets::EncryptedStoragePlugin *plugin,
                                bool autotestMode);
     ~CryptoStoragePluginWrapper();

--- a/daemon/SecretsImpl/metadatadb.cpp
+++ b/daemon/SecretsImpl/metadatadb.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "metadatadb_p.h"
+#include "controller_p.h"
 
 using namespace Sailfish::Secrets;
 
@@ -74,10 +75,14 @@ static Daemon::Sqlite::UpgradeOperation upgradeVersions[] = {
 static const int currentSchemaVersion = 1;
 
 Daemon::ApiImpl::MetadataDatabase::MetadataDatabase(
+        const QString &defaultEncryptionPluginName,
+        const QString &defaultAuthenticationPluginName,
         const QString &storagePluginName,
         bool pluginIsEncryptedStorage,
         bool autotestMode)
-    : m_storagePluginName(storagePluginName)
+    : m_defaultEncryptionPluginName(defaultEncryptionPluginName)
+    , m_defaultAuthenticationPluginName(defaultAuthenticationPluginName)
+    , m_storagePluginName(storagePluginName)
     , m_pluginIsEncryptedStorage(pluginIsEncryptedStorage)
     , m_autotestMode(autotestMode)
 {
@@ -800,8 +805,8 @@ bool Daemon::ApiImpl::MetadataDatabase::initializeCollectionsFromPluginData(
             defaultMetadata.usesDeviceLockKey = false;
             defaultMetadata.encryptionPluginName = m_pluginIsEncryptedStorage
                                                  ? m_storagePluginName
-                                                 : SecretManager::DefaultEncryptionPluginName;
-            defaultMetadata.authenticationPluginName = SecretManager::DefaultAuthenticationPluginName;
+                                                 : m_defaultEncryptionPluginName;
+            defaultMetadata.authenticationPluginName = m_defaultAuthenticationPluginName;
             defaultMetadata.unlockSemantic = SecretManager::CustomLockKeepUnlocked;
             defaultMetadata.accessControlMode = SecretManager::NoAccessControlMode;
             if (insertCollectionMetadata(defaultMetadata).code() != Result::Succeeded) {
@@ -875,8 +880,8 @@ bool Daemon::ApiImpl::MetadataDatabase::initializeSecretsFromPluginData(
                 defaultMetadata.usesDeviceLockKey = false;
                 defaultMetadata.encryptionPluginName = m_pluginIsEncryptedStorage
                                                      ? m_storagePluginName
-                                                     : SecretManager::DefaultEncryptionPluginName;
-                defaultMetadata.authenticationPluginName = SecretManager::DefaultAuthenticationPluginName;
+                                                     : m_defaultEncryptionPluginName;
+                defaultMetadata.authenticationPluginName = m_defaultAuthenticationPluginName;
                 defaultMetadata.unlockSemantic = SecretManager::CustomLockKeepUnlocked;
                 defaultMetadata.accessControlMode = SecretManager::NoAccessControlMode;
                 if (insertSecretMetadata(defaultMetadata).code() != Result::Succeeded) {

--- a/daemon/SecretsImpl/metadatadb_p.h
+++ b/daemon/SecretsImpl/metadatadb_p.h
@@ -27,6 +27,8 @@ namespace Secrets {
 
 namespace Daemon {
 
+class Controller;
+
 namespace ApiImpl {
 
 class CollectionMetadata
@@ -59,7 +61,9 @@ public:
 class MetadataDatabase
 {
 public:
-    MetadataDatabase(const QString &storagePluginName,
+    MetadataDatabase(const QString &defaultEncryptionPluginName,
+                     const QString &defaultAuthenticationPluginName,
+                     const QString &storagePluginName,
                      bool pluginIsEncryptedStorage,
                      bool autotestMode);
     ~MetadataDatabase();
@@ -142,7 +146,10 @@ public:
             const QStringList &lockedCollectionNames);
 
 private:
+    Sailfish::Secrets::Daemon::Controller *m_controller;
     Sailfish::Secrets::Daemon::Sqlite::Database m_db;
+    QString m_defaultEncryptionPluginName;
+    QString m_defaultAuthenticationPluginName;
     QString m_storagePluginName;
     bool m_pluginIsEncryptedStorage;
     bool m_autotestMode;

--- a/daemon/SecretsImpl/pluginwrapper.cpp
+++ b/daemon/SecretsImpl/pluginwrapper.cpp
@@ -11,10 +11,16 @@
 using namespace Sailfish::Secrets;
 using namespace Sailfish::Secrets::Daemon::ApiImpl;
 
-PluginWrapper::PluginWrapper(Sailfish::Secrets::PluginBase *plugin,
+PluginWrapper::PluginWrapper(const QString &defaultEncryptionPluginName,
+                             const QString &defaultAuthPluginName,
+                             Sailfish::Secrets::PluginBase *plugin,
                              bool pluginIsEncryptedStorage,
                              bool autotestMode)
-    : m_metadataDb(plugin->name(), pluginIsEncryptedStorage, autotestMode)
+    : m_metadataDb(defaultEncryptionPluginName,
+                   defaultAuthPluginName,
+                   plugin->name(),
+                   pluginIsEncryptedStorage,
+                   autotestMode)
     , m_initialized(false)
     , m_plugin(plugin)
 {
@@ -142,9 +148,13 @@ Sailfish::Secrets::PluginInfo::StatusFlags PluginWrapper::status() const
 // ---------------------------------------------------------------------------
 
 StoragePluginWrapper::StoragePluginWrapper(
+        const QString &defaultEncryptionPluginName,
+        const QString &defaultAuthPluginName,
         Sailfish::Secrets::StoragePlugin *plugin,
         bool autotestMode)
-    : PluginWrapper(plugin, false, autotestMode)
+    : PluginWrapper(defaultEncryptionPluginName,
+                    defaultAuthPluginName,
+                    plugin, false, autotestMode)
     , m_storagePlugin(plugin)
 {
 }
@@ -487,8 +497,12 @@ Result StoragePluginWrapper::removeSecret(
 // ---------------------------------------------------------------------------
 
 EncryptedStoragePluginWrapper::EncryptedStoragePluginWrapper(
+        const QString &defaultEncryptionPluginName,
+        const QString &defaultAuthPluginName,
         Sailfish::Secrets::EncryptedStoragePlugin *plugin, bool autotestMode)
-    : PluginWrapper(plugin, true, autotestMode)
+    : PluginWrapper(defaultEncryptionPluginName,
+                    defaultAuthPluginName,
+                    plugin, true, autotestMode)
     , m_encryptedStoragePlugin(plugin)
 {
 }

--- a/daemon/SecretsImpl/pluginwrapper_p.h
+++ b/daemon/SecretsImpl/pluginwrapper_p.h
@@ -33,7 +33,11 @@ namespace ApiImpl {
 class PluginWrapper : public Sailfish::Secrets::PluginBase
 {
 public:
-    PluginWrapper(Sailfish::Secrets::PluginBase *plugin, bool pluginIsEncryptedStorage, bool autotestMode);
+    PluginWrapper(const QString &defaultEncryptionPluginName,
+                  const QString &defaultAuthPluginName,
+                  Sailfish::Secrets::PluginBase *plugin,
+                  bool pluginIsEncryptedStorage,
+                  bool autotestMode);
     virtual ~PluginWrapper();
 
     bool isInitialized() const;
@@ -74,7 +78,10 @@ private:
 class StoragePluginWrapper : public PluginWrapper
 {
 public:
-    StoragePluginWrapper(Sailfish::Secrets::StoragePlugin *plugin, bool autotestMode);
+    StoragePluginWrapper(const QString &defaultEncryptionPluginName,
+                         const QString &defaultAuthPluginName,
+                         Sailfish::Secrets::StoragePlugin *plugin,
+                         bool autotestMode);
     ~StoragePluginWrapper();
 
     bool initialize(const QByteArray &masterLockKey = QByteArray()) Q_DECL_OVERRIDE;
@@ -106,7 +113,10 @@ private:
 class EncryptedStoragePluginWrapper : public PluginWrapper
 {
 public:
-    EncryptedStoragePluginWrapper(Sailfish::Secrets::EncryptedStoragePlugin *plugin, bool autotestMode);
+    EncryptedStoragePluginWrapper(const QString &defaultEncryptionPluginName,
+                                  const QString &defaultAuthPluginName,
+                                  Sailfish::Secrets::EncryptedStoragePlugin *plugin,
+                                  bool autotestMode);
     ~EncryptedStoragePluginWrapper();
 
     bool initialize(const QByteArray &masterLockKey = QByteArray()) Q_DECL_OVERRIDE;

--- a/daemon/controller.cpp
+++ b/daemon/controller.cpp
@@ -139,6 +139,85 @@ QString Sailfish::Secrets::Daemon::Controller::displayNameForPlugin(const QStrin
     }
 }
 
+// If the given pluginName is a mappable identifier (like "plugin.storage.default")
+// then we return the appropriate "real" plugin name for the given mappable identifier.
+// The mapping is defined via environment variables, which can be set by
+// environment conf files: /var/lib/environment/sailfish-secretsd/*.conf
+QString Sailfish::Secrets::Daemon::Controller::mappedPluginName(const QString &pluginName) const
+{
+    static const QString testPluginSuffix(QStringLiteral(".test"));
+
+    static const QString performMapping(
+            (!QString::fromUtf8(qgetenv(ENV_PERFORM_PLUGIN_MAPPING)).isEmpty())
+                    ? QString::fromUtf8(qgetenv(ENV_PERFORM_PLUGIN_MAPPING))
+                    : QStringLiteral("true"));
+    static const QString mappedCryptoPluginName(
+            (!QString::fromUtf8(qgetenv(ENV_DEFAULT_CRYPTO_PLUGIN)).isEmpty())
+                    ? QString::fromUtf8(qgetenv(ENV_DEFAULT_CRYPTO_PLUGIN))
+                    : QStringLiteral("org.sailfishos.crypto.plugin.crypto.openssl"));
+    static const QString mappedCryptoStoragePluginName(
+            (!QString::fromUtf8(qgetenv(ENV_DEFAULT_CRYPTOSTORAGE_PLUGIN)).isEmpty())
+                    ? QString::fromUtf8(qgetenv(ENV_DEFAULT_CRYPTOSTORAGE_PLUGIN))
+                    : QStringLiteral("org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher"));
+    static const QString mappedStoragePluginName(
+            (!QString::fromUtf8(qgetenv(ENV_DEFAULT_STORAGE_PLUGIN)).isEmpty())
+                    ? QString::fromUtf8(qgetenv(ENV_DEFAULT_STORAGE_PLUGIN))
+                    : QStringLiteral("org.sailfishos.secrets.plugin.storage.sqlite"));
+    static const QString mappedEncryptionPluginName(
+            (!QString::fromUtf8(qgetenv(ENV_DEFAULT_ENCRYPTION_PLUGIN)).isEmpty())
+                    ? QString::fromUtf8(qgetenv(ENV_DEFAULT_ENCRYPTION_PLUGIN))
+                    : QStringLiteral("org.sailfishos.secrets.plugin.encryption.openssl"));
+    static const QString mappedEncryptedStoragePluginName(
+            (!QString::fromUtf8(qgetenv(ENV_DEFAULT_ENCRYPTEDSTORAGE_PLUGIN)).isEmpty())
+                    ? QString::fromUtf8(qgetenv(ENV_DEFAULT_ENCRYPTEDSTORAGE_PLUGIN))
+                    : QStringLiteral("org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher"));
+    static const QString mappedAuthenticationPluginName(
+            (!QString::fromUtf8(qgetenv(ENV_DEFAULT_AUTHENTICATION_PLUGIN)).isEmpty())
+                    ? QString::fromUtf8(qgetenv(ENV_DEFAULT_AUTHENTICATION_PLUGIN))
+                    : QStringLiteral("org.sailfishos.secrets.plugin.authentication.passwordagent"));
+    static const QString mappedInAppAuthenticationPluginName(
+            (!QString::fromUtf8(qgetenv(ENV_INAPP_AUTHENTICATION_PLUGIN)).isEmpty())
+                    ? QString::fromUtf8(qgetenv(ENV_INAPP_AUTHENTICATION_PLUGIN))
+                    : QStringLiteral("org.sailfishos.secrets.plugin.authentication.inapp"));
+
+    if (!pluginName.isEmpty()
+            && (performMapping == QStringLiteral("1")
+                || performMapping == QStringLiteral("true")
+                || performMapping == QStringLiteral("yes"))) {
+        if (pluginName.startsWith(Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName)) {
+            return pluginName.endsWith(testPluginSuffix)
+                    ? (mappedCryptoPluginName+testPluginSuffix)
+                    : mappedCryptoPluginName;
+        } else if (pluginName.startsWith(Sailfish::Crypto::CryptoManager::DefaultCryptoStoragePluginName)) {
+            return pluginName.endsWith(testPluginSuffix)
+                    ? (mappedCryptoStoragePluginName+testPluginSuffix)
+                    : mappedCryptoStoragePluginName;
+        } else if (pluginName.startsWith(Sailfish::Secrets::SecretManager::DefaultStoragePluginName)) {
+            return pluginName.endsWith(testPluginSuffix)
+                    ? (mappedStoragePluginName+testPluginSuffix)
+                    : mappedStoragePluginName;
+        } else if (pluginName.startsWith(Sailfish::Secrets::SecretManager::DefaultEncryptionPluginName)) {
+            return pluginName.endsWith(testPluginSuffix)
+                    ? (mappedEncryptionPluginName+testPluginSuffix)
+                    : mappedEncryptionPluginName;
+        } else if (pluginName.startsWith(Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName)) {
+            return pluginName.endsWith(testPluginSuffix)
+                    ? (mappedEncryptedStoragePluginName+testPluginSuffix)
+                    : mappedEncryptedStoragePluginName;
+        } else if (pluginName.startsWith(Sailfish::Secrets::SecretManager::DefaultAuthenticationPluginName)) {
+            return pluginName.endsWith(testPluginSuffix)
+                    ? (mappedAuthenticationPluginName+testPluginSuffix)
+                    : mappedAuthenticationPluginName;
+        } else if (pluginName.startsWith(Sailfish::Secrets::SecretManager::InAppAuthenticationPluginName)) {
+            return pluginName.endsWith(testPluginSuffix)
+                    ? (mappedInAppAuthenticationPluginName+testPluginSuffix)
+                    : mappedInAppAuthenticationPluginName;
+        }
+    }
+
+    return pluginName;
+}
+
 QMap<QString, Sailfish::Secrets::PluginInfo>
 Sailfish::Secrets::Daemon::Controller::pluginInfoForPlugins(
         QList<Sailfish::Secrets::PluginBase*> plugins,

--- a/daemon/controller_p.h
+++ b/daemon/controller_p.h
@@ -22,6 +22,18 @@
 #include <Secrets/Plugins/extensionplugins.h>
 #include <Secrets/plugininfo.h>
 
+// The environment variables which can be used to specify the name
+// of the default Crypto and Secrets plugins.
+// See Controller::mappedPluginName() for more information.
+#define ENV_PERFORM_PLUGIN_MAPPING "SAILFISH_SECRETSD_PERFORM_PLUGIN_MAPPING"
+#define ENV_DEFAULT_CRYPTO_PLUGIN "SAILFISH_SECRETSD_DEFAULT_CRYPTO_PLUGIN"
+#define ENV_DEFAULT_CRYPTOSTORAGE_PLUGIN "SAILFISH_SECRETSD_DEFAULT_CRYPTOSTORAGE_PLUGIN"
+#define ENV_DEFAULT_STORAGE_PLUGIN "SAILFISH_SECRETSD_DEFAULT_STORAGE_PLUGIN"
+#define ENV_DEFAULT_ENCRYPTION_PLUGIN "SAILFISH_SECRETSD_DEFAULT_ENCRYPTION_PLUGIN"
+#define ENV_DEFAULT_ENCRYPTEDSTORAGE_PLUGIN "SAILFISH_SECRETSD_DEFAULT_ENCRYPTEDSTORAGE_PLUGIN"
+#define ENV_DEFAULT_AUTHENTICATION_PLUGIN "SAILFISH_SECRETSD_DEFAULT_AUTHENTICATION_PLUGIN"
+#define ENV_INAPP_AUTHENTICATION_PLUGIN "SAILFISH_SECRETSD_INAPP_AUTHENTICATION_PLUGIN"
+
 namespace Sailfish {
 
 namespace Crypto {
@@ -54,6 +66,7 @@ public:
 
     Sailfish::Secrets::Daemon::ApiImpl::SecretsRequestQueue *secrets() const;
     Sailfish::Crypto::Daemon::ApiImpl::CryptoRequestQueue *crypto() const;
+    QString mappedPluginName(const QString &pluginName) const;
     QWeakPointer<QThreadPool> threadPoolForPlugin(const QString &pluginName) const;
     QString displayNameForPlugin(const QString &pluginName) const;
     QMap<QString, Sailfish::Secrets::PluginInfo> pluginInfoForPlugins(

--- a/lib/Crypto/cryptomanager.cpp
+++ b/lib/Crypto/cryptomanager.cpp
@@ -32,8 +32,8 @@ Q_LOGGING_CATEGORY(lcSailfishCrypto, "org.sailfishos.crypto", QtWarningMsg)
 
 using namespace Sailfish::Crypto;
 
-const QString CryptoManager::DefaultCryptoPluginName = QStringLiteral("org.sailfishos.crypto.plugin.crypto.openssl");
-const QString CryptoManager::DefaultCryptoStoragePluginName = QStringLiteral("org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher");
+const QString CryptoManager::DefaultCryptoPluginName = QStringLiteral("plugin.crypto.default");
+const QString CryptoManager::DefaultCryptoStoragePluginName = QStringLiteral("plugin.cryptostorage.default");
 
 /*!
  * \internal

--- a/lib/Secrets/secretmanager.cpp
+++ b/lib/Secrets/secretmanager.cpp
@@ -35,11 +35,11 @@ const QString Secret::TypeCryptoKey = QStringLiteral("CryptoKey"); // Do not cha
 const QString Secret::TypeCryptoCertificate = QStringLiteral("CryptoCertificate");
 const QString Secret::TypeUsernamePassword = QStringLiteral("UsernamePassword");
 
-const QString SecretManager::InAppAuthenticationPluginName = QStringLiteral("org.sailfishos.secrets.plugin.authentication.inapp");
-const QString SecretManager::DefaultAuthenticationPluginName = QStringLiteral("org.sailfishos.secrets.plugin.authentication.passwordagent");
-const QString SecretManager::DefaultStoragePluginName = QStringLiteral("org.sailfishos.secrets.plugin.storage.sqlite");
-const QString SecretManager::DefaultEncryptionPluginName = QStringLiteral("org.sailfishos.secrets.plugin.encryption.openssl");
-const QString SecretManager::DefaultEncryptedStoragePluginName = QStringLiteral("org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher");
+const QString SecretManager::InAppAuthenticationPluginName = QStringLiteral("plugin.authentication.inapp");
+const QString SecretManager::DefaultAuthenticationPluginName = QStringLiteral("plugin.authentication.default");
+const QString SecretManager::DefaultStoragePluginName = QStringLiteral("plugin.storage.default");
+const QString SecretManager::DefaultEncryptionPluginName = QStringLiteral("plugin.encryption.default");
+const QString SecretManager::DefaultEncryptedStoragePluginName = QStringLiteral("plugin.encryptedstorage.default");
 
 /*!
  * \class SecretManagerPrivate

--- a/plugins/inappauthplugin/plugin.cpp
+++ b/plugins/inappauthplugin/plugin.cpp
@@ -128,7 +128,7 @@ Daemon::Plugins::InAppPlugin::beginUserInputInteraction(
                                   Q_ARG(Sailfish::Secrets::InteractionParameters, interactionParameters),
                                   Q_ARG(QString, interactionServiceAddress),
                                   Q_ARG(Sailfish::Secrets::Result, Sailfish::Secrets::Result(Sailfish::Secrets::Result::Succeeded)),
-                                  Q_ARG(QByteArray, QByteArray("testpassphrase")));
+                                  Q_ARG(QByteArray, QByteArray("sailfish"))); // passphrase for importKey unit tests
         return Result(Result::Pending);
     }
 #endif

--- a/tests/Crypto/tst_crypto/tst_crypto.cpp
+++ b/tests/Crypto/tst_crypto/tst_crypto.cpp
@@ -143,7 +143,6 @@ void tst_crypto::getPluginInfo()
         cryptoPluginNames.append(p.name());
     }
     QVERIFY(cryptoPluginNames.size());
-    QVERIFY(cryptoPluginNames.contains(CryptoManager::DefaultCryptoPluginName + QLatin1String(".test")));
 }
 
 void tst_crypto::randomData()

--- a/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
+++ b/tests/Crypto/tst_cryptosecrets/tst_cryptosecrets.cpp
@@ -154,8 +154,6 @@ void tst_cryptosecrets::getPluginInfo()
         cryptoPluginNames.append(p.name());
     }
     QVERIFY(cryptoPluginNames.size());
-    QVERIFY(cryptoPluginNames.contains(Sailfish::Crypto::CryptoManager::DefaultCryptoPluginName + QLatin1String(".test")));
-    QVERIFY(cryptoPluginNames.contains(Sailfish::Crypto::CryptoManager::DefaultCryptoStoragePluginName + QLatin1String(".test")));
 
     QVector<Sailfish::Crypto::PluginInfo> storagePlugins = reply.argumentAt<2>();
     QStringList storagePluginNames;
@@ -163,7 +161,6 @@ void tst_cryptosecrets::getPluginInfo()
         storagePluginNames.append(p.name());
     }
     QVERIFY(storagePluginNames.size());
-    QVERIFY(storagePluginNames.contains(Sailfish::Secrets::SecretManager::DefaultStoragePluginName + QLatin1String(".test")));
 }
 
 void tst_cryptosecrets::secretsStoredKey_data()

--- a/tests/Secrets/tst_secretsrequests/tst_secretsrequests.cpp
+++ b/tests/Secrets/tst_secretsrequests/tst_secretsrequests.cpp
@@ -116,28 +116,28 @@ void tst_secretsrequests::getPluginInfo()
     for (auto p : r.storagePlugins()) {
         storagePluginNames.append(p.name());
     }
-    QVERIFY(storagePluginNames.contains(DEFAULT_TEST_STORAGE_PLUGIN));
+    QVERIFY(storagePluginNames.contains(QStringLiteral("org.sailfishos.secrets.plugin.storage.sqlite.test")));
 
     QVERIFY(r.encryptionPlugins().size());
     QStringList encryptionPluginNames;
     for (auto p : r.encryptionPlugins()) {
         encryptionPluginNames.append(p.name());
     }
-    QVERIFY(encryptionPluginNames.contains(DEFAULT_TEST_ENCRYPTION_PLUGIN));
+    QVERIFY(encryptionPluginNames.contains(QStringLiteral("org.sailfishos.secrets.plugin.encryption.openssl.test")));
 
     QVERIFY(r.encryptedStoragePlugins().size());
     QStringList encryptedStoragePluginNames;
     for (auto p : r.encryptedStoragePlugins()) {
         encryptedStoragePluginNames.append(p.name());
     }
-    QVERIFY(encryptedStoragePluginNames.contains(DEFAULT_TEST_ENCRYPTEDSTORAGE_PLUGIN));
+    QVERIFY(encryptedStoragePluginNames.contains(QStringLiteral("org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher.test")));
 
     QVERIFY(r.authenticationPlugins().size());
     QStringList authenticationPluginNames;
     for (auto p : r.authenticationPlugins()) {
         authenticationPluginNames.append(p.name());
     }
-    QVERIFY(authenticationPluginNames.contains(IN_APP_TEST_AUTHENTICATION_PLUGIN));
+    QVERIFY(authenticationPluginNames.contains(QStringLiteral("org.sailfishos.secrets.plugin.authentication.inapp.test")));
 }
 
 void tst_secretsrequests::devicelockCollection()
@@ -1810,8 +1810,8 @@ void tst_secretsrequests::lockCode()
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(lcr);
     QCOMPARE(lcr.status(), Request::Finished);
     QCOMPARE(lcr.result().code(), Result::Failed);
-    QCOMPARE(lcr.result().errorMessage(), QStringLiteral("storage plugin %1 does not support locking")
-                                                    .arg(DEFAULT_TEST_STORAGE_PLUGIN));
+    QVERIFY(lcr.result().errorMessage().startsWith(QStringLiteral("storage plugin"))
+         && lcr.result().errorMessage().endsWith(QStringLiteral("does not support locking")));
 
     uiParams.setPromptText(QLatin1String("Provide the lock code for the storage plugin"));
     lcr.setLockCodeRequestType(LockCodeRequest::ProvideLockCode);
@@ -1821,16 +1821,16 @@ void tst_secretsrequests::lockCode()
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(lcr);
     QCOMPARE(lcr.status(), Request::Finished);
     QCOMPARE(lcr.result().code(), Result::Failed);
-    QCOMPARE(lcr.result().errorMessage(), QStringLiteral("storage plugin %1 does not support locking")
-                                                    .arg(DEFAULT_TEST_STORAGE_PLUGIN));
+    QVERIFY(lcr.result().errorMessage().startsWith(QStringLiteral("storage plugin"))
+         && lcr.result().errorMessage().endsWith(QStringLiteral("does not support locking")));
 
     lcr.setLockCodeRequestType(LockCodeRequest::ForgetLockCode);
     lcr.startRequest();
     WAIT_FOR_FINISHED_WITHOUT_BLOCKING(lcr);
     QCOMPARE(lcr.status(), Request::Finished);
     QCOMPARE(lcr.result().code(), Result::Failed);
-    QCOMPARE(lcr.result().errorMessage(), QStringLiteral("storage plugin %1 does not support locking")
-                                                    .arg(DEFAULT_TEST_STORAGE_PLUGIN));
+    QVERIFY(lcr.result().errorMessage().startsWith(QStringLiteral("storage plugin"))
+         && lcr.result().errorMessage().endsWith(QStringLiteral("does not support locking")));
 }
 
 void tst_secretsrequests::collectionLocks()

--- a/tools/secrets-tool/commandhelper.cpp
+++ b/tools/secrets-tool/commandhelper.cpp
@@ -248,8 +248,11 @@ void CommandHelper::start(const QString &command, const QStringList &args, const
 
         const QString storagePluginName = ccArgs.value(0);
         bool isEncryptedStoragePlugin = false;
-        if (!m_storagePlugins.contains(storagePluginName)) {
-            if (!m_encryptedStoragePlugins.contains(storagePluginName)) {
+        if (storagePluginName != Sailfish::Secrets::SecretManager::DefaultStoragePluginName
+                && !m_storagePlugins.contains(storagePluginName)) {
+            if (storagePluginName != Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName
+                    && storagePluginName != Sailfish::Crypto::CryptoManager::DefaultCryptoStoragePluginName
+                    && !m_encryptedStoragePlugins.contains(storagePluginName)) {
                 qInfo() << "Invalid storage plugin name specified";
                 emitFinished(EXITCODE_FAILED);
                 return;
@@ -268,7 +271,9 @@ void CommandHelper::start(const QString &command, const QStringList &args, const
                        + (m_autotestMode ? QStringLiteral(".test") : QString()));
 
         if ((isEncryptedStoragePlugin && encryptionPluginName != storagePluginName)
-                || (!isEncryptedStoragePlugin && !m_encryptionPlugins.contains(encryptionPluginName))) {
+                || (!isEncryptedStoragePlugin
+                    && encryptionPluginName != Sailfish::Secrets::SecretManager::DefaultEncryptionPluginName
+                    && !m_encryptionPlugins.contains(encryptionPluginName))) {
             qInfo() << "Invalid encryption plugin specified";
             emitFinished(EXITCODE_FAILED);
             return;
@@ -335,8 +340,11 @@ void CommandHelper::start(const QString &command, const QStringList &args, const
 
         const QString storagePluginName = ccArgs.value(0);
         bool isEncryptedStoragePlugin = false;
-        if (!m_storagePlugins.contains(storagePluginName)) {
-            if (!m_encryptedStoragePlugins.contains(storagePluginName)) {
+        if (storagePluginName != Sailfish::Secrets::SecretManager::DefaultStoragePluginName
+                && !m_storagePlugins.contains(storagePluginName)) {
+            if (storagePluginName != Sailfish::Secrets::SecretManager::DefaultEncryptedStoragePluginName
+                    && storagePluginName != Sailfish::Crypto::CryptoManager::DefaultCryptoStoragePluginName
+                    && !m_encryptedStoragePlugins.contains(storagePluginName)) {
                 qInfo() << "Invalid storage plugin name specified";
                 emitFinished(EXITCODE_FAILED);
                 return;
@@ -347,7 +355,9 @@ void CommandHelper::start(const QString &command, const QStringList &args, const
 
         const QString encryptionPluginName = ccArgs.value(1);
         if ((isEncryptedStoragePlugin && encryptionPluginName != storagePluginName)
-                || (!isEncryptedStoragePlugin && !m_encryptionPlugins.contains(encryptionPluginName))) {
+                || (!isEncryptedStoragePlugin
+                    && encryptionPluginName != Sailfish::Secrets::SecretManager::DefaultEncryptionPluginName
+                    && !m_encryptionPlugins.contains(encryptionPluginName))) {
             qInfo() << "Invalid encryption plugin specified";
             emitFinished(EXITCODE_FAILED);
             return;


### PR DESCRIPTION
This commit changes the client-side default plugin name variables
to be generic names (e.g. "plugin.storage.default") which then get
mapped to "real" plugin names by the daemon.

This allows the default plugins to be configurable (via .conf file
which provides environment variable values), allowing vendors to
supply their own default plugins which clients can use without
needing to modify client code.

Finally, unit tests are fixed to work with the changes.

Contributes to JB#42192