### PR TITLE
Add ImportStoredKeyRequest in QML export.

### DIFF
--- a/daemon/CryptoImpl/crypto.cpp
+++ b/daemon/CryptoImpl/crypto.cpp
@@ -912,7 +912,7 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
             break;
         }
         case ImportKeyRequest: {
-            qCDebug(lcSailfishCryptoDaemon) << "Handling GenerateKeyRequest from client:" << request->remotePid << ", request number:" << request->requestId;
+            qCDebug(lcSailfishCryptoDaemon) << "Handling ImportKeyRequest from client:" << request->remotePid << ", request number:" << request->requestId;
             Key importedKey;
             QByteArray data = request->inParams.size()
                     ? request->inParams.takeFirst().value<QByteArray>()
@@ -947,7 +947,7 @@ void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(
             break;
         }
         case ImportStoredKeyRequest: {
-            qCDebug(lcSailfishCryptoDaemon) << "Handling GenerateStoredKeyRequest from client:" << request->remotePid << ", request number:" << request->requestId;
+            qCDebug(lcSailfishCryptoDaemon) << "Handling ImportStoredKeyRequest from client:" << request->remotePid << ", request number:" << request->requestId;
             Key importedKey;
             QByteArray data = request->inParams.size()
                     ? request->inParams.takeFirst().value<QByteArray>()

--- a/daemon/SecretsImpl/metadatadb.cpp
+++ b/daemon/SecretsImpl/metadatadb.cpp
@@ -150,6 +150,11 @@ bool Daemon::ApiImpl::MetadataDatabase::openDatabase(const QByteArray &hexKey)
     return success;
 }
 
+QString Daemon::ApiImpl::MetadataDatabase::errorMessage() const
+{
+    return m_db.lastError().text();
+}
+
 bool Daemon::ApiImpl::MetadataDatabase::isOpen() const
 {
     return m_db.isOpen();

--- a/daemon/SecretsImpl/metadatadb_p.h
+++ b/daemon/SecretsImpl/metadatadb_p.h
@@ -70,6 +70,7 @@ public:
 
     bool isOpen() const;
     bool openDatabase(const QByteArray &hexKey);
+    QString errorMessage() const;
 
     bool beginTransaction();
     bool commitTransaction();

--- a/lib/Crypto/request.h
+++ b/lib/Crypto/request.h
@@ -24,7 +24,7 @@ class SAILFISH_CRYPTO_API Request : public QObject
     Q_OBJECT
     Q_PROPERTY(Sailfish::Crypto::CryptoManager* manager READ manager WRITE setManager NOTIFY managerChanged)
     Q_PROPERTY(QVariantMap customParameters READ customParameters WRITE setCustomParameters NOTIFY customParametersChanged)
-    Q_PROPERTY(Request::Status status READ status NOTIFY statusChanged)
+    Q_PROPERTY(Sailfish::Crypto::Request::Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(Sailfish::Crypto::Result result READ result NOTIFY resultChanged)
 
 public:

--- a/qml/Crypto/main.cpp
+++ b/qml/Crypto/main.cpp
@@ -33,6 +33,8 @@ void Sailfish::Crypto::Plugin::CryptoPlugin::registerTypes(const char *uri)
     qmlRegisterType<Sailfish::Crypto::GenerateRandomDataRequest>(uri, 1, 0, "GenerateRandomDataRequest");
     qmlRegisterType<Sailfish::Crypto::GenerateKeyRequest>(uri, 1, 0, "GenerateKeyRequest");
     qmlRegisterType<Sailfish::Crypto::GenerateStoredKeyRequest>(uri, 1, 0, "GenerateStoredKeyRequest");
+    qmlRegisterType<Sailfish::Crypto::ImportKeyRequest>(uri, 1, 0, "ImportKeyRequest");
+    qmlRegisterType<Sailfish::Crypto::ImportStoredKeyRequest>(uri, 1, 0, "ImportStoredKeyRequest");
     qmlRegisterType<Sailfish::Crypto::StoredKeyRequest>(uri, 1, 0, "StoredKeyRequest");
     qmlRegisterType<Sailfish::Crypto::Plugin::StoredKeyIdentifiersRequestWrapper>(uri, 1, 0, "StoredKeyIdentifiersRequest");
     qmlRegisterType<Sailfish::Crypto::DeleteStoredKeyRequest>(uri, 1, 0, "DeleteStoredKeyRequest");
@@ -72,6 +74,11 @@ Sailfish::Crypto::Result Sailfish::Crypto::Plugin::CryptoManager::constructResul
 Sailfish::Crypto::Key Sailfish::Crypto::Plugin::CryptoManager::constructKey() const
 {
     return Sailfish::Crypto::Key();
+}
+
+Sailfish::Crypto::Key Sailfish::Crypto::Plugin::CryptoManager::constructKey(const QString &name, const QString &collectionName, const QString &storagePluginName) const
+{
+    return Sailfish::Crypto::Key(name, collectionName, storagePluginName);
 }
 
 QVariant Sailfish::Crypto::Plugin::CryptoManager::constructRsaKeygenParams() const

--- a/qml/Crypto/plugintypes.h
+++ b/qml/Crypto/plugintypes.h
@@ -17,6 +17,8 @@
 #include "Crypto/generaterandomdatarequest.h"
 #include "Crypto/generatekeyrequest.h"
 #include "Crypto/generatestoredkeyrequest.h"
+#include "Crypto/importkeyrequest.h"
+#include "Crypto/importstoredkeyrequest.h"
 #include "Crypto/storedkeyrequest.h"
 #include "Crypto/deletestoredkeyrequest.h"
 #include "Crypto/storedkeyidentifiersrequest.h"
@@ -64,6 +66,9 @@ public:
     // QML API - allow clients to construct "uncreatable" value types
     Q_INVOKABLE Result constructResult() const;
     Q_INVOKABLE Key constructKey() const;
+    Q_INVOKABLE Key constructKey(const QString &name,
+                                 const QString &collectionName,
+                                 const QString &storagePluginName) const;
     Q_INVOKABLE QVariant constructRsaKeygenParams() const;
     Q_INVOKABLE QVariant constructEcKeygenParams() const;
     Q_INVOKABLE QVariant constructDsaKeygenParams() const;


### PR DESCRIPTION
The importation request was missing from QML. This PR adds it. It also:

* correct the Request::Status type when exported to QML, to avoid error like "unsupported type Request::Status for property status of Sailfish::Crypto::ImportStoredKeyRequest";
* log reason for metadata database initialisation failures;
* add a ```constructKeyTemplate()``` method to be able to write things like that in QML:
<pre>
ImportStoredKeyRequest {
    keyTemplate: cryptoManager.constructKeyTemplate(email.signingKeys[0],
                                                   "import",
                                                   "org.sailfishos.crypto.plugin.gnupg.openpgp")
}
</pre>