### PR TITLE
Better handling of data corruption

### DIFF
--- a/daemon/SecretsImpl/secrets.cpp
+++ b/daemon/SecretsImpl/secrets.cpp
@@ -38,6 +38,11 @@
 #define MAP_PLUGIN_NAMES(variable) ::mapPluginNames(m_requestQueue->controller(), variable)
 
 namespace {
+
+    const QString systemDataDirPath(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QStringLiteral("/system"));
+    const QString privilegedDataDirPath(systemDataDirPath + QStringLiteral("/privileged"));
+    const QString secretsDirPath(privilegedDataDirPath + QStringLiteral("/Secrets"));
+
     void specifyDummyMasterlockKeys(
             const QByteArray &lockCode,
             QByteArray *testCipherText,
@@ -818,9 +823,7 @@ bool Daemon::ApiImpl::SecretsRequestQueue::writeTestCipherText(
     // so this test should be safe.
     // TODO: check with crypto expert!
     // TODO: Should I just store a hash of the key instead?
-    const QString systemDataDirPath(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/system/");
-    const QString privilegedDataDirPath(systemDataDirPath + QLatin1String("privileged") + "/");
-    const QString secretsDirPath(privilegedDataDirPath + QLatin1String("Secrets"));
+
     QDir secretsDir(secretsDirPath);
     if (!secretsDir.mkpath(secretsDirPath)) {
         qCWarning(lcSailfishSecretsDaemon) << "Permissions error: unable to create secrets directory:" << secretsDirPath;
@@ -845,9 +848,6 @@ bool Daemon::ApiImpl::SecretsRequestQueue::writeTestCipherText(
 bool Daemon::ApiImpl::SecretsRequestQueue::determineTestCipherPlugin(
         QString *cipherPluginName) const
 {
-    const QString systemDataDirPath(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/system/");
-    const QString privilegedDataDirPath(systemDataDirPath + QLatin1String("privileged") + "/");
-    const QString secretsDirPath(privilegedDataDirPath + QLatin1String("Secrets"));
     QDir secretsDir(secretsDirPath);
     if (!secretsDir.mkpath(secretsDirPath)) {
         qCWarning(lcSailfishSecretsDaemon) << "Permissions error: unable to create secrets directory:" << secretsDirPath;
@@ -886,9 +886,7 @@ bool Daemon::ApiImpl::SecretsRequestQueue::compareTestCipherText(
     // so this test should be safe.
     // TODO: check with crypto expert!
     // TODO: Should I just store a hash of the key instead?
-    const QString systemDataDirPath(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/system/");
-    const QString privilegedDataDirPath(systemDataDirPath + QLatin1String("privileged") + "/");
-    const QString secretsDirPath(privilegedDataDirPath + QLatin1String("Secrets"));
+
     QDir secretsDir(secretsDirPath);
     if (!secretsDir.mkpath(secretsDirPath)) {
         qCWarning(lcSailfishSecretsDaemon) << "Permissions error: unable to create secrets directory:" << secretsDirPath;
@@ -963,9 +961,6 @@ QByteArray Daemon::ApiImpl::SecretsRequestQueue::saltData() const
         return m_saltData;
     }
 
-    const QString systemDataDirPath(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/system/");
-    const QString privilegedDataDirPath(systemDataDirPath + QLatin1String("privileged") + "/");
-    const QString secretsDirPath(privilegedDataDirPath + QLatin1String("Secrets"));
     QDir secretsDir(secretsDirPath);
     if (!secretsDir.mkpath(secretsDirPath)) {
         qCWarning(lcSailfishSecretsDaemon) << "Permissions error: unable to create secrets directory:" << secretsDirPath;
@@ -2599,11 +2594,6 @@ void Daemon::ApiImpl::SecretsRequestQueue::dealWithDataCorruption() const
     // NOTE: Right now we just delete all corrupted data.
     //       In the future if only the masterlock is broken we could just ask
     //       the user to set a new master lock (without clearing all data).
-
-    // Find secrets directory
-    const static QString systemDataDirPath(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/system/");
-    const static QString privilegedDataDirPath(systemDataDirPath + QLatin1String("privileged") + "/");
-    const static QString secretsDirPath(privilegedDataDirPath + QLatin1String("Secrets"));
 
     // Remove entire secrets directory
     QDir secretsDir(secretsDirPath);

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -14,6 +14,7 @@
 #include "Secrets/secret.h"
 #include "Secrets/interactionparameters.h"
 #include "Secrets/plugininfo.h"
+#include "Secrets/healthcheckrequest.h"
 #include "Secrets/secretmanager.h"
 #include "Secrets/result.h"
 #include "Secrets/lockcoderequest.h"
@@ -66,6 +67,14 @@ class SecretsDBusObject : public QObject, protected QDBusContext
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out2\" value=\"QVector<Sailfish::Secrets::PluginInfo>\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out3\" value=\"QVector<Sailfish::Secrets::PluginInfo>\" />\n"
     "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out4\" value=\"QVector<Sailfish::Secrets::PluginInfo>\" />\n"
+    "      </method>\n"
+    "      <method name=\"getHealthInfo\">\n"
+    "          <arg name=\"result\" type=\"(iis)\" direction=\"out\" />\n"
+    "          <arg name=\"saltDataHealth\" type=\"(i)\" direction=\"out\" />\n"
+    "          <arg name=\"masterlockHealth\" type=\"(i)\" direction=\"out\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"Sailfish::Secrets::Result\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out1\" value=\"Sailfish::Secrets::HealthCheckRequest::Health\" />\n"
+    "          <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out2\" value=\"Sailfish::Secrets::HealthCheckRequest::Health\" />\n"
     "      </method>\n"
     "      <method name=\"userInput\">\n"
     "          <arg name=\"uiParams\" type=\"(sss(i)sss(i)(i))\" direction=\"in\" />\n"
@@ -254,6 +263,13 @@ public Q_SLOTS:
             QVector<Sailfish::Secrets::PluginInfo> &encryptionPlugins,
             QVector<Sailfish::Secrets::PluginInfo> &encryptedStoragePlugins,
             QVector<Sailfish::Secrets::PluginInfo> &authenticationPlugins);
+
+    // retrieve information about secrets health
+    void getHealthInfo(
+            const QDBusMessage &message,
+            Sailfish::Secrets::Result &result,
+            Sailfish::Secrets::HealthCheckRequest::Health &saltDataHealth,
+            Sailfish::Secrets::HealthCheckRequest::Health &masterlockHealth);
 
     // retrieve user input for the client (daemon)
     void userInput(
@@ -526,6 +542,7 @@ private:
 enum RequestType {
     InvalidRequest = 0,
     GetPluginInfoRequest,
+    GetHealthInfoRequest,
     UserInputRequest,
     CollectionNamesRequest,
     CreateDeviceLockCollectionRequest,

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -454,6 +454,7 @@ private:
     mutable QByteArray m_saltData;
     bool generateKeyData(const QByteArray &lockCode, const QString &cipherPluginName, QByteArray *bkdbKey, QByteArray *deviceLockKey, QByteArray *testCipherText, QString *usedCipherPluginName) const;
     bool initializeKeyData(const QByteArray &bkdkKey, const QByteArray &deviceLockKey);
+    void dealWithDataCorruption() const;
 
 public: // For use by the secrets request processor to handle device-locked collection/secret semantics
     bool masterLocked() const;

--- a/daemon/SecretsImpl/secretsrequestprocessor_p.h
+++ b/daemon/SecretsImpl/secretsrequestprocessor_p.h
@@ -31,6 +31,7 @@
 #include "Secrets/secret.h"
 #include "Secrets/interactionparameters.h"
 #include "Secrets/lockcoderequest.h"
+#include "Secrets/healthcheckrequest.h"
 
 #include "SecretsImpl/secrets_p.h"
 #include "SecretsImpl/pluginwrapper_p.h"
@@ -83,6 +84,14 @@ public:
             QVector<Sailfish::Secrets::PluginInfo> *encryptionPlugins,
             QVector<Sailfish::Secrets::PluginInfo> *encryptedStoragePlugins,
             QVector<Sailfish::Secrets::PluginInfo> *authenticationPlugins);
+
+    // retrieve information about secrets health
+    Sailfish::Secrets::Result getHealthInfo(
+            pid_t callerPid,
+            quint64 requestId,
+            const QString &secretsDir,
+            Sailfish::Secrets::HealthCheckRequest::Health *saltDataHealth,
+            Sailfish::Secrets::HealthCheckRequest::Health *masterlockHealth);
 
     // retrieve the names of collections
     Sailfish::Secrets::Result collectionNames(

--- a/daemon/daemon.pro
+++ b/daemon/daemon.pro
@@ -19,6 +19,13 @@ QT += sql dbus concurrent
 CONFIG += link_pkgconfig hide_symbols
 PKGCONFIG += dbus-1 Qt5Concurrent Qt5DBus Qt5Core
 
+packagesExist(nemonotifications-qt5) {
+    PKGCONFIG += nemonotifications-qt5
+    DEFINES += HAS_NEMO_NOTIFICATIONS
+} else {
+    warning("package nemonotifications-qt5 is not present, building without notification support")
+}
+
 HEADERS += \
     $$PWD/controller_p.h \
     $$PWD/discoveryobject_p.h \

--- a/lib/Secrets/Secrets.pro
+++ b/lib/Secrets/Secrets.pro
@@ -23,6 +23,7 @@ PUBLIC_HEADERS += \
     $$PWD/lockcoderequest.h \
     $$PWD/plugininfo.h \
     $$PWD/plugininforequest.h \
+    $$PWD/healthcheckrequest.h \
     $$PWD/request.h \
     $$PWD/result.h \
     $$PWD/secret.h \
@@ -49,6 +50,7 @@ PRIVATE_HEADERS += \
     $$PWD/lockcoderequest_p.h \
     $$PWD/plugininfo_p.h \
     $$PWD/plugininforequest_p.h \
+    $$PWD/healthcheckrequest_p.h \
     $$PWD/result_p.h \
     $$PWD/secret_p.h \
     $$PWD/secretsdaemonconnection_p_p.h \
@@ -74,6 +76,7 @@ SOURCES += \
     $$PWD/lockcoderequest.cpp \
     $$PWD/plugininfo.cpp \
     $$PWD/plugininforequest.cpp \
+    $$PWD/healthcheckrequest.cpp \
     $$PWD/request.cpp \
     $$PWD/result.cpp \
     $$PWD/secret.cpp \

--- a/lib/Secrets/healthcheckrequest.cpp
+++ b/lib/Secrets/healthcheckrequest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2018 Jolla Ltd.
+ * Contact: Timur Kristóf <timur.kristof@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#include "Secrets/healthcheckrequest.h"
+#include "Secrets/healthcheckrequest_p.h"
+
+#include "Secrets/secretmanager.h"
+#include "Secrets/secretmanager_p.h"
+#include "Secrets/serialization_p.h"
+
+#include <QtDBus/QDBusPendingReply>
+#include <QtDBus/QDBusPendingCallWatcher>
+
+using namespace Sailfish::Secrets;
+
+HealthCheckRequestPrivate::HealthCheckRequestPrivate()
+    : m_status(Request::Inactive)
+    , m_saltDataHealth(HealthCheckRequest::HealthUnknown)
+    , m_masterlockHealth(HealthCheckRequest::HealthUnknown)
+{
+}
+
+/*!
+ * \class HealthCheckRequest
+ * \brief Allows a client request information about the well-being of secrets data.
+ *
+ * Normally, a client does not have to use this kind of request, because the
+ * data corruption is taken care of by the Settings app. When a data corruption
+ * is detected by the secrets daemon it will display a notification to the user
+ * which opens the Settings app that will take care of it.
+ *
+ * Here is an example that retrieves information about the secrets data health:
+ *
+ * \code
+ * Sailfish::Secrets::SecretManager man;
+ * Sailfish::Secrets::HealthCheckRequest req;
+ * req.setManager(&man);
+ * req.startRequest(); // status() will change to Finished when complete
+ *
+ * // real clients should not use waitForFinished() because it blocks
+ * req.waitForFinished();
+ * qDebug() << "salt data health:" << req.saltDataHealth();
+ * qDebug() << "masterlock health:" << req.masterlockHealth();
+ * \endcode
+ */
+
+/*!
+ * \brief Constructs a new HealthCheckRequest object with the given \a parent.
+ */
+HealthCheckRequest::HealthCheckRequest(QObject *parent)
+    : Request(parent)
+    , d_ptr(new HealthCheckRequestPrivate)
+{
+}
+
+/*!
+ * \brief Destroys the HealthCheckRequest
+ */
+HealthCheckRequest::~HealthCheckRequest()
+{
+}
+
+/*!
+ * \brief Returns information about salt data health.
+ *
+ * The result can be used to decuce whether a data corruption happened
+ * to the salt data.
+ */
+HealthCheckRequest::Health HealthCheckRequest::saltDataHealth() const
+{
+    Q_D(const HealthCheckRequest);
+    return d->m_saltDataHealth;
+}
+
+/*!
+ * \brief Returns information about masterlock health.
+ *
+ * The result can be used to decuce whether a data corruption happened
+ * to the masterlock data.
+ */
+HealthCheckRequest::Health HealthCheckRequest::masterlockHealth() const
+{
+    Q_D(const HealthCheckRequest);
+    return d->m_masterlockHealth;
+}
+
+/*!
+ * \brief Tells whether the secrets data is completely healthy.
+ *
+ * The result can be used to decuce whether a data corruption happened
+ * to any data which is monitored for data corruptions. Returns true if
+ * everything is okay and false otherwise.
+ */
+bool HealthCheckRequest::isHealthy() const
+{
+    Q_D(const HealthCheckRequest);
+    return (d->m_saltDataHealth == HealthOK) && (d->m_masterlockHealth == HealthOK);
+}
+
+Request::Status HealthCheckRequest::status() const
+{
+    Q_D(const HealthCheckRequest);
+    return d->m_status;
+}
+
+Result HealthCheckRequest::result() const
+{
+    Q_D(const HealthCheckRequest);
+    return d->m_result;
+}
+
+SecretManager *HealthCheckRequest::manager() const
+{
+    Q_D(const HealthCheckRequest);
+    return d->m_manager.data();
+}
+
+void HealthCheckRequest::setManager(SecretManager *manager)
+{
+    Q_D(HealthCheckRequest);
+    if (d->m_manager.data() != manager) {
+        d->m_manager = manager;
+        emit managerChanged();
+    }
+}
+
+void HealthCheckRequest::startRequest()
+{
+    Q_D(HealthCheckRequest);
+    if (d->m_status != Request::Active && !d->m_manager.isNull()) {
+        d->m_status = Request::Active;
+        emit statusChanged();
+        if (d->m_result.code() != Result::Pending) {
+            d->m_result = Result(Result::Pending);
+            emit resultChanged();
+        }
+
+        QDBusPendingReply<Result,
+                          HealthCheckRequest::Health,
+                          HealthCheckRequest::Health> reply
+                = d->m_manager->d_ptr->getHealthInfo();
+        if (!reply.isValid() && !reply.error().message().isEmpty()) {
+            d->m_status = Request::Finished;
+            d->m_result = Result(Result::SecretManagerNotInitializedError,
+                                 reply.error().message());
+            d->m_saltDataHealth = HealthCheckRequest::HealthUnknown;
+            d->m_masterlockHealth = HealthCheckRequest::HealthUnknown;
+            emit saltDataHealthChanged();
+            emit masterlockHealthChanged();
+            emit isHealthyChanged();
+            emit statusChanged();
+            emit resultChanged();
+        } else if (reply.isFinished()
+                // work around a bug in QDBusAbstractInterface / QDBusConnection...
+                && reply.argumentAt<0>().code() != Sailfish::Secrets::Result::Succeeded) {
+            d->m_status = Request::Finished;
+            d->m_result = reply.argumentAt<0>();
+            d->m_saltDataHealth = reply.argumentAt<1>();
+            d->m_masterlockHealth = reply.argumentAt<2>();
+            emit saltDataHealthChanged();
+            emit masterlockHealthChanged();
+            emit isHealthyChanged();
+            emit statusChanged();
+            emit resultChanged();
+        } else {
+            d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
+            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished, [this] {
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingReply<Result,
+                                  HealthCheckRequest::Health,
+                                  HealthCheckRequest::Health> reply = *watcher;
+                this->d_ptr->m_status = Request::Finished;
+                this->d_ptr->m_result = reply.argumentAt<0>();
+                this->d_ptr->m_saltDataHealth = reply.argumentAt<1>();
+                this->d_ptr->m_masterlockHealth = reply.argumentAt<2>();
+                watcher->deleteLater();
+                emit this->saltDataHealthChanged();
+                emit this->masterlockHealthChanged();
+                emit this->isHealthyChanged();
+                emit this->statusChanged();
+                emit this->resultChanged();
+            });
+        }
+    }
+}
+
+void HealthCheckRequest::waitForFinished()
+{
+    Q_D(HealthCheckRequest);
+    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+        d->m_watcher->waitForFinished();
+    }
+}

--- a/lib/Secrets/healthcheckrequest.h
+++ b/lib/Secrets/healthcheckrequest.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018 Jolla Ltd.
+ * Contact: Timur Kristóf <timur.kristof@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#ifndef LIBSAILFISHSECRETS_HEATHCHECKREQUEST_H
+#define LIBSAILFISHSECRETS_HEATHCHECKREQUEST_H
+
+#include "Secrets/secretsglobal.h"
+#include "Secrets/request.h"
+#include "Secrets/secret.h"
+#include "Secrets/secretmanager.h"
+#include "Secrets/plugininfo.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QScopedPointer>
+#include <QtCore/QString>
+#include <QtCore/QVector>
+
+namespace Sailfish {
+
+namespace Secrets {
+
+class HealthCheckRequestPrivate;
+class SAILFISH_SECRETS_API HealthCheckRequest : public Sailfish::Secrets::Request
+{
+    Q_OBJECT
+    Q_PROPERTY(Health saltDataHealth READ saltDataHealth NOTIFY saltDataHealthChanged)
+    Q_PROPERTY(Health masterlockHealth READ masterlockHealth NOTIFY masterlockHealthChanged)
+    Q_PROPERTY(bool isHealthy READ isHealthy NOTIFY isHealthyChanged)
+
+public:
+    enum Health {
+        HealthOK = 0,
+        HealthUnknown,
+        HealthCorrupted,
+        HealthOtherError,
+    };
+    Q_ENUM(Health)
+
+    HealthCheckRequest(QObject *parent = Q_NULLPTR);
+    ~HealthCheckRequest() Q_DECL_OVERRIDE;
+
+    Health saltDataHealth() const;
+    Health masterlockHealth() const;
+    bool isHealthy() const;
+
+    Sailfish::Secrets::Request::Status status() const Q_DECL_OVERRIDE;
+    Sailfish::Secrets::Result result() const Q_DECL_OVERRIDE;
+
+    Sailfish::Secrets::SecretManager *manager() const Q_DECL_OVERRIDE;
+    void setManager(Sailfish::Secrets::SecretManager *manager) Q_DECL_OVERRIDE;
+
+    void startRequest() Q_DECL_OVERRIDE;
+    void waitForFinished() Q_DECL_OVERRIDE;
+
+Q_SIGNALS:
+    void saltDataHealthChanged();
+    void masterlockHealthChanged();
+    void isHealthyChanged();
+
+private:
+    QScopedPointer<HealthCheckRequestPrivate> const d_ptr;
+    Q_DECLARE_PRIVATE(HealthCheckRequest)
+};
+
+} // namespace Secrets
+
+} // namespace Sailfish
+
+#endif // LIBSAILFISHSECRETS_HEATHCHECKREQUEST_H

--- a/lib/Secrets/healthcheckrequest.h
+++ b/lib/Secrets/healthcheckrequest.h
@@ -70,4 +70,6 @@ private:
 
 } // namespace Sailfish
 
+Q_DECLARE_METATYPE(::Sailfish::Secrets::HealthCheckRequest::Health);
+
 #endif // LIBSAILFISHSECRETS_HEATHCHECKREQUEST_H

--- a/lib/Secrets/healthcheckrequest_p.h
+++ b/lib/Secrets/healthcheckrequest_p.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2018 Jolla Ltd.
+ * Contact: Timur Kristóf <timur.kristof@jollamobile.com>
+ * All rights reserved.
+ * BSD 3-Clause License, see LICENSE.
+ */
+
+#ifndef LIBSAILFISHSECRETS_HEALTHCHECKREQUEST_P_H
+#define LIBSAILFISHSECRETS_HEALTHCHECKREQUEST_P_H
+
+#include "Secrets/secretsglobal.h"
+#include "Secrets/secretmanager.h"
+#include "Secrets/secret.h"
+#include "Secrets/healthcheckrequest.h"
+
+#include <QtCore/QPointer>
+#include <QtCore/QScopedPointer>
+#include <QtCore/QString>
+
+#include <QtDBus/QDBusPendingCallWatcher>
+
+namespace Sailfish {
+
+namespace Secrets {
+
+class HealthCheckRequestPrivate
+{
+    Q_DISABLE_COPY(HealthCheckRequestPrivate)
+
+public:
+    explicit HealthCheckRequestPrivate();
+
+    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    Sailfish::Secrets::Request::Status m_status;
+    Sailfish::Secrets::Result m_result;
+
+    QPointer<Sailfish::Secrets::SecretManager> m_manager;
+    HealthCheckRequest::Health m_saltDataHealth;
+    HealthCheckRequest::Health m_masterlockHealth;
+};
+
+} // namespace Secrets
+
+} // namespace Sailfish
+
+#endif // LIBSAILFISHSECRETS_HEALTHCHECKREQUEST_P_H

--- a/lib/Secrets/secretmanager.cpp
+++ b/lib/Secrets/secretmanager.cpp
@@ -96,7 +96,11 @@ QDBusPendingReply<Result,
 SecretManagerPrivate::getPluginInfo()
 {
     if (!m_interface) {
-        return QDBusPendingReply<Result>(
+        return QDBusPendingReply<Result,
+                                 QVector<PluginInfo>,
+                                 QVector<PluginInfo>,
+                                 QVector<PluginInfo>,
+                                 QVector<PluginInfo> >(
                     QDBusMessage::createError(QDBusError::Other,
                                               QStringLiteral("Not connected to daemon")));
     }
@@ -107,6 +111,27 @@ SecretManagerPrivate::getPluginInfo()
                       QVector<PluginInfo>,
                       QVector<PluginInfo> > reply
             = m_interface->asyncCall(QStringLiteral("getPluginInfo"));
+    return reply;
+}
+
+
+QDBusPendingReply<Sailfish::Secrets::Result,
+                  HealthCheckRequest::Health,
+                  HealthCheckRequest::Health>
+SecretManagerPrivate::getHealthInfo()
+{
+    if (!m_interface) {
+        return QDBusPendingReply<Sailfish::Secrets::Result,
+                                 HealthCheckRequest::Health,
+                                 HealthCheckRequest::Health>(
+                    QDBusMessage::createError(QDBusError::Other,
+                                              QStringLiteral("Not connected to daemon")));
+    }
+
+    QDBusPendingReply<Sailfish::Secrets::Result,
+                      HealthCheckRequest::Health,
+                      HealthCheckRequest::Health> reply
+            = m_interface->asyncCall(QStringLiteral("getHealthInfo"));
     return reply;
 }
 

--- a/lib/Secrets/secretmanager.h
+++ b/lib/Secrets/secretmanager.h
@@ -104,6 +104,7 @@ private:
     friend class InteractionRequest;
     friend class LockCodeRequest;
     friend class PluginInfoRequest;
+    friend class HealthCheckRequest;
     friend class StoredSecretRequest;
     friend class StoreSecretRequest;
 };

--- a/lib/Secrets/secretmanager_p.h
+++ b/lib/Secrets/secretmanager_p.h
@@ -13,6 +13,7 @@
 #include "Secrets/interactionparameters.h"
 #include "Secrets/secretsdaemonconnection_p.h"
 #include "Secrets/plugininfo.h"
+#include "Secrets/healthcheckrequest.h"
 #include "Secrets/interactionview.h"
 #include "Secrets/interactionservice_p.h"
 #include "Secrets/lockcoderequest.h"
@@ -53,6 +54,11 @@ public:
                       QVector<Sailfish::Secrets::PluginInfo>,
                       QVector<Sailfish::Secrets::PluginInfo>,
                       QVector<Sailfish::Secrets::PluginInfo> > getPluginInfo();
+
+    // retrieve information about health
+    QDBusPendingReply<Sailfish::Secrets::Result,
+                      HealthCheckRequest::Health,
+                      HealthCheckRequest::Health> getHealthInfo();
 
     // retrieve user input data
     QDBusPendingReply<Sailfish::Secrets::Result, QByteArray> userInput(

--- a/lib/Secrets/secretsdaemonconnection.cpp
+++ b/lib/Secrets/secretsdaemonconnection.cpp
@@ -12,6 +12,7 @@
 #include "Secrets/secretmanager.h"
 #include "Secrets/interactionparameters.h"
 #include "Secrets/plugininfo.h"
+#include "Secrets/healthcheckrequest.h"
 #include "Secrets/result.h"
 #include "Secrets/secret.h"
 #include "Secrets/interactionparameters.h"
@@ -176,6 +177,7 @@ void Sailfish::Secrets::SecretsDaemonConnection::registerDBusTypes()
     qRegisterMetaType<Sailfish::Secrets::InteractionResponse>("Sailfish::Secrets::InteractionResponse");
     qRegisterMetaType<Sailfish::Secrets::LockCodeRequest::LockCodeTargetType>("Sailfish::Secrets::LockCodeRequest::LockCodeTargetType");
     qRegisterMetaType<Sailfish::Secrets::LockCodeRequest::LockStatus>("Sailfish::Secrets::LockCodeRequest::LockStatus");
+    qRegisterMetaType<Sailfish::Secrets::HealthCheckRequest::Health>("Sailfish::Secrets::HealthCheckRequest::Health");
 
     qDBusRegisterMetaType<Sailfish::Secrets::SecretManager::UserInteractionMode>();
     qDBusRegisterMetaType<Sailfish::Secrets::SecretManager::AccessControlMode>();
@@ -198,4 +200,5 @@ void Sailfish::Secrets::SecretsDaemonConnection::registerDBusTypes()
     qDBusRegisterMetaType<Sailfish::Secrets::InteractionResponse>();
     qDBusRegisterMetaType<Sailfish::Secrets::LockCodeRequest::LockCodeTargetType>();
     qDBusRegisterMetaType<Sailfish::Secrets::LockCodeRequest::LockStatus>();
+    qDBusRegisterMetaType<Sailfish::Secrets::HealthCheckRequest::Health>();
 }

--- a/lib/Secrets/serialization.cpp
+++ b/lib/Secrets/serialization.cpp
@@ -412,6 +412,25 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, LockCodeRequest::
     return argument;
 }
 
+QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Secrets::HealthCheckRequest::Health &h)
+{
+    int i = static_cast<int>(h);
+    argument.beginStructure();
+    argument << i;
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Secrets::HealthCheckRequest::Health &h)
+{
+    int i = 0;
+    argument.beginStructure();
+    argument >> i;
+    argument.endStructure();
+    h = static_cast<Sailfish::Secrets::HealthCheckRequest::Health>(i);
+    return argument;
+}
+
 } // namespace Secrets
 
 } // namespace Sailfish

--- a/lib/Secrets/serialization_p.h
+++ b/lib/Secrets/serialization_p.h
@@ -18,6 +18,7 @@
 #include "Secrets/secret.h"
 #include "Secrets/interactionparameters.h"
 #include "Secrets/plugininfo.h"
+#include "Secrets/healthcheckrequest.h"
 #include "Secrets/secretmanager.h"
 #include "Secrets/interactionparameters.h"
 #include "Secrets/interactionresponse.h"
@@ -70,6 +71,9 @@ QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Secrets::Lock
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Secrets::LockCodeRequest::LockCodeTargetType &type) SAILFISH_SECRETS_API;
 QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Secrets::LockCodeRequest::LockStatus &status) SAILFISH_SECRETS_API;
 const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Secrets::LockCodeRequest::LockStatus &status) SAILFISH_SECRETS_API;
+
+QDBusArgument &operator<<(QDBusArgument &argument, const Sailfish::Secrets::HealthCheckRequest::Health &h) SAILFISH_SECRETS_API;
+const QDBusArgument &operator>>(const QDBusArgument &argument, Sailfish::Secrets::HealthCheckRequest::Health &h) SAILFISH_SECRETS_API;
 
 } // namespace Secrets
 

--- a/qml/Secrets/main.cpp
+++ b/qml/Secrets/main.cpp
@@ -32,7 +32,9 @@ void Sailfish::Secrets::Plugin::SecretsPlugin::registerTypes(const char *uri)
 
     qRegisterMetaType<Sailfish::Secrets::Result>("SecretsResult");
     QMetaType::registerComparators<Sailfish::Secrets::Result>();
-    qmlRegisterUncreatableType<Sailfish::Secrets::Result>(uri, 1, 0, "Result", QStringLiteral("Result objects cannot be constructed directly in QML"));
+    qmlRegisterUncreatableType<Sailfish::Secrets::Result>(uri, 1, 0, "SecretsResult", QStringLiteral("Result objects cannot be constructed directly in QML"));
+    qRegisterMetaType<Sailfish::Secrets::Result::ResultCode>("SecretsResultCode");
+    qRegisterMetaType<Sailfish::Secrets::Result::ErrorCode>("SecretsErrorCode");
 
     qRegisterMetaType<Sailfish::Secrets::Secret>("Secret");
     QMetaType::registerComparators<Sailfish::Secrets::Secret>();

--- a/qml/Secrets/main.cpp
+++ b/qml/Secrets/main.cpp
@@ -42,6 +42,7 @@ void Sailfish::Secrets::Plugin::SecretsPlugin::registerTypes(const char *uri)
     qRegisterMetaType<Sailfish::Secrets::Request::Status>("SecretsRequestStatus");
     qmlRegisterUncreatableType<Sailfish::Secrets::PluginInfo>(uri, 1, 0, "PluginInfo", QStringLiteral("PluginInfo objects cannot be constructed directly in QML"));
     qmlRegisterType<Sailfish::Secrets::PluginInfoRequest>(uri, 1, 0, "PluginInfoRequest");
+    qmlRegisterType<Sailfish::Secrets::HealthCheckRequest>(uri, 1, 0, "HealthCheckRequest");
     qmlRegisterType<Sailfish::Secrets::CollectionNamesRequest>(uri, 1, 0, "CollectionNamesRequest");
     qmlRegisterType<Sailfish::Secrets::CreateCollectionRequest>(uri, 1, 0, "CreateCollectionRequest");
     qmlRegisterType<Sailfish::Secrets::DeleteCollectionRequest>(uri, 1, 0, "DeleteCollectionRequest");

--- a/qml/Secrets/plugintypes.h
+++ b/qml/Secrets/plugintypes.h
@@ -15,6 +15,7 @@
 #include "Secrets/secretmanager.h"
 
 #include "Secrets/plugininforequest.h"
+#include "Secrets/healthcheckrequest.h"
 #include "Secrets/interactionrequest.h"
 #include "Secrets/collectionnamesrequest.h"
 #include "Secrets/createcollectionrequest.h"

--- a/tools/secrets-tool/commandhelper.cpp
+++ b/tools/secrets-tool/commandhelper.cpp
@@ -16,6 +16,7 @@
 #include <Secrets/storedsecretrequest.h>
 #include <Secrets/deletesecretrequest.h>
 #include <Secrets/interactionrequest.h>
+#include <Secrets/healthcheckrequest.h>
 
 #include <Crypto/interactionparameters.h>
 #include <Crypto/keypairgenerationparameters.h>
@@ -853,6 +854,13 @@ void CommandHelper::start(const QString &command, const QStringList &args, const
         connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
                 this, &CommandHelper::secretsRequestStatusChanged);
         m_secretsRequest->startRequest();
+    } else if (command == QStringLiteral("--health-check")) {
+        Sailfish::Secrets::HealthCheckRequest *r = new Sailfish::Secrets::HealthCheckRequest;
+        m_secretsRequest.reset(r);
+        m_secretsRequest->setManager(&m_secretManager);
+        connect(m_secretsRequest.data(), &Sailfish::Secrets::Request::statusChanged,
+                this, &CommandHelper::secretsRequestStatusChanged);
+        m_secretsRequest->startRequest();
     } else {
         qInfo() << "Unknown command:" << command;
         emitFinished(EXITCODE_FAILED);
@@ -887,6 +895,10 @@ void CommandHelper::secretsRequestStatusChanged()
         Sailfish::Secrets::InteractionRequest *r = qobject_cast<Sailfish::Secrets::InteractionRequest*>(m_secretsRequest.data());
         qInfo() << "Got user input:";
         qInfo() << "\t" << r->userInput();
+    } else if (m_command == QStringLiteral("--health-check")) {
+        Sailfish::Secrets::HealthCheckRequest *r = qobject_cast<Sailfish::Secrets::HealthCheckRequest*>(m_secretsRequest.data());
+        qInfo() << "Salt data health:" << r->saltDataHealth();
+        qInfo() << "Masterlock health:" << r->masterlockHealth();
     }
 
     emitFinished(EXITCODE_SUCCESS);

--- a/tools/secrets-tool/main.cpp
+++ b/tools/secrets-tool/main.cpp
@@ -73,6 +73,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         {"--encrypt", "Encrypt a particular file with the specified key, output to stdout" },
         {"--decrypt", "Decrypt a particular file with the specified key, output to stdout" },
         {"--get-user-input", "Request user input via system dialog" },
+        {"--health-check", "Check the health of secrets daemon data" },
     };
 
     const QMap<QString, QString> paramOptions {
@@ -96,6 +97,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         {"--encrypt", "<cryptoPlugin> <storagePlugin> <collectionName> <keyName> <fileName>" },
         {"--decrypt", "<cryptoPlugin> <storagePlugin> <collectionName> <keyName> <fileName>" },
         {"--get-user-input", "" },
+        {"--health-check", "" },
     };
 
     const QMap<QString, int> paramOptionsMin {
@@ -122,6 +124,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         {"--encrypt", 5 },
         {"--decrypt", 5 },
         {"--get-user-input", 0 },
+        {"--health-check", 0 },
     };
 
     const QMap<QString, int> paramOptionsMax {
@@ -148,6 +151,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         {"--encrypt", 5 },
         {"--decrypt", 5 },
         {"--get-user-input", 0 },
+        {"--health-check", 0 },
     };
 
     const QMap<QString, QString> paramExamples {
@@ -174,6 +178,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         {"--encrypt", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyAesKey document.txt > document.txt.enc" },
         {"--decrypt", "org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher org.sailfishos.secrets.plugin.encryptedstorage.sqlcipher MyCollection MyAesKey document.txt.enc > document.txt.dec" },
         {"--get-user-input", "" },
+        {"--health-check", "" },
     };
 
     bool autotestMode = false;


### PR DESCRIPTION
This PR is a follow-up to the data protection PR which added the `DataProtector` class to the secrets daemon. This one deals with what happens when data corruption happens.

* Separate the cases when there is data corruption from when the data is otherwise inaccessible.
* When the data is irretrieveable, delete the data.
* When the data is irretrieveable, send a notification to the user.

Further idea:

* When just the lock code data is gone, maybe prompt the user to set up a new lock code. This is nice to have, but considering how unlikely it is that this actually happens, I have not implemented it yet. Our time is better spent elsewhere.