### PR TITLE
[sailfish-secrets] Add a helper constructIdenifier() function to be able to set it in DeleteStoredKeyRequest and StoredKeyRequest from QML.

### DIFF
--- a/lib/Crypto/deletestoredkeyrequest.h
+++ b/lib/Crypto/deletestoredkeyrequest.h
@@ -25,7 +25,7 @@ class DeleteStoredKeyRequestPrivate;
 class SAILFISH_CRYPTO_API DeleteStoredKeyRequest : public Sailfish::Crypto::Request
 {
     Q_OBJECT
-    Q_PROPERTY(Sailfish::Crypto::Key::Identifier identifier READ identifier NOTIFY identifierChanged)
+    Q_PROPERTY(Sailfish::Crypto::Key::Identifier identifier READ identifier WRITE setIdentifier NOTIFY identifierChanged)
 
 public:
     DeleteStoredKeyRequest(QObject *parent = Q_NULLPTR);

--- a/lib/Crypto/storedkeyrequest.h
+++ b/lib/Crypto/storedkeyrequest.h
@@ -25,7 +25,7 @@ class StoredKeyRequestPrivate;
 class SAILFISH_CRYPTO_API StoredKeyRequest : public Sailfish::Crypto::Request
 {
     Q_OBJECT
-    Q_PROPERTY(Sailfish::Crypto::Key::Identifier identifier READ identifier NOTIFY identifierChanged)
+    Q_PROPERTY(Sailfish::Crypto::Key::Identifier identifier READ identifier WRITE setIdentifier NOTIFY identifierChanged)
     Q_PROPERTY(Sailfish::Crypto::Key::Components keyComponents READ keyComponents WRITE setKeyComponents NOTIFY keyComponentsChanged)
     Q_PROPERTY(Sailfish::Crypto::Key storedKey READ storedKey NOTIFY storedKeyChanged)
 

--- a/qml/Crypto/main.cpp
+++ b/qml/Crypto/main.cpp
@@ -81,6 +81,11 @@ Sailfish::Crypto::Key Sailfish::Crypto::Plugin::CryptoManager::constructKey(cons
     return Sailfish::Crypto::Key(name, collectionName, storagePluginName);
 }
 
+Sailfish::Crypto::Key::Identifier Sailfish::Crypto::Plugin::CryptoManager::constructIdentifier(const QString &name, const QString &collectionName, const QString &storagePluginName) const
+{
+    return Sailfish::Crypto::Key::Identifier(name, collectionName, storagePluginName);
+}
+
 QVariant Sailfish::Crypto::Plugin::CryptoManager::constructRsaKeygenParams() const
 {
     return QVariant::fromValue<KeyPairGenerationParameters>(RsaKeyPairGenerationParameters());

--- a/qml/Crypto/plugintypes.h
+++ b/qml/Crypto/plugintypes.h
@@ -69,6 +69,10 @@ public:
     Q_INVOKABLE Key constructKey(const QString &name,
                                  const QString &collectionName,
                                  const QString &storagePluginName) const;
+    Q_INVOKABLE Sailfish::Crypto::Key::Identifier
+        constructIdentifier(const QString &name,
+                            const QString &collectionName,
+                            const QString &storagePluginName) const;
     Q_INVOKABLE QVariant constructRsaKeygenParams() const;
     Q_INVOKABLE QVariant constructEcKeygenParams() const;
     Q_INVOKABLE QVariant constructDsaKeygenParams() const;


### PR DESCRIPTION
The Crypto::Key::Identifier is not exposed to QML, and even not a Q_GADGET. Following the wrapper for StoredKeyIdendifierRequest, I've added wrappers for DeleteStoredKey and StoredKey requests to be able to set the identifier.