### PR TITLE
[sailfish-secrets] Add parameters to the key generation QML bindings.

### DIFF
--- a/qml/Crypto/main.cpp
+++ b/qml/Crypto/main.cpp
@@ -91,9 +91,35 @@ QVariant Sailfish::Crypto::Plugin::CryptoManager::constructRsaKeygenParams() con
     return QVariant::fromValue<KeyPairGenerationParameters>(RsaKeyPairGenerationParameters());
 }
 
+QVariant Sailfish::Crypto::Plugin::CryptoManager::constructRsaKeygenParams(const QVariantMap &args) const
+{
+    QVariantMap customParams;
+    RsaKeyPairGenerationParameters params;
+    for (QVariantMap::ConstIterator it = args.constBegin(); it != args.constEnd(); it++) {
+        if (it.key().compare("modulusLength") == 0) {
+            params.setModulusLength(it->toInt());
+        } else if (it.key().compare("numberPrimes") == 0) {
+            params.setNumberPrimes(it->toInt());
+        } else if (it.key().compare("publicExponent") == 0) {
+            params.setPublicExponent(it->value<quint64>());
+        } else {
+            customParams.insert(it.key(), it.value());
+        }
+    }
+    params.setCustomParameters(customParams);
+    return QVariant::fromValue<KeyPairGenerationParameters>(params);
+}
+
 QVariant Sailfish::Crypto::Plugin::CryptoManager::constructEcKeygenParams() const
 {
     return QVariant::fromValue<KeyPairGenerationParameters>(EcKeyPairGenerationParameters());
+}
+
+QVariant Sailfish::Crypto::Plugin::CryptoManager::constructEcKeygenParams(const QVariantMap &args) const
+{
+    EcKeyPairGenerationParameters params;
+    params.setCustomParameters(args);
+    return QVariant::fromValue<KeyPairGenerationParameters>(params);
 }
 
 QVariant Sailfish::Crypto::Plugin::CryptoManager::constructDsaKeygenParams() const
@@ -101,7 +127,55 @@ QVariant Sailfish::Crypto::Plugin::CryptoManager::constructDsaKeygenParams() con
     return QVariant::fromValue<KeyPairGenerationParameters>(DsaKeyPairGenerationParameters());
 }
 
+QVariant Sailfish::Crypto::Plugin::CryptoManager::constructDsaKeygenParams(const QVariantMap &args) const
+{
+    QVariantMap customParams;
+    DsaKeyPairGenerationParameters params;
+    for (QVariantMap::ConstIterator it = args.constBegin(); it != args.constEnd(); it++) {
+        if (it.key().compare("modulusLength") == 0) {
+            params.setModulusLength(it->toInt());
+        } else if (it.key().compare("primeFactorLength") == 0) {
+            params.setPrimeFactorLength(it->toInt());
+        } else if (it.key().compare("base") == 0) {
+            params.setBase(it->toByteArray());
+        } else if (it.key().compare("modulus") == 0) {
+            params.setModulus(it->toByteArray());
+        } else if (it.key().compare("generateFamilyParameters") == 0) {
+            params.setGenerateFamilyParameters(it->toBool());
+        } else if (it.key().compare("primeFactor") == 0) {
+            params.setPrimeFactor(it->toByteArray());
+        } else {
+            customParams.insert(it.key(), it.value());
+        }
+    }
+    params.setCustomParameters(customParams);
+    return QVariant::fromValue<KeyPairGenerationParameters>(params);
+}
+
 QVariant Sailfish::Crypto::Plugin::CryptoManager::constructDhKeygenParams() const
 {
     return QVariant::fromValue<KeyPairGenerationParameters>(DhKeyPairGenerationParameters());
+}
+
+QVariant Sailfish::Crypto::Plugin::CryptoManager::constructDhKeygenParams(const QVariantMap &args) const
+{
+    QVariantMap customParams;
+    DhKeyPairGenerationParameters params;
+    for (QVariantMap::ConstIterator it = args.constBegin(); it != args.constEnd(); it++) {
+        if (it.key().compare("modulusLength") == 0) {
+            params.setModulusLength(it->toInt());
+        } else if (it.key().compare("privateExponentLength") == 0) {
+            params.setPrivateExponentLength(it->toInt());
+        } else if (it.key().compare("base") == 0) {
+            params.setBase(it->toByteArray());
+        } else if (it.key().compare("modulus") == 0) {
+            params.setModulus(it->toByteArray());
+        } else if (it.key().compare("generateFamilyParameters") == 0) {
+            params.setGenerateFamilyParameters(it->toBool());
+        } else {
+            customParams.insert(it.key(), it.value());
+        }
+    }
+    params.setCustomParameters(customParams);
+    return QVariant::fromValue<KeyPairGenerationParameters>(params);
 }

--- a/qml/Crypto/plugintypes.h
+++ b/qml/Crypto/plugintypes.h
@@ -74,9 +74,16 @@ public:
                             const QString &collectionName,
                             const QString &storagePluginName) const;
     Q_INVOKABLE QVariant constructRsaKeygenParams() const;
+    Q_INVOKABLE QVariant constructRsaKeygenParams(const QVariantMap &args) const;
+
     Q_INVOKABLE QVariant constructEcKeygenParams() const;
+    Q_INVOKABLE QVariant constructEcKeygenParams(const QVariantMap &args) const;
+
     Q_INVOKABLE QVariant constructDsaKeygenParams() const;
+    Q_INVOKABLE QVariant constructDsaKeygenParams(const QVariantMap &args) const;
+
     Q_INVOKABLE QVariant constructDhKeygenParams() const;
+    Q_INVOKABLE QVariant constructDhKeygenParams(const QVariantMap &args) const;
 };
 
 } // Plugin


### PR DESCRIPTION
Allow to set up key generation parameters from QML bindings. One can write something like:
<pre>
keyPairGenerationParameters: cryptoManager.constructRsaKeygenParams
    ({"name": root.identity,
      "email": root.emailAddress,
      "modulusLength": 3072})
</pre>
Known parameters are set via their setters, while all other key:values are passed as custom parameters.