### PR TITLE
[sailfish-secrets] Export lists to QML from PluginInfoRequest.

### DIFF
--- a/qml/Crypto/main.cpp
+++ b/qml/Crypto/main.cpp
@@ -28,7 +28,7 @@ void Sailfish::Crypto::Plugin::CryptoPlugin::registerTypes(const char *uri)
     qmlRegisterUncreatableType<Sailfish::Crypto::Request>(uri, 1, 0, "CryptoRequest", QStringLiteral("Request is an abstract class, can't construct in QML"));
     qRegisterMetaType<Sailfish::Crypto::Request::Status>("CryptoRequestStatus");
     qmlRegisterUncreatableType<Sailfish::Crypto::PluginInfo>(uri, 1, 0, "PluginInfo", QStringLiteral("PluginInfo objects cannot be constructed directly in QML"));
-    qmlRegisterType<Sailfish::Crypto::PluginInfoRequest>(uri, 1, 0, "PluginInfoRequest");
+    qmlRegisterType<Sailfish::Crypto::Plugin::PluginInfoRequestWrapper>(uri, 1, 0, "PluginInfoRequest");
     qmlRegisterType<Sailfish::Crypto::SeedRandomDataGeneratorRequest>(uri, 1, 0, "SeedRandomDataGeneratorRequest");
     qmlRegisterType<Sailfish::Crypto::GenerateRandomDataRequest>(uri, 1, 0, "GenerateRandomDataRequest");
     qmlRegisterType<Sailfish::Crypto::GenerateKeyRequest>(uri, 1, 0, "GenerateKeyRequest");

--- a/qml/Crypto/storedkeyidentifiersrequestwrapper.cpp
+++ b/qml/Crypto/storedkeyidentifiersrequestwrapper.cpp
@@ -41,3 +41,33 @@ QVariantList Sailfish::Crypto::Plugin::StoredKeyIdentifiersRequestWrapper::ident
 
     return results;
 }
+
+Sailfish::Crypto::Plugin::PluginInfoRequestWrapper::PluginInfoRequestWrapper(QObject *parent) : Sailfish::Crypto::PluginInfoRequest(parent)
+{
+    connect(this, &Sailfish::Crypto::PluginInfoRequest::cryptoPluginsChanged, this, &Sailfish::Crypto::Plugin::PluginInfoRequestWrapper::cryptoPluginsChanged);
+    connect(this, &Sailfish::Crypto::PluginInfoRequest::storagePluginsChanged, this, &Sailfish::Crypto::Plugin::PluginInfoRequestWrapper::storagePluginsChanged);
+}
+
+QVariantList Sailfish::Crypto::Plugin::PluginInfoRequestWrapper::cryptoPlugins() const
+{
+    auto resultsFromBase = Sailfish::Crypto::PluginInfoRequest::cryptoPlugins();
+    QVariantList results;
+
+    for (auto i : resultsFromBase) {
+        results.append(QVariant::fromValue(i));
+    }
+
+    return results;
+}
+
+QVariantList Sailfish::Crypto::Plugin::PluginInfoRequestWrapper::storagePlugins() const
+{
+    auto resultsFromBase = Sailfish::Crypto::PluginInfoRequest::storagePlugins();
+    QVariantList results;
+
+    for (auto i : resultsFromBase) {
+        results.append(QVariant::fromValue(i));
+    }
+
+    return results;
+}

--- a/qml/Crypto/storedkeyidentifiersrequestwrapper.h
+++ b/qml/Crypto/storedkeyidentifiersrequestwrapper.h
@@ -12,6 +12,7 @@
 #include "Crypto/key.h"
 
 #include "Crypto/storedkeyidentifiersrequest.h"
+#include "Crypto/plugininforequest.h"
 
 #include <QtCore/QVariant>
 #include <QtCore/QVariantList>
@@ -48,6 +49,21 @@ public:
 
 Q_SIGNALS:
     void identifiersChanged();
+};
+
+class PluginInfoRequestWrapper : public Sailfish::Crypto::PluginInfoRequest {
+    Q_OBJECT
+    Q_PROPERTY(QVariantList cryptoPlugins READ cryptoPlugins NOTIFY cryptoPluginsChanged)
+    Q_PROPERTY(QVariantList storagePlugins READ storagePlugins NOTIFY storagePluginsChanged)
+
+public:
+    PluginInfoRequestWrapper(QObject *parent = Q_NULLPTR);
+    QVariantList cryptoPlugins() const;
+    QVariantList storagePlugins() const;
+
+Q_SIGNALS:
+    void cryptoPluginsChanged();
+    void storagePluginsChanged();
 };
 
 } // Plugin

--- a/qml/Secrets/findsecretsrequestwrapper.cpp
+++ b/qml/Secrets/findsecretsrequestwrapper.cpp
@@ -41,3 +41,59 @@ QVariantList Sailfish::Secrets::Plugin::FindSecretsRequestWrapper::identifiers()
 
     return results;
 }
+
+Sailfish::Secrets::Plugin::PluginInfoRequestWrapper::PluginInfoRequestWrapper(QObject *parent) : Sailfish::Secrets::PluginInfoRequest(parent)
+{
+    connect(this, &Sailfish::Secrets::PluginInfoRequest::storagePluginsChanged, this, &Sailfish::Secrets::Plugin::PluginInfoRequestWrapper::storagePluginsChanged);
+    connect(this, &Sailfish::Secrets::PluginInfoRequest::encryptionPluginsChanged, this, &Sailfish::Secrets::Plugin::PluginInfoRequestWrapper::encryptionPluginsChanged);
+    connect(this, &Sailfish::Secrets::PluginInfoRequest::encryptedStoragePluginsChanged, this, &Sailfish::Secrets::Plugin::PluginInfoRequestWrapper::encryptedStoragePluginsChanged);
+    connect(this, &Sailfish::Secrets::PluginInfoRequest::authenticationPluginsChanged, this, &Sailfish::Secrets::Plugin::PluginInfoRequestWrapper::authenticationPluginsChanged);
+}
+
+QVariantList Sailfish::Secrets::Plugin::PluginInfoRequestWrapper::storagePlugins() const
+{
+    auto resultsFromBase = Sailfish::Secrets::PluginInfoRequest::storagePlugins();
+    QVariantList results;
+
+    for (auto i : resultsFromBase) {
+        results.append(QVariant::fromValue(i));
+    }
+
+    return results;
+}
+
+QVariantList Sailfish::Secrets::Plugin::PluginInfoRequestWrapper::encryptionPlugins() const
+{
+    auto resultsFromBase = Sailfish::Secrets::PluginInfoRequest::encryptionPlugins();
+    QVariantList results;
+
+    for (auto i : resultsFromBase) {
+        results.append(QVariant::fromValue(i));
+    }
+
+    return results;
+}
+
+QVariantList Sailfish::Secrets::Plugin::PluginInfoRequestWrapper::encryptedStoragePlugins() const
+{
+    auto resultsFromBase = Sailfish::Secrets::PluginInfoRequest::encryptedStoragePlugins();
+    QVariantList results;
+
+    for (auto i : resultsFromBase) {
+        results.append(QVariant::fromValue(i));
+    }
+
+    return results;
+}
+
+QVariantList Sailfish::Secrets::Plugin::PluginInfoRequestWrapper::authenticationPlugins() const
+{
+    auto resultsFromBase = Sailfish::Secrets::PluginInfoRequest::authenticationPlugins();
+    QVariantList results;
+
+    for (auto i : resultsFromBase) {
+        results.append(QVariant::fromValue(i));
+    }
+
+    return results;
+}

--- a/qml/Secrets/findsecretsrequestwrapper.h
+++ b/qml/Secrets/findsecretsrequestwrapper.h
@@ -12,6 +12,7 @@
 #include "Secrets/secret.h"
 
 #include "Secrets/findsecretsrequest.h"
+#include "Secrets/plugininforequest.h"
 
 #include <QtCore/QVariant>
 #include <QtCore/QVariantList>
@@ -48,6 +49,27 @@ public:
 
 Q_SIGNALS:
     void identifiersChanged();
+};
+
+class PluginInfoRequestWrapper : public Sailfish::Secrets::PluginInfoRequest {
+    Q_OBJECT
+    Q_PROPERTY(QVariantList storagePlugins READ storagePlugins NOTIFY storagePluginsChanged)
+    Q_PROPERTY(QVariantList encryptionPlugins READ encryptionPlugins NOTIFY encryptionPluginsChanged)
+    Q_PROPERTY(QVariantList encryptedStoragePlugins READ encryptedStoragePlugins NOTIFY encryptedStoragePluginsChanged)
+    Q_PROPERTY(QVariantList authenticationPlugins READ authenticationPlugins NOTIFY authenticationPluginsChanged)
+
+public:
+    PluginInfoRequestWrapper(QObject *parent = Q_NULLPTR);
+    QVariantList storagePlugins() const;
+    QVariantList encryptionPlugins() const;
+    QVariantList encryptedStoragePlugins() const;
+    QVariantList authenticationPlugins() const;
+
+Q_SIGNALS:
+    void storagePluginsChanged();
+    void encryptionPluginsChanged();
+    void encryptedStoragePluginsChanged();
+    void authenticationPluginsChanged();
 };
 
 } // Plugin

--- a/qml/Secrets/main.cpp
+++ b/qml/Secrets/main.cpp
@@ -43,7 +43,7 @@ void Sailfish::Secrets::Plugin::SecretsPlugin::registerTypes(const char *uri)
     qmlRegisterUncreatableType<Sailfish::Secrets::Request>(uri, 1, 0, "SecretsRequest", QStringLiteral("Request is an abstract class, can't construct in QML"));
     qRegisterMetaType<Sailfish::Secrets::Request::Status>("SecretsRequestStatus");
     qmlRegisterUncreatableType<Sailfish::Secrets::PluginInfo>(uri, 1, 0, "PluginInfo", QStringLiteral("PluginInfo objects cannot be constructed directly in QML"));
-    qmlRegisterType<Sailfish::Secrets::PluginInfoRequest>(uri, 1, 0, "PluginInfoRequest");
+    qmlRegisterType<Sailfish::Secrets::Plugin::PluginInfoRequestWrapper>(uri, 1, 0, "PluginInfoRequest");
     qmlRegisterType<Sailfish::Secrets::HealthCheckRequest>(uri, 1, 0, "HealthCheckRequest");
     qmlRegisterType<Sailfish::Secrets::CollectionNamesRequest>(uri, 1, 0, "CollectionNamesRequest");
     qmlRegisterType<Sailfish::Secrets::CreateCollectionRequest>(uri, 1, 0, "CreateCollectionRequest");


### PR DESCRIPTION
As for #140, add wrappers for PluginInfoRequest so that the list attributes are available from QML.

@chriadam and @venemo, any remarks?