### PR TITLE
[sailfish-secrets] Switch to password creation from operation(), and not from prompt texts. Contributes to JB#36797

### DIFF
--- a/lib/Secrets/interactionparameters.h
+++ b/lib/Secrets/interactionparameters.h
@@ -94,6 +94,8 @@ public:
         StoreKey            = 1 << 25,
         ImportKey           = 1 << 26,
 
+        CreatePassword      = 1 << 27,
+
         // reserved
         LastOperation       = 1 << 30
     };

--- a/plugins/gnupgplugin/gpgmebase.cpp
+++ b/plugins/gnupgplugin/gpgmebase.cpp
@@ -268,10 +268,7 @@ Result Daemon::Plugins::GnuPGPlugin::generateKey(const Key &keyTemplate,
         if (empty == kpgParams.customParameters().constEnd()) {
             Sailfish::Secrets::SecretManager secretManager;
             Sailfish::Secrets::InteractionParameters uiParams;
-            Sailfish::Secrets::InteractionParameters::PromptText prompt;
-            //% "Repeat password"
-            prompt.setRepeatInstruction(qtTrId("gnupg_plugin-repeat_passphrase"));
-            uiParams.setPromptText(prompt);
+            uiParams.setOperation(Sailfish::Secrets::InteractionParameters::CreatePassword);
             uiParams.setInputType(Sailfish::Secrets::InteractionParameters::AlphaNumericInput);
             uiParams.setEchoMode(Sailfish::Secrets::InteractionParameters::PasswordEcho);
 

--- a/plugins/passwordagentauthplugin/passwordagentplugin.cpp
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.cpp
@@ -648,9 +648,11 @@ Result PasswordAgentPlugin::beginUserInputInteraction(
                              << "in collection" << interactionParameters.collectionName()
                              << interactionServiceAddress;
 
-    // If there's a repeat prompt call CreatePassword which will ask for the password
-    // to be repeated twice.
-    const bool newPassword = promptText.contains(InteractionParameters::RepeatInstruction);
+    const bool newPassword = (interactionParameters.operation()
+                              == InteractionParameters::CreatePassword
+                              /* Keep old behaviour, before CreatePassword operation
+                                 was introduced. */
+                              || promptText.contains(InteractionParameters::RepeatInstruction));
 
     QDBusPendingCall call = agent->asyncCall(newPassword
                     ? QStringLiteral("CreatePassword")


### PR DESCRIPTION
As discussed in #144 it is not possible at the moment to request a password creation input window without overriding the default repeat message.

This PR is fixing this by defining a new operation in InteractionParameters and detecting the creation request from operation in password plugin instead of relying on the prompt texts.

IMHO, it's more semantic to switch action depending on operation than trying to infer it from context (here prompt texts). Prompt texts should be kept for what they are: overriding default text messages in the system window.