### PR TITLE
[sailfish-secrets] Clean emails before storing them for S/MIME keys.

### DIFF
--- a/plugins/gnupgplugin/gpgme_p.h
+++ b/plugins/gnupgplugin/gpgme_p.h
@@ -294,8 +294,17 @@ struct GPGmeKey {
         QStringList emails;
         gpgme_user_id_t uid = key->uids;
         while (uid) {
-            if (uid->email) {
-                emails << uid->email;
+            if (uid->email && uid->email[0]) {
+                // email can have the form <foo@example.org> or foo@example.org
+                if (uid->email[0] == '<') {
+                    QString email(uid->email + 1);
+                    if (email.endsWith('>')) {
+                        email.chop(1);
+                    }
+                    emails << email;
+                } else {
+                    emails << uid->email;
+                }
             }
             uid = uid->next;
         }


### PR DESCRIPTION
Email filtering is currently failing in a FindSecretRequest for S/MIME keys because emails are stored within brackets. This PR is removing the brackets if any, storing emails as they are.

@chriadam this will be necessary for selection of S/MIME keys for email signature.