### PR TITLE
[sailfish-secrets] Don't fetch cache passphrase on retry. Contributes to JB#43783

### DIFF
--- a/plugins/gnupgplugin/pinentry/qassuanserver.cpp
+++ b/plugins/gnupgplugin/pinentry/qassuanserver.cpp
@@ -357,7 +357,7 @@ Sailfish::Secrets::Result QAssuanServer::requestPassphrase(QByteArray *passphras
     passphrase->clear();
 
     bool useCache = m_useCache->value(QVariant(true)).toBool();
-    if (useCache && cacheId.isValid()) {
+    if (useCache && cacheId.isValid() && prompt.instruction().isEmpty()) {
         Sailfish::Secrets::StoredSecretRequest request;
         qCDebug(lcSailfishPinentry) << "Starting cache request for" << cacheId.name();
         request.setManager(&secretManager);


### PR DESCRIPTION
Passphrases can be cached as Secrets, so they are not asked everytime. Before asking to enter a passphrase to unlock a GnuPG key, the pinentry is requesting access to a Secret collection to retrieve the passhrase if stored.

This commit disables this cache retrieval if the provided passphrase was erroneous (having an error generates a prompt instruction explaining about the error).

@chriadam may you review ?