### PR TITLE
[sailfish-secrets] Ensure that authentication plugin are installed with GnuPG plugins.

### DIFF
--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -280,6 +280,7 @@ BuildRequires:  libassuan-devel
 Requires:   %{secretsdaemon} = %{version}-%{release}
 Requires:   libsailfishcrypto = %{version}-%{release}
 Requires:   libsailfishcryptopluginapi = %{version}-%{release}
+Requires:   %{secretsdaemon}-secretsplugin-common
 
 %description -n %{secretsdaemon}-cryptoplugins-gnupg
 %{summary}.


### PR DESCRIPTION
Currently, pulling in the GnuPG plugin on a bare system will install the daemon but the authentication plugin that is used by pinentry is not installed.

@chriadam and @pvuorela this may solve some of the dependency issues we have went installing only this package on a bare system.