### PR TITLE
[sailfish-secrets] Ensure user input dialog timeout before request. Contributes to JB#44199

### DIFF
--- a/plugins/passwordagentauthplugin/passwordagentplugin.cpp
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.cpp
@@ -654,12 +654,16 @@ Result PasswordAgentPlugin::beginUserInputInteraction(
                                  was introduced. */
                               || promptText.contains(InteractionParameters::RepeatInstruction));
 
+    // SecretManager connection timeout is fixed at 3 minutes.
+    // Keep the timeout of the password dialog below this
+    // threshold to avoid having the dialog stay on screen
+    // while the request has already timeouted.
     QDBusPendingCall call = agent->asyncCall(newPassword
                     ? QStringLiteral("CreatePassword")
                     : QStringLiteral("QueryPassword"), {
                 QVariant::fromValue(cookie),
                 QVariant::fromValue(promptText.message()),
-                QVariant::fromValue(properties) }, 5 * 60 * 1000);
+                QVariant::fromValue(properties) }, 2 * 60 * 1000 + 30 * 1000);
 
     PasswordResponse * const response = new PasswordResponse(
                 call,


### PR DESCRIPTION
Introduce a timeout attribute to interaction parameters. Use this
timeout value in password plugin to ensure that dialog is dismissed
before the request itself timeout. This avoid the request to return
an empty user input with a successful result while the dialog itself
is still being displayed.

Solve issue #155 

@chriadam there is still a possible issue with inconsistent hard coded timeout values: in `secretdaemonconnection.cpp:createInterface()` (/resp./ in crypto) the timeout is fixed to 3 minutes, which is fine for the default timeout of 2 minutes, but can create issues in my opinion if user sets up a longer timeout. The problem is that this timeout is set for the manager itself, so for all requests. I don't think it can be a good idea to change the timeout after creation when we want to manage a user input with a longer timeout.
A possible solution would be to fix timeouts as a constant somewhere in secret API and use this constant in password plugin. What do you think ?