### PR TITLE
[sailfish-secrets] Add a cancellation mechanism to authentication and user input requests.

### DIFF
--- a/daemon/CryptoImpl/crypto.cpp
+++ b/daemon/CryptoImpl/crypto.cpp
@@ -21,7 +21,7 @@
 #include <QtCore/QVector>
 #include <QtCore/QByteArray>
 
-#define MAP_PLUGIN_NAMES(variable) ::mapPluginNames(m_requestQueue->controller(), variable)
+#define MAP_PLUGIN_NAMES(variable) ::mapPluginNames(static_cast<Daemon::ApiImpl::CryptoRequestQueue*>(m_requestQueue)->controller(), variable)
 
 namespace {
     Sailfish::Crypto::Key mapPluginNames(
@@ -60,8 +60,7 @@ using namespace Sailfish::Crypto;
 
 Daemon::ApiImpl::CryptoDBusObject::CryptoDBusObject(
         Daemon::ApiImpl::CryptoRequestQueue *parent)
-    : QObject(parent)
-    , m_requestQueue(parent)
+    : DBusObject(parent)
 {
 }
 
@@ -723,6 +722,13 @@ QString Daemon::ApiImpl::CryptoRequestQueue::requestTypeToString(int type) const
         default: break;
     }
     return QLatin1String("Unknown Crypto Request!");
+}
+
+void Daemon::ApiImpl::CryptoRequestQueue::handleCancelation(
+        Sailfish::Secrets::Daemon::ApiImpl::RequestQueue::RequestData *request)
+{
+    Q_UNUSED(request);
+    // Only UserInput from Secrets is currently cancellable.
 }
 
 void Daemon::ApiImpl::CryptoRequestQueue::handlePendingRequest(

--- a/daemon/CryptoImpl/crypto_p.h
+++ b/daemon/CryptoImpl/crypto_p.h
@@ -45,8 +45,7 @@ namespace Daemon {
 
 namespace ApiImpl {
 
-class CryptoRequestQueue;
-class CryptoDBusObject : public QObject, protected QDBusContext
+class CryptoDBusObject : public Secrets::Daemon::ApiImpl::DBusObject
 {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.sailfishos.crypto")
@@ -561,9 +560,6 @@ public Q_SLOTS:
             const Sailfish::Crypto::InteractionParameters &interactionParameters,
             const QDBusMessage &message,
             Sailfish::Crypto::Result &result);
-
-private:
-    Sailfish::Crypto::Daemon::ApiImpl::CryptoRequestQueue *m_requestQueue;
 };
 
 class RequestProcessor;
@@ -586,6 +582,7 @@ public:
     bool unlockPlugin(const QString &pluginName, const QByteArray &lockCode);
     bool setLockCodePlugin(const QString &pluginName, const QByteArray &oldCode, const QByteArray &newCode);
 
+    void handleCancelation(Sailfish::Secrets::Daemon::ApiImpl::RequestQueue::RequestData *request) Q_DECL_OVERRIDE;
     void handlePendingRequest(Sailfish::Secrets::Daemon::ApiImpl::RequestQueue::RequestData *request, bool *completed) Q_DECL_OVERRIDE;
     void handleFinishedRequest(Sailfish::Secrets::Daemon::ApiImpl::RequestQueue::RequestData *request, bool *completed) Q_DECL_OVERRIDE;
     QString requestTypeToString(int type) const Q_DECL_OVERRIDE;

--- a/daemon/SecretsImpl/secrets.cpp
+++ b/daemon/SecretsImpl/secrets.cpp
@@ -39,7 +39,7 @@
 #include <notification.h>
 #endif
 
-#define MAP_PLUGIN_NAMES(variable) ::mapPluginNames(m_requestQueue->controller(), variable)
+#define MAP_PLUGIN_NAMES(variable) ::mapPluginNames(static_cast<Daemon::ApiImpl::SecretsRequestQueue*>(m_requestQueue)->controller(), variable)
 
 namespace {
 
@@ -108,8 +108,7 @@ using namespace Sailfish::Secrets;
 
 Daemon::ApiImpl::SecretsDBusObject::SecretsDBusObject(
         Daemon::ApiImpl::SecretsRequestQueue *parent)
-    : QObject(parent)
-    , m_requestQueue(parent)
+    : DBusObject(parent)
 {
 }
 
@@ -1211,6 +1210,13 @@ QString Daemon::ApiImpl::SecretsRequestQueue::requestTypeToString(int type) cons
         default: break;
     }
     return QLatin1String("Unknown Secrets Request!");
+}
+
+void Daemon::ApiImpl::SecretsRequestQueue::handleCancelation(
+        Daemon::ApiImpl::RequestQueue::RequestData *request)
+{
+    qCDebug(lcSailfishSecretsDaemon) << "Cancelling request from client:" << request->remotePid << ", request number:" << request->requestId;
+    m_requestProcessor->cancelRequest(request->remotePid, request->requestId);
 }
 
 void Daemon::ApiImpl::SecretsRequestQueue::handlePendingRequest(

--- a/daemon/SecretsImpl/secrets_p.h
+++ b/daemon/SecretsImpl/secrets_p.h
@@ -49,8 +49,7 @@ namespace Daemon {
 
 namespace ApiImpl {
 
-class SecretsRequestQueue;
-class SecretsDBusObject : public QObject, protected QDBusContext
+class SecretsDBusObject : public DBusObject
 {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.sailfishos.secrets")
@@ -417,9 +416,6 @@ public Q_SLOTS:
             const QString &interactionServiceAddress,
             const QDBusMessage &message,
             Sailfish::Secrets::Result &result);
-
-private:
-    Sailfish::Secrets::Daemon::ApiImpl::SecretsRequestQueue *m_requestQueue;
 };
 
 class RequestProcessor;
@@ -442,6 +438,7 @@ public:
     bool initialize(const QByteArray &lockCode, InitializationMode mode);
     bool initializePlugins();
 
+    void handleCancelation(Sailfish::Secrets::Daemon::ApiImpl::RequestQueue::RequestData *request) Q_DECL_OVERRIDE;
     void handlePendingRequest(Sailfish::Secrets::Daemon::ApiImpl::RequestQueue::RequestData *request, bool *completed) Q_DECL_OVERRIDE;
     void handleFinishedRequest(Sailfish::Secrets::Daemon::ApiImpl::RequestQueue::RequestData *request, bool *completed) Q_DECL_OVERRIDE;
     QString requestTypeToString(int type) const Q_DECL_OVERRIDE;

--- a/daemon/SecretsImpl/secretsrequestprocessor_p.h
+++ b/daemon/SecretsImpl/secretsrequestprocessor_p.h
@@ -298,6 +298,7 @@ public: // helper methods for crypto API bridge (secretscryptohelpers)
             pid_t callerPid,
             quint64 requestId,
             const Sailfish::Secrets::InteractionParameters &uiParams);
+    void cancelRequest(pid_t callerPid, quint64 requestId);
 
 private Q_SLOTS:
     void authenticationCompleted(

--- a/lib/Secrets/Plugins/extensionplugins.cpp
+++ b/lib/Secrets/Plugins/extensionplugins.cpp
@@ -1338,7 +1338,7 @@ AuthenticationPlugin::~AuthenticationPlugin()
  */
 
 /*!
- * \fn AuthenticationPlugin::beginAuthentication(uint pid, qint64 requestId)
+ * \fn AuthenticationPlugin::beginAuthentication(uint pid, qint64 requestId, const Sailfish::Secrets::InteractionParameters::PromptText &promptText)
  * \brief Begin an authentication (user verification) flow on behalf of the
  *        application with the specified \a pid as part of the secrets
  *        framework request with the specified \a requestId.
@@ -1358,6 +1358,13 @@ AuthenticationPlugin::~AuthenticationPlugin()
  * Sailfish::Secrets::Result with the result code set to
  * Sailfish::Secrets::Result::Failed and the error code set to
  * Sailfish::Secrets::Result::SecretsPluginIsLockedError.
+ */
+
+/*!
+ * \fn AuthenticationPlugin::cancelAuthentication(uint pid, qint64 requestId)
+ * \brief Cancel a running authentication flow.
+ *
+ * This will cancel a running authentication flow.
  */
 
 /*!
@@ -1388,3 +1395,11 @@ AuthenticationPlugin::~AuthenticationPlugin()
  * Sailfish::Secrets::Result::Failed and the error code set to
  * Sailfish::Secrets::Result::SecretsPluginIsLockedError.
  */
+
+/*!
+ * \fn AuthenticationPlugin::cancelUserInputInteraction(uint pid, qint64 requestId)
+ * \brief Cancel a running user input interaction.
+ *
+ * This will cancel a running user input interaction.
+ */
+

--- a/lib/Secrets/Plugins/extensionplugins.h
+++ b/lib/Secrets/Plugins/extensionplugins.h
@@ -179,11 +179,19 @@ public:
             qint64 requestId,
             const Sailfish::Secrets::InteractionParameters::PromptText &promptText) = 0;
 
+    virtual void cancelAuthentication(
+            uint callerPid,
+            qint64 requestId) = 0;
+
     virtual Sailfish::Secrets::Result beginUserInputInteraction(
             uint callerPid,
             qint64 requestId,
             const Sailfish::Secrets::InteractionParameters &interactionParameters,
             const QString &interactionServiceAddress) = 0;
+
+    virtual void cancelUserInputInteraction(
+            uint callerPid,
+            qint64 requestId) = 0;
 
 Q_SIGNALS:
     void authenticationCompleted(

--- a/plugins/inappauthplugin/plugin.cpp
+++ b/plugins/inappauthplugin/plugin.cpp
@@ -38,6 +38,15 @@ Daemon::Plugins::InAppPlugin::beginAuthentication(
                   QLatin1String("In-App plugin cannot properly authenticate the user"));
 }
 
+void
+Daemon::Plugins::InAppPlugin::cancelAuthentication(
+            uint callerPid,
+            qint64 requestId)
+{
+    Q_UNUSED(callerPid);
+    Q_UNUSED(requestId);
+}
+
 Result
 Daemon::Plugins::InAppPlugin::beginUserInputInteraction(
             uint callerPid,
@@ -202,4 +211,23 @@ Daemon::Plugins::InAppPlugin::interactionRequestFinished(
                 watcher->interactionServiceAddress(),
                 response.result(),
                 response.responseData());
+}
+
+void
+Daemon::Plugins::InAppPlugin::cancelUserInputInteraction(
+            uint callerPid,
+            qint64 requestId)
+{
+    Q_UNUSED(callerPid);
+
+    if (!m_requests.contains(requestId)) {
+        // The request doesn't exist anymore, it has been finished
+        // already and cancellation is considered a success.
+        return;
+    }
+    InteractionRequestWatcher *watcher = m_requests.take(requestId);
+    watcher->disconnectFromInteractionService();
+    watcher->deleteLater();
+
+    m_responses.remove(requestId);
 }

--- a/plugins/inappauthplugin/plugin.h
+++ b/plugins/inappauthplugin/plugin.h
@@ -70,11 +70,19 @@ public:
                 qint64 requestId,
                 const Sailfish::Secrets::InteractionParameters::PromptText &promptText) Q_DECL_OVERRIDE;
 
+    void cancelAuthentication(
+                uint callerPid,
+                qint64 requestId) Q_DECL_OVERRIDE;
+
     Sailfish::Secrets::Result beginUserInputInteraction(
                 uint callerPid,
                 qint64 requestId,
                 const Sailfish::Secrets::InteractionParameters &interactionParameters,
                 const QString &interactionServiceAddress) Q_DECL_OVERRIDE;
+
+    void cancelUserInputInteraction(
+                uint callerPid,
+                qint64 requestId) Q_DECL_OVERRIDE;
 
 private Q_SLOTS:
     void interactionRequestFinished(quint64 requestId);

--- a/plugins/passwordagentauthplugin/passwordagentplugin.h
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.h
@@ -22,6 +22,7 @@
 QT_BEGIN_NAMESPACE
 class QDBusPendingCallWatcher;
 class QDBusObjectPath;
+class QTimer;
 QT_END_NAMESPACE
 
 namespace Sailfish {
@@ -65,11 +66,19 @@ public:
             qint64 requestId,
             const Sailfish::Secrets::InteractionParameters::PromptText &promptText) Q_DECL_OVERRIDE;
 
+    void cancelAuthentication(
+            uint callerPid,
+            qint64 requestId) Q_DECL_OVERRIDE;
+
     Result beginUserInputInteraction(
             uint callerPid,
             qint64 requestId,
             const InteractionParameters &interactionParameters,
             const QString &interactionServiceAddress) Q_DECL_OVERRIDE;
+
+    void cancelUserInputInteraction(
+            uint callerPid,
+            qint64 requestId) Q_DECL_OVERRIDE;
 
     void addConnection(const QDBusConnection &connection);
     void removeConnection(const QString &name);
@@ -90,6 +99,7 @@ private:
     QScopedPointer<Agent> m_sessionAgent;
     QScopedPointer<QDBusServer> m_server;
     QHash<QString, PolkitResponse *> m_polkitResponses;
+    QHash<QPair<uint, quint64>, QTimer *> m_nemoTimers;
 
     inline void destroyAgent(Agent *agent);
     void startDeviceLockAuthentication(


### PR DESCRIPTION
Closes #157 

Add listener in daemon on client DBus disconnect signal. Then notify the plugins to abort user input or authentication. Add ad hoc interface to plugins to handle cancellation.