### PR TITLE
[sailfish-secrets] Return an error to client on DBus connection error. Fix Github#155

### DIFF
--- a/lib/Crypto/cipherrequest.cpp
+++ b/lib/Crypto/cipherrequest.cpp
@@ -730,15 +730,20 @@ void CipherRequest::startRequest()
                             needsStEmit = true;
                             this->d_ptr->m_status = Request::Finished;
                         }
-                        this->d_ptr->m_result = reply.argumentAt<0>();
-                        if (this->d_ptr->m_result.code() == Result::Succeeded) {
-                            this->d_ptr->m_cipherSessionToken = 0;
-                        }
-                        this->d_ptr->m_generatedData = reply.argumentAt<1>();
                         bool needsVfEmit = false;
-                        if (this->d_ptr->m_verificationStatus != reply.argumentAt<2>()) {
-                            needsVfEmit = true;
-                            this->d_ptr->m_verificationStatus = reply.argumentAt<2>();
+                        if (reply.isError()) {
+                            this->d_ptr->m_result = Result(Result::DaemonError,
+                                                           reply.error().message());
+                        } else {
+                            this->d_ptr->m_result = reply.argumentAt<0>();
+                            if (this->d_ptr->m_result.code() == Result::Succeeded) {
+                                this->d_ptr->m_cipherSessionToken = 0;
+                            }
+                            this->d_ptr->m_generatedData = reply.argumentAt<1>();
+                            if (this->d_ptr->m_verificationStatus != reply.argumentAt<2>()) {
+                                needsVfEmit = true;
+                                this->d_ptr->m_verificationStatus = reply.argumentAt<2>();
+                            }
                         }
                         watcher->deleteLater();
                         if (needsStEmit) {

--- a/lib/Crypto/decryptrequest.cpp
+++ b/lib/Crypto/decryptrequest.cpp
@@ -377,9 +377,14 @@ void DecryptRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QByteArray, CryptoManager::VerificationStatus> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_plaintext = reply.argumentAt<1>();
-                this->d_ptr->m_verificationStatus = reply.argumentAt<2>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_plaintext = reply.argumentAt<1>();
+                    this->d_ptr->m_verificationStatus = reply.argumentAt<2>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/deletestoredkeyrequest.cpp
+++ b/lib/Crypto/deletestoredkeyrequest.cpp
@@ -149,7 +149,12 @@ void DeleteStoredKeyRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/encryptrequest.cpp
+++ b/lib/Crypto/encryptrequest.cpp
@@ -350,9 +350,14 @@ void EncryptRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QByteArray, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_ciphertext = reply.argumentAt<1>();
-                this->d_ptr->m_authenticationTag = reply.argumentAt<2>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_ciphertext = reply.argumentAt<1>();
+                    this->d_ptr->m_authenticationTag = reply.argumentAt<2>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/generateinitializationvectorrequest.cpp
+++ b/lib/Crypto/generateinitializationvectorrequest.cpp
@@ -236,8 +236,13 @@ void GenerateInitializationVectorRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_generatedIv = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_generatedIv = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/generatekeyrequest.cpp
+++ b/lib/Crypto/generatekeyrequest.cpp
@@ -254,8 +254,13 @@ void GenerateKeyRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, Key> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_generatedKey = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_generatedKey = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/generaterandomdatarequest.cpp
+++ b/lib/Crypto/generaterandomdatarequest.cpp
@@ -249,8 +249,13 @@ void GenerateRandomDataRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_generatedData = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_generatedData = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/generatestoredkeyrequest.cpp
+++ b/lib/Crypto/generatestoredkeyrequest.cpp
@@ -399,8 +399,13 @@ void GenerateStoredKeyRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, Key> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_generatedKeyReference = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_generatedKeyReference = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/lockcoderequest.cpp
+++ b/lib/Crypto/lockcoderequest.cpp
@@ -349,7 +349,12 @@ void LockCodeRequest::startRequest()
                     QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                     QDBusPendingReply<Result> reply = *watcher;
                     this->d_ptr->m_status = Request::Finished;
-                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    if (reply.isError()) {
+                        this->d_ptr->m_result = Result(Result::DaemonError,
+                                                       reply.error().message());
+                    } else {
+                        this->d_ptr->m_result = reply.argumentAt<0>();
+                    }
                     watcher->deleteLater();
                     emit this->statusChanged();
                     emit this->resultChanged();

--- a/lib/Crypto/plugininforequest.cpp
+++ b/lib/Crypto/plugininforequest.cpp
@@ -154,9 +154,14 @@ void PluginInfoRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QVector<PluginInfo>, QVector<PluginInfo> > reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_cryptoPlugins = reply.argumentAt<1>();
-                this->d_ptr->m_storagePlugins = reply.argumentAt<2>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_cryptoPlugins = reply.argumentAt<1>();
+                    this->d_ptr->m_storagePlugins = reply.argumentAt<2>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/seedrandomdatageneratorrequest.cpp
+++ b/lib/Crypto/seedrandomdatageneratorrequest.cpp
@@ -249,7 +249,12 @@ void SeedRandomDataGeneratorRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/signrequest.cpp
+++ b/lib/Crypto/signrequest.cpp
@@ -278,8 +278,13 @@ void SignRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_signature = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_signature = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/storedkeyidentifiersrequest.cpp
+++ b/lib/Crypto/storedkeyidentifiersrequest.cpp
@@ -199,8 +199,13 @@ void StoredKeyIdentifiersRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QVector<Key::Identifier> > reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_identifiers = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_identifiers = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/storedkeyrequest.cpp
+++ b/lib/Crypto/storedkeyrequest.cpp
@@ -204,8 +204,13 @@ void StoredKeyRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, Key> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_storedKey = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_storedKey = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Crypto/verifyrequest.cpp
+++ b/lib/Crypto/verifyrequest.cpp
@@ -318,8 +318,13 @@ void VerifyRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, Sailfish::Crypto::CryptoManager::VerificationStatus> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_verificationStatus = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_verificationStatus = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Secrets/collectionnamesrequest.cpp
+++ b/lib/Secrets/collectionnamesrequest.cpp
@@ -170,8 +170,13 @@ void CollectionNamesRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QMap<QString, bool> > reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_collectionNames = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_collectionNames = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Secrets/createcollectionrequest.cpp
+++ b/lib/Secrets/createcollectionrequest.cpp
@@ -400,7 +400,12 @@ void CreateCollectionRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Secrets/deletecollectionrequest.cpp
+++ b/lib/Secrets/deletecollectionrequest.cpp
@@ -210,7 +210,12 @@ void DeleteCollectionRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Secrets/deletesecretrequest.cpp
+++ b/lib/Secrets/deletesecretrequest.cpp
@@ -170,7 +170,12 @@ void DeleteSecretRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Secrets/findsecretsrequest.cpp
+++ b/lib/Secrets/findsecretsrequest.cpp
@@ -318,8 +318,13 @@ void FindSecretsRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QVector<Secret::Identifier> > reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_identifiers = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_identifiers = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Secrets/healthcheckrequest.cpp
+++ b/lib/Secrets/healthcheckrequest.cpp
@@ -174,9 +174,14 @@ void HealthCheckRequest::startRequest()
                                   HealthCheckRequest::Health,
                                   HealthCheckRequest::Health> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_saltDataHealth = reply.argumentAt<1>();
-                this->d_ptr->m_masterlockHealth = reply.argumentAt<2>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_saltDataHealth = reply.argumentAt<1>();
+                    this->d_ptr->m_masterlockHealth = reply.argumentAt<2>();
+                }
                 watcher->deleteLater();
                 emit this->saltDataHealthChanged();
                 emit this->masterlockHealthChanged();

--- a/lib/Secrets/interactionrequest.cpp
+++ b/lib/Secrets/interactionrequest.cpp
@@ -173,8 +173,13 @@ void InteractionRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_userInput = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::InteractionViewError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_userInput = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Secrets/lockcoderequest.cpp
+++ b/lib/Secrets/lockcoderequest.cpp
@@ -387,7 +387,12 @@ void LockCodeRequest::startRequest()
                     QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                     QDBusPendingReply<Result> reply = *watcher;
                     this->d_ptr->m_status = Request::Finished;
-                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    if (reply.isError()) {
+                        this->d_ptr->m_result = Result(Result::DaemonError,
+                                                       reply.error().message());
+                    } else {
+                        this->d_ptr->m_result = reply.argumentAt<0>();
+                    }
                     watcher->deleteLater();
                     emit this->statusChanged();
                     emit this->resultChanged();

--- a/lib/Secrets/plugininforequest.cpp
+++ b/lib/Secrets/plugininforequest.cpp
@@ -217,11 +217,16 @@ void PluginInfoRequest::startRequest()
                                   QVector<PluginInfo>,
                                   QVector<PluginInfo> > reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_storagePlugins = reply.argumentAt<1>();
-                this->d_ptr->m_encryptionPlugins = reply.argumentAt<2>();
-                this->d_ptr->m_encryptedStoragePlugins = reply.argumentAt<3>();
-                this->d_ptr->m_authenticationPlugins = reply.argumentAt<4>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_storagePlugins = reply.argumentAt<1>();
+                    this->d_ptr->m_encryptionPlugins = reply.argumentAt<2>();
+                    this->d_ptr->m_encryptedStoragePlugins = reply.argumentAt<3>();
+                    this->d_ptr->m_authenticationPlugins = reply.argumentAt<4>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Secrets/storedsecretrequest.cpp
+++ b/lib/Secrets/storedsecretrequest.cpp
@@ -206,8 +206,13 @@ void StoredSecretRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result, Secret> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
-                this->d_ptr->m_secret = reply.argumentAt<1>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                    this->d_ptr->m_secret = reply.argumentAt<1>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();

--- a/lib/Secrets/storesecretrequest.cpp
+++ b/lib/Secrets/storesecretrequest.cpp
@@ -539,7 +539,12 @@ void StoreSecretRequest::startRequest()
                 QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
-                this->d_ptr->m_result = reply.argumentAt<0>();
+                if (reply.isError()) {
+                    this->d_ptr->m_result = Result(Result::DaemonError,
+                                                   reply.error().message());
+                } else {
+                    this->d_ptr->m_result = reply.argumentAt<0>();
+                }
                 watcher->deleteLater();
                 emit this->statusChanged();
                 emit this->resultChanged();


### PR DESCRIPTION
Close #155.

The case when the DBus reply is an error was not treated previously. So, if the daemon is too slow to answer (or die?) and the CryptoManager or the SecretManager timeout, the result was successful and the result was empty.

Hopefully, I've catched all requests ;)

@chriadam or @Venemo any remarks ?