### PR TITLE
[sailfish-secrets] Add disclaimer to documentation overview pages. Contributes to JB#45782

### DIFF
--- a/lib/Crypto/doc/sailfish-crypto-overview.qdoc
+++ b/lib/Crypto/doc/sailfish-crypto-overview.qdoc
@@ -18,6 +18,13 @@ Sailfish OS Secrets and Crypto Framework.  Please see the Sailfish OS Secrets
 documentation for more in-depth documentation about the framework architecture,
 and broad overview of the features the framework provides.
 
+\note The Sailfish OS Secrets and Crypto Framework is still in active
+development and is subject to change.  Normal 3rd party API backward
+compatibility promises don't hold.
+Follow \l{http://together.jolla.com/}{Together Jolla} release notes and
+\l{https://lists.sailfishos.org/cgi-bin/mailman/listinfo/devel}
+{Sailfish OS Developers} mailing list to get notified of API changes.
+
 \section1 Using the Sailfish OS Crypto Library
 
 As described in the Sailfish OS Secrets and Crypto Framework overview

--- a/lib/Secrets/doc/sailfish-secrets-overview.qdoc
+++ b/lib/Secrets/doc/sailfish-secrets-overview.qdoc
@@ -19,6 +19,13 @@ Secrets and Crypto Framework documentation for more in-depth documentation
 about the framework architecture, and broad overview of the features the
 framework provides.
 
+\note The Sailfish OS Secrets and Crypto Framework is still in active
+development and is subject to change.  Normal 3rd party API backward
+compatibility promises don't hold.
+Follow \l{http://together.jolla.com/}{Together Jolla} release notes and
+\l{https://lists.sailfishos.org/cgi-bin/mailman/listinfo/devel}
+{Sailfish OS Developers} mailing list to get notified of API changes.
+
 \section1 Using the Sailfish OS Secrets Library
 
 As described in the Sailfish OS Secrets and Crypto Framework overview


### PR DESCRIPTION
The Sailfish OS Secrets and Crypto Framework is still under active
development, and as such no source or binary compatibility promises
are made at this point in time.