### PR TITLE
[sailfish-secrets] Register types with appropriate meta type names. Contributes to JB#45215

### DIFF
--- a/qml/Crypto/main.cpp
+++ b/qml/Crypto/main.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
+ * Copyright (C) 2018 - 2020 Jolla Ltd.
+ * Copyright (C) 2020 Open Mobile Platform LLC.
  * Contact: Chris Adams <chris.adams@jollamobile.com>
  * All rights reserved.
  * BSD 3-Clause License, see LICENSE.
@@ -17,16 +18,16 @@ void Sailfish::Crypto::Plugin::CryptoPlugin::initializeEngine(QQmlEngine *, cons
 
 void Sailfish::Crypto::Plugin::CryptoPlugin::registerTypes(const char *uri)
 {
-    qRegisterMetaType<Sailfish::Crypto::Result>("Result");
+    qRegisterMetaType<Sailfish::Crypto::Result>("Sailfish::Crypto::Result");
     QMetaType::registerComparators<Sailfish::Crypto::Result>();
-    qmlRegisterUncreatableType<Sailfish::Crypto::Result>(uri, 1, 0, "CryptoResult", QStringLiteral("Result objects cannot be constructed directly in QML"));
+    qmlRegisterUncreatableType<Sailfish::Crypto::Result>(uri, 1, 0, "Result", QStringLiteral("Result objects cannot be constructed directly in QML"));
 
-    qRegisterMetaType<Sailfish::Crypto::Key>("Key");
+    qRegisterMetaType<Sailfish::Crypto::Key>("Sailfish::Crypto::Key");
     QMetaType::registerComparators<Sailfish::Crypto::Key>();
     qmlRegisterUncreatableType<Sailfish::Crypto::Key>(uri, 1, 0, "Key", QStringLiteral("Key objects cannot be constructed directly in QML"));
 
-    qmlRegisterUncreatableType<Sailfish::Crypto::Request>(uri, 1, 0, "CryptoRequest", QStringLiteral("Request is an abstract class, can't construct in QML"));
-    qRegisterMetaType<Sailfish::Crypto::Request::Status>("CryptoRequestStatus");
+    qmlRegisterUncreatableType<Sailfish::Crypto::Request>(uri, 1, 0, "Request", QStringLiteral("Request is an abstract class, can't construct in QML"));
+    qRegisterMetaType<Sailfish::Crypto::Request::Status>("Sailfish::Crypto::Request::Status");
     qmlRegisterUncreatableType<Sailfish::Crypto::PluginInfo>(uri, 1, 0, "PluginInfo", QStringLiteral("PluginInfo objects cannot be constructed directly in QML"));
     qmlRegisterType<Sailfish::Crypto::Plugin::PluginInfoRequestWrapper>(uri, 1, 0, "PluginInfoRequest");
     qmlRegisterType<Sailfish::Crypto::SeedRandomDataGeneratorRequest>(uri, 1, 0, "SeedRandomDataGeneratorRequest");

--- a/qml/Crypto/plugintypes.h
+++ b/qml/Crypto/plugintypes.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
+ * Copyright (C) 2018 - 2020 Jolla Ltd.
+ * Copyright (C) 2020 Open Mobile Platform LLC.
  * Contact: Chris Adams <chris.adams@jollamobile.com>
  * All rights reserved.
  * BSD 3-Clause License, see LICENSE.
@@ -64,9 +65,9 @@ public:
     QString defaultCryptoStoragePluginName() const { return DefaultCryptoStoragePluginName; }
 
     // QML API - allow clients to construct "uncreatable" value types
-    Q_INVOKABLE Result constructResult() const;
-    Q_INVOKABLE Key constructKey() const;
-    Q_INVOKABLE Key constructKey(const QString &name,
+    Q_INVOKABLE Sailfish::Crypto::Result constructResult() const;
+    Q_INVOKABLE Sailfish::Crypto::Key constructKey() const;
+    Q_INVOKABLE Sailfish::Crypto::Key constructKey(const QString &name,
                                  const QString &collectionName,
                                  const QString &storagePluginName) const;
     Q_INVOKABLE Sailfish::Crypto::Key::Identifier

--- a/qml/Secrets/main.cpp
+++ b/qml/Secrets/main.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2017 Jolla Ltd.
+ * Copyright (C) 2017 - 2020 Jolla Ltd.
+ * Copyright (C) 2020 Open Mobile Platform LLC.
  * Contact: Chris Adams <chris.adams@jollamobile.com>
  * All rights reserved.
  * BSD 3-Clause License, see LICENSE.
@@ -18,30 +19,30 @@ void Sailfish::Secrets::Plugin::SecretsPlugin::initializeEngine(QQmlEngine *, co
 
 void Sailfish::Secrets::Plugin::SecretsPlugin::registerTypes(const char *uri)
 {
-    qRegisterMetaType<Sailfish::Secrets::InteractionParameters>("InteractionParameters");
-    qRegisterMetaType<Sailfish::Secrets::InteractionParameters::InputType>("InteractionParameters::InputType");
-    qRegisterMetaType<Sailfish::Secrets::InteractionParameters::EchoMode>("InteractionParameters::EchoMode");
-    qRegisterMetaType<Sailfish::Secrets::InteractionParameters::Operation>("InteractionParameters::Operation");
+    qRegisterMetaType<Sailfish::Secrets::InteractionParameters>("Sailfish::Secrets::InteractionParameters");
+    qRegisterMetaType<Sailfish::Secrets::InteractionParameters::InputType>("Sailfish::Secrets::InteractionParameters::InputType");
+    qRegisterMetaType<Sailfish::Secrets::InteractionParameters::EchoMode>("Sailfish::Secrets::InteractionParameters::EchoMode");
+    qRegisterMetaType<Sailfish::Secrets::InteractionParameters::Operation>("Sailfish::Secrets::InteractionParameters::Operation");
     QMetaType::registerComparators<Sailfish::Secrets::InteractionParameters>();
     qmlRegisterUncreatableType<Sailfish::Secrets::InteractionParameters>(uri, 1, 0, "InteractionParameters", QStringLiteral("InteractionParameters objects cannot be constructed directly in QML"));
     qmlRegisterUncreatableType<Sailfish::Secrets::InteractionParameters::PromptText>(uri, 1, 0, "PromptText", QStringLiteral("Can't construct PromptText in QML"));
 
-    qRegisterMetaType<Sailfish::Secrets::InteractionResponse>("InteractionResponse");
+    qRegisterMetaType<Sailfish::Secrets::InteractionResponse>("Sailfish::Secrets::InteractionResponse");
     QMetaType::registerComparators<Sailfish::Secrets::InteractionResponse>();
     qmlRegisterUncreatableType<Sailfish::Secrets::InteractionResponse>(uri, 1, 0, "InteractionResponse", QStringLiteral("InteractionResponse objects cannot be constructed directly in QML"));
 
-    qRegisterMetaType<Sailfish::Secrets::Result>("SecretsResult");
+    qRegisterMetaType<Sailfish::Secrets::Result>("Sailfish::Secrets::Result");
     QMetaType::registerComparators<Sailfish::Secrets::Result>();
-    qmlRegisterUncreatableType<Sailfish::Secrets::Result>(uri, 1, 0, "SecretsResult", QStringLiteral("Result objects cannot be constructed directly in QML"));
-    qRegisterMetaType<Sailfish::Secrets::Result::ResultCode>("SecretsResultCode");
-    qRegisterMetaType<Sailfish::Secrets::Result::ErrorCode>("SecretsErrorCode");
+    qmlRegisterUncreatableType<Sailfish::Secrets::Result>(uri, 1, 0, "Result", QStringLiteral("Result objects cannot be constructed directly in QML"));
+    qRegisterMetaType<Sailfish::Secrets::Result::ResultCode>("Sailfish::Secrets::Result::ResultCode");
+    qRegisterMetaType<Sailfish::Secrets::Result::ErrorCode>("Sailfish::Secrets::Result::ErrorCode");
 
-    qRegisterMetaType<Sailfish::Secrets::Secret>("Secret");
+    qRegisterMetaType<Sailfish::Secrets::Secret>("Sailfish::Secrets::Secret");
     QMetaType::registerComparators<Sailfish::Secrets::Secret>();
     qmlRegisterUncreatableType<Sailfish::Secrets::Secret>(uri, 1, 0, "Secret", QStringLiteral("Secret objects cannot be constructed directly in QML"));
 
-    qmlRegisterUncreatableType<Sailfish::Secrets::Request>(uri, 1, 0, "SecretsRequest", QStringLiteral("Request is an abstract class, can't construct in QML"));
-    qRegisterMetaType<Sailfish::Secrets::Request::Status>("SecretsRequestStatus");
+    qmlRegisterUncreatableType<Sailfish::Secrets::Request>(uri, 1, 0, "Request", QStringLiteral("Request is an abstract class, can't construct in QML"));
+    qRegisterMetaType<Sailfish::Secrets::Request::Status>("Sailfish::Secrets::Request::Status");
     qmlRegisterUncreatableType<Sailfish::Secrets::PluginInfo>(uri, 1, 0, "PluginInfo", QStringLiteral("PluginInfo objects cannot be constructed directly in QML"));
     qmlRegisterType<Sailfish::Secrets::Plugin::PluginInfoRequestWrapper>(uri, 1, 0, "PluginInfoRequest");
     qmlRegisterType<Sailfish::Secrets::HealthCheckRequest>(uri, 1, 0, "HealthCheckRequest");

--- a/qml/Secrets/plugintypes.h
+++ b/qml/Secrets/plugintypes.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
+ * Copyright (C) 2018 - 2020 Jolla Ltd.
+ * Copyright (C) 2020 Open Mobile Platform LLC.
  * Contact: Chris Adams <chris.adams@jollamobile.com>
  * All rights reserved.
  * BSD 3-Clause License, see LICENSE.
@@ -67,10 +68,10 @@ public:
     QString defaultEncryptedStoragePluginName() const;
 
     // QML API - allow clients to construct "uncreatable" value types
-    Q_INVOKABLE Result constructResult() const;
-    Q_INVOKABLE Secret constructSecret() const;
-    Q_INVOKABLE InteractionParameters constructInteractionParameters() const;
-    Q_INVOKABLE InteractionResponse constructInteractionResponse() const;
+    Q_INVOKABLE Sailfish::Secrets::Result constructResult() const;
+    Q_INVOKABLE Sailfish::Secrets::Secret constructSecret() const;
+    Q_INVOKABLE Sailfish::Secrets::InteractionParameters constructInteractionParameters() const;
+    Q_INVOKABLE Sailfish::Secrets::InteractionResponse constructInteractionResponse() const;
     Q_INVOKABLE Sailfish::Secrets::Secret::FilterData constructFilterData(const QVariantMap &v) const;
 };
 


### PR DESCRIPTION
This commit undoes some of the type registration naming done in
2d1f6f80 and further improves the namespacing and type registration
to ensure that clients can use the required types unambiguously.

This change is source incompatible for clients using the types from
QML, but sailfish-secrets is not allowed for harbour currently.