### PR TITLE
[sailfish-secrets] Fix libgpg-error pkgconfig symbol name

### DIFF
--- a/plugins/gnupgplugin/pinentry/pinentry.pro
+++ b/plugins/gnupgplugin/pinentry/pinentry.pro
@@ -2,7 +2,7 @@ TEMPLATE=app
 TARGET=pinentry
 QT-=gui
 CONFIG += link_pkgconfig
-PKGCONFIG += libgpg-error mlite5
+PKGCONFIG += gpg-error mlite5
 
 LIBS += -lassuan
 include($$PWD/../../../lib/libsailfishsecrets.pri)

--- a/rpm/sailfish-secrets.spec
+++ b/rpm/sailfish-secrets.spec
@@ -251,7 +251,7 @@ Requires:   libsailfishcryptopluginapi = %{version}-%{release}
 Summary:    Sailfish OS crypto daemon plugins for GnuPG
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(libcrypto)
-BuildRequires:  pkgconfig(libgpg-error)
+BuildRequires:  pkgconfig(gpg-error)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  gpgme-devel
 BuildRequires:  libassuan-devel


### PR DESCRIPTION
We used the wrong pkgconfig name for libgpg-error.
This changes fixes it after aligned with upstream.