### PR TITLE
[sailfish-secrets] Put the P2P DBus socket in a sub-directory of /run. Contributes to JB#56300

### DIFF
--- a/daemon/controller.cpp
+++ b/daemon/controller.cpp
@@ -29,13 +29,13 @@ namespace {
             return QString();
         }
 
-        QDir dir(path);
-        if (!dir.mkpath(dir.absolutePath())) {
+        QDir dir(QDir(path).absoluteFilePath(QString::fromUtf8("sailfishsecretsd")));
+        if (!dir.mkpath(dir.path())) {
             qCWarning(lcSailfishSecretsDaemonDBus) << "Could not create socket file directory";
             return QString();
         }
 
-        const QString socketFile = QString::fromUtf8("%1/%2").arg(dir.absolutePath(), QLatin1String("sailfishsecretsd-p2pSocket"));
+        const QString socketFile = dir.absoluteFilePath(QLatin1String("p2pSocket"));
         const QString address = QString::fromUtf8("unix:path=%1").arg(socketFile);
 
         return address;

--- a/lib/Crypto/cryptodaemonconnection.cpp
+++ b/lib/Crypto/cryptodaemonconnection.cpp
@@ -41,7 +41,7 @@ bool Sailfish::Crypto::CryptoDaemonConnectionPrivate::connect()
     }
 
     // Step one: query the crypto daemon's "discovery" SessionBusObject for the PeerToPeer address.
-    QString address(QStringLiteral("unix:path=") + QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + QStringLiteral("/sailfishsecretsd-p2pSocket"));
+    QString address(QStringLiteral("unix:path=") + QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + QStringLiteral("/sailfishsecretsd/p2pSocket"));
     QDBusInterface iface("org.sailfishos.crypto.daemon.discovery",
                          "/Sailfish/Crypto/Discovery",
                          "org.sailfishos.crypto.daemon.discovery",

--- a/lib/Secrets/secretsdaemonconnection.cpp
+++ b/lib/Secrets/secretsdaemonconnection.cpp
@@ -42,7 +42,7 @@ bool Sailfish::Secrets::SecretsDaemonConnectionPrivate::connect()
     }
 
     // Step one: query the secret daemon's "discovery" SessionBusObject for the PeerToPeer address.
-    QString address(QStringLiteral("unix:path=") + QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + QStringLiteral("/sailfishsecretsd-p2pSocket"));
+    QString address(QStringLiteral("unix:path=") + QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation) + QStringLiteral("/sailfishsecretsd/p2pSocket"));
     QDBusInterface iface("org.sailfishos.secrets.daemon.discovery",
                          "/Sailfish/Secrets/Discovery",
                          "org.sailfishos.secrets.daemon.discovery",

--- a/plugins/passwordagentauthplugin/passwordagentplugin.cpp
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.cpp
@@ -418,7 +418,7 @@ PasswordAgentPlugin::PasswordAgentPlugin(QObject *parent)
 
 void PasswordAgentPlugin::initialize()
 {
-    m_server.reset(new QDBusServer(QStringLiteral("unix:path=%1/sailfishsecretsd-p2pSocket-agent").arg(
+    m_server.reset(new QDBusServer(QStringLiteral("unix:path=%1/sailfishsecretsd/p2pSocket-agent").arg(
                 QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation))));
 
     qDBusRegisterMetaType<PolkitSubject>();


### PR DESCRIPTION
The DBus dialog is currently happening on `/run/user/100000/sailfishsecretsd-p2pSocket`. For instance when you need a confirmation to access the secret storage, or you require a password.

But for jailed application, /run is no readable. So like QMF, this MR is moving the socket to a subdirectory to allow to whitelist it.

@chriadam do you agree ?