### PR TITLE
[sailfish-secrets] Correct p2p socket name for the password agent. Contributes to JB#56300

### DIFF
--- a/plugins/passwordagentauthplugin/passwordagentplugin.cpp
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.cpp
@@ -418,7 +418,7 @@ PasswordAgentPlugin::PasswordAgentPlugin(QObject *parent)
 
 void PasswordAgentPlugin::initialize()
 {
-    m_server.reset(new QDBusServer(QStringLiteral("unix:path=%1/sailfishsecretsd/p2pSocket-agent").arg(
+    m_server.reset(new QDBusServer(QStringLiteral("unix:path=%1/sailfishsecretsd/p2pSocket").arg(
                 QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation))));
 
     qDBusRegisterMetaType<PolkitSubject>();


### PR DESCRIPTION
…ntributes to JB#56300

@chriadam , I'm confused how I could have forgotten to commit the change in socket name in the password agent too.

At the moment, `systemctl --user status lipstick-security-ui.service` is green, but actually, if you run it by hand, you notice that it warns with:
```
[W] unknown:0 - Connection to org.lipstick.securityui failed.  Failed to connect to socket /run/user/100000/sailfishsecretsd/p2pSocket-agent: Aucun fichier ou dossier de ce type
```

As a consequence, there is no system prompt for password or anything related to password entry. Any attempt is failing with:
```
[D] unknown:0 - Starting passphrase request
[D] unknown:0 - -> return code Sailfish::Secrets::Result::ResultCode(Failed)
[W] unknown:0 - "No password agent is registered"
```

I was sure I did the change, but it seems that I forgot to commit it, or lost it in a rebase. I'm sorry for the mess.