### PR TITLE
Revert "[sailfish-secrets] Correct p2p socket name for the password a…

### DIFF
--- a/plugins/passwordagentauthplugin/passwordagentplugin.cpp
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.cpp
@@ -418,7 +418,7 @@ PasswordAgentPlugin::PasswordAgentPlugin(QObject *parent)
 
 void PasswordAgentPlugin::initialize()
 {
-    m_server.reset(new QDBusServer(QStringLiteral("unix:path=%1/sailfishsecretsd/p2pSocket").arg(
+    m_server.reset(new QDBusServer(QStringLiteral("unix:path=%1/sailfishsecretsd/p2pSocket-agent").arg(
                 QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation))));
 
     qDBusRegisterMetaType<PolkitSubject>();


### PR DESCRIPTION
…gent. Contributes to JB#56300"

This reverts commit 9e7cb2a22882f06df260adb90d8d651f340f5259.
The p2pSocket-agent is used by the password plugin to communicate
with lipstick. The p2pSocket is the daemon socket only.

@chriadam , I'm so sorry for such confusion. I don't know what went wrong when I tested the 4.4.0.1 version and get an error with the lipstick-secuirty-ui making the prompt window not appearing. I've recompiled the master branch reverting the erroneous commit I made and pushed to you. And it's now working properly with 4.4.0.12...