### PR TITLE
[sailfish-secrets] Create the socket directory in the plugin also. Contributes to JB#56300

### DIFF
--- a/plugins/passwordagentauthplugin/passwordagentplugin.cpp
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.cpp
@@ -18,6 +18,7 @@
 #include <QtDBus/QDBusReply>
 
 #include <QtCore/QFile>
+#include <QtCore/QDir>
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QTimer>
 
@@ -418,8 +419,12 @@ PasswordAgentPlugin::PasswordAgentPlugin(QObject *parent)
 
 void PasswordAgentPlugin::initialize()
 {
-    m_server.reset(new QDBusServer(QStringLiteral("unix:path=%1/sailfishsecretsd/p2pSocket-agent").arg(
-                QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation))));
+    QDir dir(QStringLiteral("%1/sailfishsecretsd").arg(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation)));
+    if (!dir.mkpath(dir.path())) {
+        qCWarning(lcPasswordAgent) << "Could not create socket file directory";
+        return;
+    }
+    m_server.reset(new QDBusServer(QStringLiteral("unix:path=%1/p2pSocket-agent").arg(dir.path())));
 
     qDBusRegisterMetaType<PolkitSubject>();
     qDBusRegisterMetaType<PolkitAuthorizationResult>();


### PR DESCRIPTION
Plugin are initialised before the daemon is creating its own
socket and ensuring the exitence of the directory under
/run/user/xxx/sailfishsecretsd. So create also that directory
in the password agent plugin which is using this directory.

@chriadam : this is the true root of the problem, I guess. By moving the socket under a subdirectory, I created an issue with this plugin that was then unable to start its QDBusServer because the path was not existing yet (it's created later on by the daemon). It also explains why when testing it was always working : because then the directory was existing and everything was working after a daemon restart. While it was not working directly after a boot of the device.