### PR TITLE
[sailfish-secrets] Indicate that SQLCipher db version is 3.

### DIFF
--- a/daemon/SecretsImpl/metadatadb.cpp
+++ b/daemon/SecretsImpl/metadatadb.cpp
@@ -18,6 +18,9 @@ static const char *setupEncryptionKey =
 static const char *setupReEncryptionKey =
         "\n PRAGMA rekey = \"x\'%1\'\";";
 
+static const char *setupCompatibilityTo3 =
+        "\n PRAGMA cipher_compatibility = 3;";
+
 static const char *setupEnforceForeignKeys =
         "\n PRAGMA foreign_keys = ON;";
 
@@ -108,6 +111,7 @@ bool Daemon::ApiImpl::MetadataDatabase::openDatabase(const QByteArray &hexKey)
     const char *setupKeyStatementData = setupKeyStatement.constData();
     const char *setupStatements[] = {
         setupKeyStatementData,
+        setupCompatibilityTo3,
         setupEnforceForeignKeys,
         setupEncoding,
         setupTempStore,


### PR DESCRIPTION
@chriadam and @pvuorela this is a minimal change to allow to use SQLCipher 4 with our database without handling a migration.

This is not optimal, but at least one can update SQLCipher without too much fuss. It's still possible to later migrate the databases to version 4 in another PR. See sailfishos/sqlcipher#4