### PR TITLE
[sailfish-secrets] Properly detect the key ID in case of a subkey.

### DIFF
--- a/plugins/gnupgplugin/pinentry/qassuanserver.cpp
+++ b/plugins/gnupgplugin/pinentry/qassuanserver.cpp
@@ -77,15 +77,17 @@ gpg_error_t _assuan_cmd_setdesc(assuan_context_t ctx, char *line)
 {
     qCDebug(lcSailfishPinentry) << __func__ << line;
     QAssuanServer *self = static_cast<QAssuanServer*>(assuan_get_pointer(ctx));
-    self->prompt.setMessage(QByteArray::fromPercentEncoding(line));
+    self->prompt.setMessage(QByteArray::fromPercentEncoding(line).simplified());
 
     // Ugly hack here due to GnuPG being stuck in 2.0.4
-    // and not having SETKEYINFO command yet. Description may contain "ID xxxxx".
+    // and not having SETKEYINFO command yet. Description looks like:
+    // "user: "John Dow <john.dow@example.org>""
+    // "2048-bit RSA key, ID A099539B, created 2018-04-13 (main key ID 41123AA4)"
     {
         const QString &str(self->prompt.message());
-        int id = str.lastIndexOf("ID ");
+        int id = str.lastIndexOf(", ID ");
         if (id > 0) {
-            self->cacheId.setName(str.mid(id + 3, 8));
+            self->cacheId.setName(str.mid(id + 5, 8));
             qCDebug(lcSailfishPinentry) << "cacheID" << self->cacheId.name();
         }
     }

--- a/plugins/gnupgplugin/pinentry/qassuanserver.cpp
+++ b/plugins/gnupgplugin/pinentry/qassuanserver.cpp
@@ -373,6 +373,11 @@ Sailfish::Secrets::Result QAssuanServer::requestPassphrase(QByteArray *passphras
             qCDebug(lcSailfishPinentry) << "found cached secret";
             *passphrase = request.secret().data();
             return request.result();
+        } else if (request.result().code() == Sailfish::Secrets::Result::Failed
+                   && request.result().errorCode() == Sailfish::Secrets::Result::InteractionViewUserCanceledError) {
+            // Later on, in case of a valid key, don't ask again the
+            // user to grant access to key caching.
+            useCache = false;
         }
     }
 


### PR DESCRIPTION
Also don't bother the user with a second demand to access the cache passphrase if the first attempt was dismissed.

@pvuorela , if you have time to give a look. Thank you.