### PR TITLE
[sailfish-secrets] Declare proper copy constructors for KeyPairGenerationParameters. JB#55609

### DIFF
--- a/lib/Crypto/keypairgenerationparameters.cpp
+++ b/lib/Crypto/keypairgenerationparameters.cpp
@@ -702,7 +702,7 @@ DhKeyPairGenerationParameters::DhKeyPairGenerationParameters()
  */
 DhKeyPairGenerationParameters::DhKeyPairGenerationParameters(
         const KeyPairGenerationParameters &other)
-    :KeyPairGenerationParameters(other)
+    : KeyPairGenerationParameters(other)
 {
 }
 

--- a/lib/Crypto/keypairgenerationparameters.h
+++ b/lib/Crypto/keypairgenerationparameters.h
@@ -71,6 +71,7 @@ class SAILFISH_CRYPTO_API EcKeyPairGenerationParameters : public KeyPairGenerati
 public:
     EcKeyPairGenerationParameters();
     EcKeyPairGenerationParameters(const KeyPairGenerationParameters &other);
+    EcKeyPairGenerationParameters(const EcKeyPairGenerationParameters &other) = default;
     ~EcKeyPairGenerationParameters();
 
     EcKeyPairGenerationParameters& operator=(const EcKeyPairGenerationParameters &other);
@@ -89,6 +90,7 @@ class SAILFISH_CRYPTO_API RsaKeyPairGenerationParameters : public KeyPairGenerat
 public:
     RsaKeyPairGenerationParameters();
     RsaKeyPairGenerationParameters(const KeyPairGenerationParameters &other);
+    RsaKeyPairGenerationParameters(const RsaKeyPairGenerationParameters &other) = default;
     ~RsaKeyPairGenerationParameters();
 
     RsaKeyPairGenerationParameters& operator=(const RsaKeyPairGenerationParameters &other);
@@ -116,6 +118,7 @@ class SAILFISH_CRYPTO_API DsaKeyPairGenerationParameters : public KeyPairGenerat
 public:
     DsaKeyPairGenerationParameters();
     DsaKeyPairGenerationParameters(const KeyPairGenerationParameters &other);
+    DsaKeyPairGenerationParameters(const DsaKeyPairGenerationParameters &other) = default;
     ~DsaKeyPairGenerationParameters();
 
     DsaKeyPairGenerationParameters& operator=(const DsaKeyPairGenerationParameters &other);
@@ -154,6 +157,7 @@ class SAILFISH_CRYPTO_API DhKeyPairGenerationParameters : public KeyPairGenerati
 public:
     DhKeyPairGenerationParameters();
     DhKeyPairGenerationParameters(const KeyPairGenerationParameters &other);
+    DhKeyPairGenerationParameters(const DhKeyPairGenerationParameters &other) = default;
     ~DhKeyPairGenerationParameters();
 
     DhKeyPairGenerationParameters& operator=(const DhKeyPairGenerationParameters &other);


### PR DESCRIPTION
Newer compilers warn about implicitly declared copy-contstructors. Here there were almost proper explicitly defined ones but they take the parent class parameter. Such a code is also needed as KeyPairGenerationParameters::isValid() tries to create copies with parent class reference.