### PR TITLE
Migrate away from QScopedPointer::take

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -1,10 +1,5 @@
-unix|macx {
-    QMAKE_CXXFLAGS += -Werror
-}
-
 QT -= gui
 CONFIG += rtti_off
-CONFIG += c++11
 
 # Ignore errors about errors RSA_new and friends for now.
 # Has to be ported to not directly use openssl data types but their wrapper API's

--- a/examples/plugins/examplecryptoplugin/examplecryptoplugin.pro
+++ b/examples/plugins/examplecryptoplugin/examplecryptoplugin.pro
@@ -1,5 +1,5 @@
 TEMPLATE = lib
-CONFIG += qt plugin hide_symbols link_pkgconfig c++11
+CONFIG += qt plugin hide_symbols link_pkgconfig
 TARGET = sailfishcrypto-examplecryptoplugin
 TARGET = $$qtLibraryTarget($$TARGET)
 PKGCONFIG += sailfishcryptopluginapi

--- a/examples/plugins/examplecryptostorageplugin/examplecryptostorageplugin.pro
+++ b/examples/plugins/examplecryptostorageplugin/examplecryptostorageplugin.pro
@@ -1,5 +1,5 @@
 TEMPLATE = lib
-CONFIG += qt plugin hide_symbols link_pkgconfig c++11
+CONFIG += qt plugin hide_symbols link_pkgconfig
 TARGET = sailfishsecrets-examplecryptostorageplugin
 TARGET = $$qtLibraryTarget($$TARGET)
 PKGCONFIG += sailfishcryptopluginapi

--- a/lib/Crypto/calculatedigestrequest.cpp
+++ b/lib/Crypto/calculatedigestrequest.cpp
@@ -322,9 +322,9 @@ void CalculateDigestRequest::startRequest()
             emit digestChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 this->d_ptr->m_result = reply.argumentAt<0>();
@@ -341,7 +341,7 @@ void CalculateDigestRequest::startRequest()
 void CalculateDigestRequest::waitForFinished()
 {
     Q_D(CalculateDigestRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/calculatedigestrequest_p.h
+++ b/lib/Crypto/calculatedigestrequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -37,7 +38,7 @@ public:
     QString m_cryptoPluginName;
     QByteArray m_digest;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/decryptrequest.cpp
+++ b/lib/Crypto/decryptrequest.cpp
@@ -468,9 +468,9 @@ void DecryptRequest::startRequest()
             emit verificationStatusChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QByteArray, CryptoManager::VerificationStatus> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -494,7 +494,7 @@ void DecryptRequest::startRequest()
 void DecryptRequest::waitForFinished()
 {
     Q_D(DecryptRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/decryptrequest_p.h
+++ b/lib/Crypto/decryptrequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -42,7 +43,7 @@ public:
     QByteArray m_plaintext;
     Sailfish::Crypto::CryptoManager::VerificationStatus m_verificationStatus;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/deletestoredkeyrequest.cpp
+++ b/lib/Crypto/deletestoredkeyrequest.cpp
@@ -159,9 +159,9 @@ void DeleteStoredKeyRequest::startRequest()
             emit resultChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -181,7 +181,7 @@ void DeleteStoredKeyRequest::startRequest()
 void DeleteStoredKeyRequest::waitForFinished()
 {
     Q_D(DeleteStoredKeyRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/deletestoredkeyrequest_p.h
+++ b/lib/Crypto/deletestoredkeyrequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -33,7 +34,7 @@ public:
     QVariantMap m_customParameters;
     Sailfish::Crypto::Key::Identifier m_identifier;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/encryptrequest.cpp
+++ b/lib/Crypto/encryptrequest.cpp
@@ -428,9 +428,9 @@ void EncryptRequest::startRequest()
             emit authenticationTagChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QByteArray, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -454,7 +454,7 @@ void EncryptRequest::startRequest()
 void EncryptRequest::waitForFinished()
 {
     Q_D(EncryptRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/encryptrequest_p.h
+++ b/lib/Crypto/encryptrequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -41,7 +42,7 @@ public:
     QByteArray m_authenticationData;
     QByteArray m_authenticationTag;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/generateinitializationvectorrequest.cpp
+++ b/lib/Crypto/generateinitializationvectorrequest.cpp
@@ -233,9 +233,9 @@ void GenerateInitializationVectorRequest::startRequest()
             emit generatedInitializationVectorChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -257,7 +257,7 @@ void GenerateInitializationVectorRequest::startRequest()
 void GenerateInitializationVectorRequest::waitForFinished()
 {
     Q_D(GenerateInitializationVectorRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/generateinitializationvectorrequest_p.h
+++ b/lib/Crypto/generateinitializationvectorrequest_p.h
@@ -13,11 +13,12 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 #include <QtCore/QQueue>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -31,7 +32,7 @@ public:
     explicit GenerateInitializationVectorRequestPrivate();
 
     QPointer<Sailfish::Crypto::CryptoManager> m_manager;
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
 
     QVariantMap m_customParameters;
     QByteArray m_generatedIv;

--- a/lib/Crypto/generatekeyrequest.cpp
+++ b/lib/Crypto/generatekeyrequest.cpp
@@ -286,9 +286,9 @@ void GenerateKeyRequest::startRequest()
             emit generatedKeyChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, Key> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -310,7 +310,7 @@ void GenerateKeyRequest::startRequest()
 void GenerateKeyRequest::waitForFinished()
 {
     Q_D(GenerateKeyRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/generatekeyrequest_p.h
+++ b/lib/Crypto/generatekeyrequest_p.h
@@ -15,10 +15,11 @@
 #include "Crypto/keyderivationparameters.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -39,7 +40,7 @@ public:
     Sailfish::Crypto::Key m_keyTemplate;
     Sailfish::Crypto::Key m_generatedKey;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/generaterandomdatarequest.cpp
+++ b/lib/Crypto/generaterandomdatarequest.cpp
@@ -278,9 +278,9 @@ void GenerateRandomDataRequest::startRequest()
             emit generatedDataChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -302,7 +302,7 @@ void GenerateRandomDataRequest::startRequest()
 void GenerateRandomDataRequest::waitForFinished()
 {
     Q_D(GenerateRandomDataRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/generaterandomdatarequest_p.h
+++ b/lib/Crypto/generaterandomdatarequest_p.h
@@ -13,11 +13,12 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 #include <QtCore/QByteArray>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -37,7 +38,7 @@ public:
     quint64 m_numberBytes;
     QByteArray m_generatedData;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/generatestoredkeyrequest.cpp
+++ b/lib/Crypto/generatestoredkeyrequest.cpp
@@ -436,9 +436,9 @@ void GenerateStoredKeyRequest::startRequest()
             emit generatedKeyReferenceChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, Key> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -460,7 +460,7 @@ void GenerateStoredKeyRequest::startRequest()
 void GenerateStoredKeyRequest::waitForFinished()
 {
     Q_D(GenerateStoredKeyRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/generatestoredkeyrequest_p.h
+++ b/lib/Crypto/generatestoredkeyrequest_p.h
@@ -16,10 +16,11 @@
 #include "Crypto/keyderivationparameters.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -41,7 +42,7 @@ public:
     Sailfish::Crypto::Key m_keyTemplate;
     Sailfish::Crypto::Key m_generatedKeyReference;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/importkeyrequest.cpp
+++ b/lib/Crypto/importkeyrequest.cpp
@@ -246,9 +246,9 @@ void ImportKeyRequest::startRequest()
             emit importedKeyChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, Key> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -271,7 +271,7 @@ void ImportKeyRequest::startRequest()
 void ImportKeyRequest::waitForFinished()
 {
     Q_D(ImportKeyRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/importkeyrequest_p.h
+++ b/lib/Crypto/importkeyrequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -36,7 +37,7 @@ public:
     QByteArray m_data;
     Sailfish::Crypto::Key m_importedKey;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/importstoredkeyrequest.cpp
+++ b/lib/Crypto/importstoredkeyrequest.cpp
@@ -336,9 +336,9 @@ void ImportStoredKeyRequest::startRequest()
             emit importedKeyReferenceChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, Key> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -361,7 +361,7 @@ void ImportStoredKeyRequest::startRequest()
 void ImportStoredKeyRequest::waitForFinished()
 {
     Q_D(ImportStoredKeyRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/importstoredkeyrequest_p.h
+++ b/lib/Crypto/importstoredkeyrequest_p.h
@@ -15,10 +15,11 @@
 #include "Crypto/key.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -39,7 +40,7 @@ public:
     Sailfish::Crypto::Key m_keyTemplate;
     Sailfish::Crypto::Key m_importedKeyReference;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/lockcoderequest.cpp
+++ b/lib/Crypto/lockcoderequest.cpp
@@ -301,9 +301,9 @@ void LockCodeRequest::startRequest()
                 emit resultChanged();
             } else {
                 d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-                connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+                connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                         [this] {
-                    QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                    QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                     QDBusPendingReply<Result, LockCodeRequest::LockStatus> reply = *watcher;
                     this->d_ptr->m_status = Request::Finished;
                     this->d_ptr->m_result = reply.argumentAt<0>();
@@ -346,9 +346,9 @@ void LockCodeRequest::startRequest()
                 emit resultChanged();
             } else {
                 d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-                connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+                connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                         [this] {
-                    QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                    QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                     QDBusPendingReply<Result> reply = *watcher;
                     this->d_ptr->m_status = Request::Finished;
                     if (reply.isError()) {
@@ -369,7 +369,7 @@ void LockCodeRequest::startRequest()
 void LockCodeRequest::waitForFinished()
 {
     Q_D(LockCodeRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/lockcoderequest_p.h
+++ b/lib/Crypto/lockcoderequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -37,7 +38,7 @@ public:
     Sailfish::Crypto::InteractionParameters m_interactionParameters;
     QString m_lockCodeTarget;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/plugininforequest.cpp
+++ b/lib/Crypto/plugininforequest.cpp
@@ -151,9 +151,9 @@ void PluginInfoRequest::startRequest()
             emit storagePluginsChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QVector<PluginInfo>, QVector<PluginInfo> > reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -177,7 +177,7 @@ void PluginInfoRequest::startRequest()
 void PluginInfoRequest::waitForFinished()
 {
     Q_D(PluginInfoRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/plugininforequest_p.h
+++ b/lib/Crypto/plugininforequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -34,7 +35,7 @@ public:
     QVector<Sailfish::Crypto::PluginInfo> m_cryptoPlugins;
     QVector<Sailfish::Crypto::PluginInfo> m_storagePlugins;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/seedrandomdatageneratorrequest.cpp
+++ b/lib/Crypto/seedrandomdatageneratorrequest.cpp
@@ -275,9 +275,9 @@ void SeedRandomDataGeneratorRequest::startRequest()
             emit resultChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -297,7 +297,7 @@ void SeedRandomDataGeneratorRequest::startRequest()
 void SeedRandomDataGeneratorRequest::waitForFinished()
 {
     Q_D(SeedRandomDataGeneratorRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/seedrandomdatageneratorrequest_p.h
+++ b/lib/Crypto/seedrandomdatageneratorrequest_p.h
@@ -13,11 +13,12 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 #include <QtCore/QByteArray>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -37,7 +38,7 @@ public:
     double m_entropyEstimate;
     QByteArray m_seedData;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/signrequest.cpp
+++ b/lib/Crypto/signrequest.cpp
@@ -365,9 +365,9 @@ void SignRequest::startRequest()
             emit signatureChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -389,7 +389,7 @@ void SignRequest::startRequest()
 void SignRequest::waitForFinished()
 {
     Q_D(SignRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/signrequest_p.h
+++ b/lib/Crypto/signrequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -38,7 +39,7 @@ public:
     QString m_cryptoPluginName;
     QByteArray m_signature;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/storedkeyidentifiersrequest.cpp
+++ b/lib/Crypto/storedkeyidentifiersrequest.cpp
@@ -206,9 +206,9 @@ void StoredKeyIdentifiersRequest::startRequest()
             emit identifiersChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QVector<Key::Identifier> > reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -230,7 +230,7 @@ void StoredKeyIdentifiersRequest::startRequest()
 void StoredKeyIdentifiersRequest::waitForFinished()
 {
     Q_D(StoredKeyIdentifiersRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/storedkeyidentifiersrequest_p.h
+++ b/lib/Crypto/storedkeyidentifiersrequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -35,7 +36,7 @@ public:
     QVariantMap m_customParameters;
     QVector<Sailfish::Crypto::Key::Identifier> m_identifiers;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/storedkeyrequest.cpp
+++ b/lib/Crypto/storedkeyrequest.cpp
@@ -230,9 +230,9 @@ void StoredKeyRequest::startRequest()
             emit storedKeyChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, Key> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -254,7 +254,7 @@ void StoredKeyRequest::startRequest()
 void StoredKeyRequest::waitForFinished()
 {
     Q_D(StoredKeyRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/storedkeyrequest_p.h
+++ b/lib/Crypto/storedkeyrequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -35,7 +36,7 @@ public:
     Key::Components m_keyComponents;
     Sailfish::Crypto::Key m_storedKey;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Crypto/verifyrequest.cpp
+++ b/lib/Crypto/verifyrequest.cpp
@@ -412,9 +412,9 @@ void VerifyRequest::startRequest()
             emit verificationStatusChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, Sailfish::Crypto::CryptoManager::VerificationStatus> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -436,7 +436,7 @@ void VerifyRequest::startRequest()
 void VerifyRequest::waitForFinished()
 {
     Q_D(VerifyRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Crypto/verifyrequest_p.h
+++ b/lib/Crypto/verifyrequest_p.h
@@ -13,10 +13,11 @@
 #include "Crypto/cryptomanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -39,7 +40,7 @@ public:
     QString m_cryptoPluginName;
     Sailfish::Crypto::CryptoManager::VerificationStatus m_verificationStatus;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Crypto::Request::Status m_status;
     Sailfish::Crypto::Result m_result;
 };

--- a/lib/Secrets/collectionnamesrequest.cpp
+++ b/lib/Secrets/collectionnamesrequest.cpp
@@ -190,9 +190,9 @@ void CollectionNamesRequest::startRequest()
             emit resultChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QMap<QString, bool> > reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -214,7 +214,7 @@ void CollectionNamesRequest::startRequest()
 void CollectionNamesRequest::waitForFinished()
 {
     Q_D(CollectionNamesRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/collectionnamesrequest_p.h
+++ b/lib/Secrets/collectionnamesrequest_p.h
@@ -12,10 +12,11 @@
 #include "Secrets/secretmanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -32,7 +33,7 @@ public:
     QString m_storagePluginName;
     QMap<QString, bool> m_collectionNames; // name,isLocked
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/lib/Secrets/createcollectionrequest.cpp
+++ b/lib/Secrets/createcollectionrequest.cpp
@@ -464,9 +464,9 @@ void CreateCollectionRequest::startRequest()
             emit resultChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -486,7 +486,7 @@ void CreateCollectionRequest::startRequest()
 void CreateCollectionRequest::waitForFinished()
 {
     Q_D(CreateCollectionRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/createcollectionrequest_p.h
+++ b/lib/Secrets/createcollectionrequest_p.h
@@ -13,10 +13,11 @@
 #include "Secrets/secretmanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -40,7 +41,7 @@ public:
     Sailfish::Secrets::SecretManager::AccessControlMode m_accessControlMode;
     Sailfish::Secrets::SecretManager::UserInteractionMode m_userInteractionMode;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/lib/Secrets/deletecollectionrequest.cpp
+++ b/lib/Secrets/deletecollectionrequest.cpp
@@ -232,9 +232,9 @@ void DeleteCollectionRequest::startRequest()
             emit resultChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -254,7 +254,7 @@ void DeleteCollectionRequest::startRequest()
 void DeleteCollectionRequest::waitForFinished()
 {
     Q_D(DeleteCollectionRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/deletecollectionrequest_p.h
+++ b/lib/Secrets/deletecollectionrequest_p.h
@@ -13,10 +13,11 @@
 #include "Secrets/secretmanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -34,7 +35,7 @@ public:
     QString m_storagePluginName;
     Sailfish::Secrets::SecretManager::UserInteractionMode m_userInteractionMode;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/lib/Secrets/deletesecretrequest.cpp
+++ b/lib/Secrets/deletesecretrequest.cpp
@@ -187,9 +187,9 @@ void DeleteSecretRequest::startRequest()
             emit resultChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -209,7 +209,7 @@ void DeleteSecretRequest::startRequest()
 void DeleteSecretRequest::waitForFinished()
 {
     Q_D(DeleteSecretRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/deletesecretrequest_p.h
+++ b/lib/Secrets/deletesecretrequest_p.h
@@ -13,10 +13,11 @@
 #include "Secrets/secret.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -33,7 +34,7 @@ public:
     Sailfish::Secrets::Secret::Identifier m_identifier;
     Sailfish::Secrets::SecretManager::UserInteractionMode m_userInteractionMode;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/lib/Secrets/findsecretsrequest.cpp
+++ b/lib/Secrets/findsecretsrequest.cpp
@@ -350,9 +350,9 @@ void FindSecretsRequest::startRequest()
             emit identifiersChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QVector<Secret::Identifier> > reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -374,7 +374,7 @@ void FindSecretsRequest::startRequest()
 void FindSecretsRequest::waitForFinished()
 {
     Q_D(FindSecretsRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/findsecretsrequest_p.h
+++ b/lib/Secrets/findsecretsrequest_p.h
@@ -13,11 +13,12 @@
 #include "Secrets/secret.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 #include <QtCore/QVector>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -38,7 +39,7 @@ public:
     Sailfish::Secrets::SecretManager::UserInteractionMode m_userInteractionMode;
     QVector<Sailfish::Secrets::Secret::Identifier> m_identifiers;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/lib/Secrets/healthcheckrequest.cpp
+++ b/lib/Secrets/healthcheckrequest.cpp
@@ -200,8 +200,8 @@ void HealthCheckRequest::startRequest()
             emit resultChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished, [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished, [this] {
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result,
                                   HealthCheckRequest::Health,
                                   HealthCheckRequest::Health> reply = *watcher;
@@ -228,7 +228,7 @@ void HealthCheckRequest::startRequest()
 void HealthCheckRequest::waitForFinished()
 {
     Q_D(HealthCheckRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/healthcheckrequest_p.h
+++ b/lib/Secrets/healthcheckrequest_p.h
@@ -14,10 +14,11 @@
 #include "Secrets/healthcheckrequest.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -30,7 +31,7 @@ class HealthCheckRequestPrivate
 public:
     explicit HealthCheckRequestPrivate();
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 

--- a/lib/Secrets/interactionrequest.cpp
+++ b/lib/Secrets/interactionrequest.cpp
@@ -182,9 +182,9 @@ void InteractionRequest::startRequest()
             emit userInputChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, QByteArray> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -206,7 +206,7 @@ void InteractionRequest::startRequest()
 void InteractionRequest::waitForFinished()
 {
     Q_D(InteractionRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/interactionrequest_p.h
+++ b/lib/Secrets/interactionrequest_p.h
@@ -13,10 +13,11 @@
 #include "Secrets/secret.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -33,7 +34,7 @@ public:
     Sailfish::Secrets::InteractionParameters m_interactionParameters;
     QByteArray m_userInput;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/lib/Secrets/lockcoderequest.cpp
+++ b/lib/Secrets/lockcoderequest.cpp
@@ -390,9 +390,9 @@ void LockCodeRequest::startRequest()
                 emit resultChanged();
             } else {
                 d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-                connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+                connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                         [this] {
-                    QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                    QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                     QDBusPendingReply<Result, LockCodeRequest::LockStatus> reply = *watcher;
                     this->d_ptr->m_status = Request::Finished;
                     this->d_ptr->m_result = reply.argumentAt<0>();
@@ -437,9 +437,9 @@ void LockCodeRequest::startRequest()
                 emit resultChanged();
             } else {
                 d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-                connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+                connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                         [this] {
-                    QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                    QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                     QDBusPendingReply<Result> reply = *watcher;
                     this->d_ptr->m_status = Request::Finished;
                     if (reply.isError()) {
@@ -460,7 +460,7 @@ void LockCodeRequest::startRequest()
 void LockCodeRequest::waitForFinished()
 {
     Q_D(LockCodeRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/lockcoderequest_p.h
+++ b/lib/Secrets/lockcoderequest_p.h
@@ -14,10 +14,11 @@
 #include "Secrets/interactionparameters.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -38,7 +39,7 @@ public:
     Sailfish::Secrets::InteractionParameters m_interactionParameters;
     QString m_lockCodeTarget;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/lib/Secrets/plugininforequest.cpp
+++ b/lib/Secrets/plugininforequest.cpp
@@ -210,9 +210,9 @@ void PluginInfoRequest::startRequest()
             emit authenticationPluginsChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result,
                                   QVector<PluginInfo>,
                                   QVector<PluginInfo>,
@@ -244,7 +244,7 @@ void PluginInfoRequest::startRequest()
 void PluginInfoRequest::waitForFinished()
 {
     Q_D(PluginInfoRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/plugininforequest_p.h
+++ b/lib/Secrets/plugininforequest_p.h
@@ -14,10 +14,11 @@
 #include "Secrets/plugininfo.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -36,7 +37,7 @@ public:
     QVector<Sailfish::Secrets::PluginInfo> m_encryptedStoragePlugins;
     QVector<Sailfish::Secrets::PluginInfo> m_authenticationPlugins;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/lib/Secrets/storedsecretrequest.cpp
+++ b/lib/Secrets/storedsecretrequest.cpp
@@ -231,9 +231,9 @@ void StoredSecretRequest::startRequest()
             emit secretChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result, Secret> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -255,7 +255,7 @@ void StoredSecretRequest::startRequest()
 void StoredSecretRequest::waitForFinished()
 {
     Q_D(StoredSecretRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/storedsecretrequest_p.h
+++ b/lib/Secrets/storedsecretrequest_p.h
@@ -13,10 +13,11 @@
 #include "Secrets/secret.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -34,7 +35,7 @@ public:
     Sailfish::Secrets::SecretManager::UserInteractionMode m_userInteractionMode;
     Sailfish::Secrets::Secret m_secret;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/lib/Secrets/storesecretrequest.cpp
+++ b/lib/Secrets/storesecretrequest.cpp
@@ -604,9 +604,9 @@ void StoreSecretRequest::startRequest()
             emit resultChanged();
         } else {
             d->m_watcher.reset(new QDBusPendingCallWatcher(reply));
-            connect(d->m_watcher.data(), &QDBusPendingCallWatcher::finished,
+            connect(d->m_watcher.get(), &QDBusPendingCallWatcher::finished,
                     [this] {
-                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.take();
+                QDBusPendingCallWatcher *watcher = this->d_ptr->m_watcher.release();
                 QDBusPendingReply<Result> reply = *watcher;
                 this->d_ptr->m_status = Request::Finished;
                 if (reply.isError()) {
@@ -626,7 +626,7 @@ void StoreSecretRequest::startRequest()
 void StoreSecretRequest::waitForFinished()
 {
     Q_D(StoreSecretRequest);
-    if (d->m_status == Request::Active && !d->m_watcher.isNull()) {
+    if (d->m_status == Request::Active && d->m_watcher) {
         d->m_watcher->waitForFinished();
     }
 }

--- a/lib/Secrets/storesecretrequest_p.h
+++ b/lib/Secrets/storesecretrequest_p.h
@@ -14,10 +14,11 @@
 #include "Secrets/secretmanager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopedPointer>
 #include <QtCore/QString>
 
 #include <QtDBus/QDBusPendingCallWatcher>
+
+#include <memory>
 
 namespace Sailfish {
 
@@ -41,7 +42,7 @@ public:
     Sailfish::Secrets::SecretManager::AccessControlMode m_accessControlMode;
     Sailfish::Secrets::SecretManager::UserInteractionMode m_userInteractionMode;
 
-    QScopedPointer<QDBusPendingCallWatcher> m_watcher;
+    std::unique_ptr<QDBusPendingCallWatcher> m_watcher;
     Sailfish::Secrets::Request::Status m_status;
     Sailfish::Secrets::Result m_result;
 };

--- a/plugins/passwordagentauthplugin/passwordagentplugin.cpp
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.cpp
@@ -662,7 +662,7 @@ Result PasswordAgentPlugin::beginUserInputInteraction(
         const InteractionParameters &interactionParameters,
         const QString &interactionServiceAddress)
 {
-    Agent * const agent = m_sessionAgent.data();
+    Agent * const agent = m_sessionAgent.get();
 
     if (!agent) {
         return Result(Result::InteractionViewError, QStringLiteral("No password agent is registered"));
@@ -796,7 +796,7 @@ void PasswordAgentPlugin::addConnection(const QDBusConnection &connection)
 void PasswordAgentPlugin::removeConnection(const QString &name)
 {
     if (m_sessionAgent && m_sessionAgent->connection.name() == name) {
-        destroyAgent(m_sessionAgent.take());
+        destroyAgent(m_sessionAgent.release());
     }
 }
 
@@ -818,7 +818,7 @@ void PasswordAgentPlugin::UnregisterSessionAgent(const QDBusObjectPath &agent)
             && m_sessionAgent->connection.name() == QDBusContext::connection().name()
             && m_sessionAgent->service == QDBusContext::message().service()
             && m_sessionAgent->path == agent.path()) {
-        destroyAgent(m_sessionAgent.take());
+        destroyAgent(m_sessionAgent.release());
     }
 }
 

--- a/plugins/passwordagentauthplugin/passwordagentplugin.h
+++ b/plugins/passwordagentauthplugin/passwordagentplugin.h
@@ -19,6 +19,8 @@
 #include <QDBusContext>
 #include <QDBusServer>
 
+#include <memory>
+
 QT_BEGIN_NAMESPACE
 class QDBusPendingCallWatcher;
 class QDBusObjectPath;
@@ -96,7 +98,7 @@ private:
     class PasswordResponse;
     class PolkitResponse;
 
-    QScopedPointer<Agent> m_sessionAgent;
+    std::unique_ptr<Agent> m_sessionAgent;
     QScopedPointer<QDBusServer> m_server;
     QHash<QString, PolkitResponse *> m_polkitResponses;
     QHash<QPair<uint, quint64>, QTimer *> m_nemoTimers;


### PR DESCRIPTION
Main commit:

    Mostly same thing repeating over and over with QDBusPendingCallWatcher.
    The API is deprecated on 6.1 with suggestion of just using
    std::unique_ptr. The Qt version is far away but let's anyway just
    change these as trivial migration.

Most of this just a couple sed scripts executed.